### PR TITLE
Add Adobe 2018 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,35 @@
 language: java
 sudo: required
-services:
-  - mysql
-jdk:
-  - oraclejdk8
-cache:
-  directories:
-  - "$HOME/.CommandBox/artifacts/"
-  - "$HOME/.CommandBox/server/"
-env:
-  matrix:
-    - ENGINE=adobe@2016
-    - ENGINE=adobe@11
-    - ENGINE=lucee@5
-    - ENGINE=lucee@4.5
-before_install:
-  - sudo apt-key adv --keyserver keys.gnupg.net --recv 6DA70622
-  - sudo echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
-  - mysql -e 'CREATE DATABASE quick;'
-install:
-  - sudo apt-get update && sudo apt-get --assume-yes install commandbox
-  - box install commandbox-cfconfig
-  - box install
-before_script:
-  - box server start cfengine=$ENGINE port=8500 debug=true
-script:
-  - box testbox run runner='http://127.0.0.1:8500/tests/runner.cfm' verbose=true reporter=text
-after_success:
-  - box install commandbox-semantic-release
-  - box config set endpoints.forgebox.APIToken=${FORGEBOX_TOKEN}
-  - box semantic-release
-notifications:
-  email: false
+services: 
+- mysql
+jdk: 
+- oraclejdk8
+cache: 
+   directories: 
+   - $HOME/.CommandBox/artifacts/
+   - $HOME/.CommandBox/server/
+env: 
+   matrix: 
+   - ENGINE=lucee@5
+   - ENGINE=lucee@4.5
+   - ENGINE=adobe@2018
+   - ENGINE=adobe@2016
+   - ENGINE=adobe@11
+before_install: 
+- sudo apt-key adv --keyserver keys.gnupg.net --recv 6DA70622
+- sudo echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
+- mysql -e 'CREATE DATABASE quick;'
+install: 
+- sudo apt-get update && sudo apt-get --assume-yes install commandbox
+- box install commandbox-cfconfig
+- box install
+before_script: 
+- box server start cfengine=$ENGINE port=8500 debug=true
+script: 
+- box testbox run runner='http://127.0.0.1:8500/tests/runner.cfm' verbose=true reporter=text
+after_success: 
+- box install commandbox-semantic-release
+- box config set endpoints.forgebox.APIToken=${FORGEBOX_TOKEN}
+- box semantic-release
+notifications: 
+   email: false


### PR DESCRIPTION
This auto-generated PR adds Adobe 2018 to the Travis CI matrix