### PR TITLE
feat(Scopes): Allow scopes to call other scopes

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -627,7 +627,7 @@ component accessors="true" {
         if ( ! isNull( columnValue ) ) { return columnValue; }
         var q = tryScopes( missingMethodName, missingMethodArguments );
         if ( ! isNull( q ) ) {
-            variables.query = q;
+            variables.query = q.getQuery();
             return this;
         }
         var r = tryRelationships( missingMethodName, missingMethodArguments );
@@ -716,7 +716,7 @@ component accessors="true" {
     private function tryScopes( missingMethodName, missingMethodArguments ) {
         if ( structKeyExists( variables, "scope#missingMethodName#" ) ) {
             return invoke( this, "scope#missingMethodName#", {
-                query = getQuery(),
+                query = this,
                 args = missingMethodArguments
             } );
         }


### PR DESCRIPTION
By passing through the Quick instance, you can call
scopes from other scopes.

```
component extends="quick.models.BaseEntity" {

    property name="username";
    property name="email";
    property name="password";
    property name="active";

    function scopeActive( query ) {
        return query.where( "active", 1 );
    }

    function scopeAlphabeticSubscribers( query ) {
        return query.active().orderBy( "username" );
    }

}
```

The calling site would simply use `getInstance( "User" ).alphabeticSubscribers()`