### PR TITLE
refactor(BaseEntity): Make internal properties more resistant to name clashes

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -585,7 +585,7 @@ component accessors="true" {
         } ).unique();
         var relatedEntity = invoke( entities.get( 1 ), relationName ).getRelated();
         var owningKey = invoke( entities.get( 1 ), relationName ).getOwningKey();
-        var relations = relatedEntity.resetQuery().whereIn( owningKey, keys.get() ).get( options = getQueryOptions()  );
+        var relations = relatedEntity.resetQuery().whereIn( owningKey, keys.get() ).get( options = variables._queryOptions );
 
         return matchRelations( entities, relations, relationName );
     }

--- a/models/KeyTypes/AutoIncrementing.cfc
+++ b/models/KeyTypes/AutoIncrementing.cfc
@@ -14,7 +14,7 @@ component implements="KeyType" {
      */
     public void function postInsert( required entity, required struct result ) {
         var generatedKey = result.keyExists( "generated_key" ) ? result[ "generated_key" ] : result[ "generatedKey" ];
-        entity.setAttribute( entity.getKey(), generatedKey );
+        entity.assignAttribute( entity.get_Key(), generatedKey );
     }
 
 }

--- a/models/KeyTypes/UUID.cfc
+++ b/models/KeyTypes/UUID.cfc
@@ -5,7 +5,7 @@ component implements="KeyType" {
      * Recieves the entity as the only argument.
      */
     public void function preInsert( required entity ) {
-        entity.setAttribute( entity.getKey(), createUUID() );
+        entity.assignAttribute( entity.get_Key(), createUUID() );
     }
 
     /**

--- a/models/QuickCollection.cfc
+++ b/models/QuickCollection.cfc
@@ -47,10 +47,10 @@ component extends="cfcollection.models.Collection" {
         return this.each( function( entity ) {
             var relationship = invoke( entity, relationName );
             if ( structKeyExists( groupedRelations, relationship.getForeignKeyValue() ) ) {
-                entity.setRelationship( relationName, groupedRelations[ relationship.getForeignKeyValue() ] );
+                entity.assignRelationship( relationName, groupedRelations[ relationship.getForeignKeyValue() ] );
             }
             else {
-                entity.setRelationship( relationName, relationship.getDefaultValue() );
+                entity.assignRelationship( relationName, relationship.getDefaultValue() );
             }
         } );
     }

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -18,10 +18,10 @@ component extends="quick.models.Relationships.BaseRelationship" {
 
     function associate( entity ) {
         if ( isQuickEntity( entity ) ) {
-            arguments.entity = entity.getKeyValue();
+            arguments.entity = entity.keyValue();
         }
 
-        return getOwning().setAttribute( getForeignKey(), entity );
+        return getOwning().assignAttribute( getForeignKey(), entity );
     }
 
     function disassociate() {

--- a/models/Relationships/BelongsToMany.cfc
+++ b/models/Relationships/BelongsToMany.cfc
@@ -16,12 +16,12 @@ component accessors="true" extends="quick.models.Relationships.BaseRelationship"
     }
 
     function apply() {
-        getRelated().join( getTable(), function( j ) {
+        getRelated().join( variables.table, function( j ) {
             j.on(
-                "#getRelated().getTable()#.#getRelated().getKey()#",
-                "#getTable()#.#getOwningKey()#"
+                "#getRelated().get_Table()#.#getRelated().get_Key()#",
+                "#variables.table#.#getOwningKey()#"
             );
-            j.where( "#getTable()#.#getForeignKey()#", getForeignKeyValue() );
+            j.where( "#variables.table#.#getForeignKey()#", getForeignKeyValue() );
         } );
     }
 
@@ -42,10 +42,10 @@ component accessors="true" extends="quick.models.Relationships.BaseRelationship"
             if ( isSimpleValue( id ) ) {
                 return id;
             }
-            return id.getKeyValue();
+            return id.keyValue();
         } );
 
-        builder.get().from( getTable() ).insert( arrayMap( arguments.ids, function( id ) {
+        builder.get().from( variables.table ).insert( arrayMap( arguments.ids, function( id ) {
             return {
                 "#getForeignKey()#" = getForeignKeyValue(),
                 "#getOwningKey()#" = id
@@ -66,11 +66,11 @@ component accessors="true" extends="quick.models.Relationships.BaseRelationship"
             if ( isSimpleValue( id ) ) {
                 return id;
             }
-            return id.getKeyValue();
+            return id.keyValue();
         } );
 
         builder.get()
-            .from( getTable() )
+            .from( variables.table )
             .where( getForeignKey(), getForeignKeyValue() )
             .whereIn( getOwningKey(), arguments.ids )
             .delete();
@@ -89,11 +89,11 @@ component accessors="true" extends="quick.models.Relationships.BaseRelationship"
             if ( isSimpleValue( id ) ) {
                 return id;
             }
-            return id.getKeyValue();
+            return id.keyValue();
         } );
 
         builder.get()
-            .from( getTable() )
+            .from( variables.table )
             .where( getForeignKey(), getForeignKeyValue() )
             .delete();
 

--- a/models/Relationships/HasMany.cfc
+++ b/models/Relationships/HasMany.cfc
@@ -18,14 +18,14 @@ component extends="quick.models.Relationships.BaseRelationship" {
 
     function save( entity ) {
         getOwning().clearRelationship( getRelationMethodName() );
-        return entity.setAttribute( getOwningKey(), getForeignKeyValue() ).save();
+        return entity.assignAttribute( getOwningKey(), getForeignKeyValue() ).save();
     }
 
     function create( attributes ) {
         getOwning().clearRelationship( getRelationMethodName() );
         return wirebox.getInstance( getRelationName() )
-            .setAttributesData( attributes )
-            .setAttribute( getOwningKey(), getForeignKeyValue() )
+            .assignAttributesData( attributes )
+            .assignAttribute( getOwningKey(), getForeignKeyValue() )
             .save();
     }
 

--- a/models/Relationships/HasManyThrough.cfc
+++ b/models/Relationships/HasManyThrough.cfc
@@ -17,16 +17,16 @@ component accessors="true" extends="quick.models.Relationships.BaseRelationship"
     function apply() {
         getRelated()
             .join(
-                getIntermediate().getTable(),
-                "#getIntermediate().getTable()#.#getIntermediate().getKey()#",
-                "#getRelated().getTable()#.#getIntermediateKey()#"
+                getIntermediate().get_Table(),
+                "#getIntermediate().get_Table()#.#getIntermediate().get_Key()#",
+                "#getRelated().get_Table()#.#getIntermediateKey()#"
             )
             .join(
-                getOwning().getTable(),
-                "#getOwning().getTable()#.#getOwningKey()#",
-                "#getIntermediate().getTable()#.#getForeignKey()#"
+                getOwning().get_Table(),
+                "#getOwning().get_Table()#.#getOwningKey()#",
+                "#getIntermediate().get_Table()#.#getForeignKey()#"
             )
-            .where( "#getOwning().getTable()#.#getOwningKey()#", getOwning().getKeyValue() );
+            .where( "#getOwning().get_Table()#.#getOwningKey()#", getOwning().keyValue() );
     }
 
     function fromGroup( items ) {

--- a/models/Relationships/PolymorphicHasMany.cfc
+++ b/models/Relationships/PolymorphicHasMany.cfc
@@ -14,8 +14,8 @@ component accessors="true" extends="quick.models.Relationships.BaseRelationship"
 
     function apply() {
         getRelated()
-            .where( "#getPrefix()#_type", getOwning().getMapping() )
-            .where( "#getPrefix()#_id", getOwning().getKeyValue() );
+            .where( "#getPrefix()#_type", getOwning().get_Mapping() )
+            .where( "#getPrefix()#_id", getOwning().keyValue() );
     }
 
     function fromGroup( items ) {

--- a/tests/resources/app/models/Country.cfc
+++ b/tests/resources/app/models/Country.cfc
@@ -1,6 +1,6 @@
 component extends="quick.models.BaseEntity" {
 
-    property name="keyType" inject="UUID@quick" persistent="false";
+    property name="_keyType" inject="UUID@quick" persistent="false";
 
     property name="id";
     property name="name";

--- a/tests/resources/app/models/Link.cfc
+++ b/tests/resources/app/models/Link.cfc
@@ -6,6 +6,6 @@ component extends="quick.models.BaseEntity" {
     property name="url" column="link_url";
     property name="createdDate" column="created_date" readonly="true";
 
-    variables.key = "link_id";
+    variables._key = "link_id";
 
 }

--- a/tests/resources/app/models/Post.cfc
+++ b/tests/resources/app/models/Post.cfc
@@ -6,7 +6,7 @@ component entityname="MyPost" table="my_posts" extends="quick.models.BaseEntity"
     property name="createdDate" column="created_date";
     property name="modifiedDate" column="modified_date";
 
-    variables.key = "post_pk";
+    variables._key = "post_pk";
 
     function author() {
         return belongsTo( "User", "user_id" );

--- a/tests/specs/integration/BaseEntity/AttributeCasingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCasingSpec.cfc
@@ -5,21 +5,21 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             it( "defaults to no transformation", function() {
                 var post = getInstance( "Post" ).find( 1 );
 
-                expect( post.getAttributesData() ).toHaveKey( "post_pk" );
-                expect( post.getAttributesData() ).notToHaveKey( "PostPk" );
+                expect( post.retrieveAttributesData() ).toHaveKey( "post_pk" );
+                expect( post.retrieveAttributesData() ).notToHaveKey( "PostPk" );
 
                 expect( post.getPost_Pk() ).notToBeNull();
 
                 post.setCreatedDate( now() );
 
-                expect( post.getAttributesData() ).toHaveKey( "created_date" );
+                expect( post.retrieveAttributesData() ).toHaveKey( "created_date" );
             } );
 
             it( "converts stores all attributes internally as snake case when the `attributecasing` metadata property is set to `snake`", function() {
                 var user = getInstance( "User" ).find( 1 );
 
-                expect( user.getAttributesData() ).toHaveKey( "first_name" );
-                expect( user.getAttributesData() ).notToHaveKey( "firstName" );
+                expect( user.retrieveAttributesData() ).toHaveKey( "first_name" );
+                expect( user.retrieveAttributesData() ).notToHaveKey( "firstName" );
 
                 expect( function() {
                     user.getFirstName();
@@ -31,8 +31,8 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 user.setCreatedDate( now() );
 
-                expect( user.getAttributesData() ).notToHaveKey( "createdDate" );
-                expect( user.getAttributesData() ).toHaveKey( "created_date" );
+                expect( user.retrieveAttributesData() ).notToHaveKey( "createdDate" );
+                expect( user.retrieveAttributesData() ).toHaveKey( "created_date" );
             } );
         } );
     }

--- a/tests/specs/integration/BaseEntity/AttributeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeSpec.cfc
@@ -23,22 +23,22 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
             it( "can retrieve the original attributes of a loaded entity", function() {
                 var user = getInstance( "User" ).find( 1 );
-                var originalAttributes = user.getAttributesData();
+                var originalAttributes = user.retrieveAttributesData();
                 user.setUsername( "new_username" );
-                expect( originalAttributes ).notToBe( user.getAttributesData() );
-                expect( originalAttributes ).toBe( user.getOriginalAttributes() );
+                expect( originalAttributes ).notToBe( user.retrieveAttributesData() );
+                expect( originalAttributes ).toBe( user.get_OriginalAttributes() );
             } );
 
             it( "returns a default value if the attribute is not yet set", function() {
                 var user = getInstance( "User" );
-                expect( user.getAttribute( "username" ) ).toBe( "" );
-                expect( user.getAttribute( "username", "default-value" ) ).toBe( "default-value" );
+                expect( user.retrieveAttribute( "username" ) ).toBe( "" );
+                expect( user.retrieveAttribute( "username", "default-value" ) ).toBe( "default-value" );
             } );
 
             it( "throws an exception when trying to set an attribute that does not exist", function() {
                 var user = getInstance( "User" );
                 expect( function() {
-                    user.setAttribute( "does-not-exist", "any-value" );
+                    user.assignAttribute( "does-not-exist", "any-value" );
                 } ).toThrow( type = "AttributeNotFound" );
             } );
 

--- a/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
@@ -4,7 +4,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
         describe( "Columns", function() {
             it( "retrieves all columns by default", function() {
                 var user = getInstance( "User" ).findOrFail( 1 );
-                var attributeNames = user.getAttributeNames();
+                var attributeNames = user.retrieveAttributeNames( columnNames = true );
                 arraySort( attributeNames, "textnocase" );
 
                 expect( attributeNames ).toBeArray();
@@ -24,11 +24,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             it( "always retrieves the primary key", function() {
                 var link = getInstance( "Link" ).findOrFail( 1 );
 
-                var configuredAttributes = link.getAttributes();
+                var configuredAttributes = link.get_Attributes();
                 expect( configuredAttributes ).toBeStruct();
                 expect( configuredAttributes ).notToHaveKey( "link_id" );
 
-                var attributeNames = link.getAttributeNames();
+                var attributeNames = link.retrieveAttributeNames( columnNames = true );
                 arraySort( attributeNames, "textnocase" );
                 expect( attributeNames ).toBeArray();
                 expect( attributeNames ).toHaveLength( 3 );
@@ -38,20 +38,20 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             it( "can access the attributes by their alias", function() {
                 var link = getInstance( "Link" ).findOrFail( 1 );
 
-                var configuredAttributes = link.getAttributes();
+                var configuredAttributes = link.get_Attributes();
                 expect( configuredAttributes ).toBeStruct();
                 expect( configuredAttributes ).notToHaveKey( "link_id" );
 
-                var attributeNames = link.getAttributeNames();
+                var attributeNames = link.retrieveAttributeNames( columnNames = true );
                 arraySort( attributeNames, "textnocase" );
                 expect( attributeNames ).toBeArray();
                 expect( attributeNames ).toHaveLength( 3 );
                 expect( attributeNames ).toBe( [ "created_date", "link_id", "link_url" ] );
 
                 expect( link.getId() ).toBe( 1 );
-                expect( link.getId() ).toBe( link.getAttributesData()[ "link_id" ] );
+                expect( link.getId() ).toBe( link.retrieveAttributesData()[ "link_id" ] );
                 expect( link.getUrl() ).toBe( "http://example.com/some-link" );
-                expect( link.getUrl() ).toBe( link.getAttributesData()[ "link_url" ] );
+                expect( link.getUrl() ).toBe( link.retrieveAttributesData()[ "link_url" ] );
             } );
 
             it( "ignores non-persistent attributes", function() {

--- a/tests/specs/integration/BaseEntity/CreateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CreateSpec.cfc
@@ -9,7 +9,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                     "last_name" = "Doe",
                     "password" = hash( "password" )
                 } );
-                expect( user.getLoaded() ).toBeTrue();
+                expect( user.isLoaded() ).toBeTrue();
                 expect( user.newEntity().where( "username", "JaneDoe" ).first() ).notToBeNull();
             } );
         } );

--- a/tests/specs/integration/BaseEntity/Events/PostInsertSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PostInsertSpec.cfc
@@ -21,7 +21,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( variables.quickPostInsertCalled ).toBeStruct();
                 expect( variables.quickPostInsertCalled ).toHaveKey( "entity" );
                 expect( variables.quickPostInsertCalled.entity.getTitle() ).toBe( "Rainbow Connection" );
-                expect( variables.quickPostInsertCalled.entity.getLoaded() ).toBeTrue();
+                expect( variables.quickPostInsertCalled.entity.isLoaded() ).toBeTrue();
                 structDelete( variables, "quickPostInsertCalled" );
             } );
 
@@ -34,7 +34,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( request.postInsertCalled ).toBeStruct();
                 expect( request.postInsertCalled ).toHaveKey( "entity" );
                 expect( request.postInsertCalled.entity.getTitle() ).toBe( "Rainbow Connection" );
-                expect( request.postInsertCalled.entity.getLoaded() ).toBeTrue();
+                expect( request.postInsertCalled.entity.isLoaded() ).toBeTrue();
                 structDelete( request, "postInsertCalled" );
             } );
         } );

--- a/tests/specs/integration/BaseEntity/Events/PostLoadSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PostLoadSpec.cfc
@@ -17,7 +17,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( variables ).toHaveKey( "quickPostLoadCalled" );
                 expect( variables.quickPostLoadCalled ).toBeStruct();
                 expect( variables.quickPostLoadCalled ).toHaveKey( "entity" );
-                expect( variables.quickPostLoadCalled.entity.getKeyValue() ).toBe( 1 );
+                expect( variables.quickPostLoadCalled.entity.keyValue() ).toBe( 1 );
                 structDelete( variables, "quickPostLoadCalled" );
             } );
 
@@ -26,7 +26,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( request ).toHaveKey( "postLoadCalled" );
                 expect( request.postLoadCalled ).toBeStruct();
                 expect( request.postLoadCalled ).toHaveKey( "entity" );
-                expect( request.postLoadCalled.entity.getKeyValue() ).toBe( 1 );
+                expect( request.postLoadCalled.entity.keyValue() ).toBe( 1 );
                 structDelete( request, "postLoadCalled" );
             } );
         } );

--- a/tests/specs/integration/BaseEntity/Events/PostSaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PostSaveSpec.cfc
@@ -18,7 +18,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( variables.quickPostSaveCalled ).toBeStruct();
                 expect( variables.quickPostSaveCalled ).toHaveKey( "entity" );
                 expect( variables.quickPostSaveCalled.entity.getDownloadUrl() ).toBe( "https://open.spotify.com/track/1SJ4ycWow4yz6z4oFz8NAG" );
-                expect( variables.quickPostSaveCalled.entity.getLoaded() ).toBeTrue();
+                expect( variables.quickPostSaveCalled.entity.isLoaded() ).toBeTrue();
                 structDelete( variables, "quickPostSaveCalled" );
             } );
 
@@ -45,7 +45,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( request.postSaveCalled ).toBeStruct();
                 expect( request.postSaveCalled ).toHaveKey( "entity" );
                 expect( request.postSaveCalled.entity.getDownloadUrl() ).toBe( "https://open.spotify.com/track/1SJ4ycWow4yz6z4oFz8NAG" );
-                expect( request.postSaveCalled.entity.getLoaded() ).toBeTrue();
+                expect( request.postSaveCalled.entity.isLoaded() ).toBeTrue();
                 structDelete( request, "postSaveCalled" );
             } );
 

--- a/tests/specs/integration/BaseEntity/Events/PreInsertSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PreInsertSpec.cfc
@@ -21,7 +21,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( variables.quickPreInsertCalled ).toBeStruct();
                 expect( variables.quickPreInsertCalled ).toHaveKey( "entity" );
                 expect( variables.quickPreInsertCalled.entity.getTitle() ).toBe( "Rainbow Connection" );
-                expect( variables.quickPreInsertCalled.entity.getLoaded() ).toBeFalse();
+                expect( variables.quickPreInsertCalled.entity.isLoaded() ).toBeFalse();
                 structDelete( variables, "quickPreInsertCalled" );
             } );
 
@@ -34,7 +34,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( request.preInsertCalled ).toBeStruct();
                 expect( request.preInsertCalled ).toHaveKey( "entity" );
                 expect( request.preInsertCalled.entity.getTitle() ).toBe( "Rainbow Connection" );
-                expect( request.preInsertCalled.entity.getLoaded() ).toBeFalse();
+                expect( request.preInsertCalled.entity.isLoaded() ).toBeFalse();
                 structDelete( request, "preInsertCalled" );
             } );
         } );

--- a/tests/specs/integration/BaseEntity/Events/PreSaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PreSaveSpec.cfc
@@ -18,7 +18,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( variables.quickPreSaveCalled ).toBeStruct();
                 expect( variables.quickPreSaveCalled ).toHaveKey( "entity" );
                 expect( variables.quickPreSaveCalled.entity.getDownloadUrl() ).toBe( "https://open.spotify.com/track/1SJ4ycWow4yz6z4oFz8NAG" );
-                expect( variables.quickPreSaveCalled.entity.getLoaded() ).toBeFalse();
+                expect( variables.quickPreSaveCalled.entity.isLoaded() ).toBeFalse();
                 structDelete( variables, "quickPreSaveCalled" );
             } );
 
@@ -45,7 +45,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( request.preSaveCalled ).toBeStruct();
                 expect( request.preSaveCalled ).toHaveKey( "entity" );
                 expect( request.preSaveCalled.entity.getDownloadUrl() ).toBe( "https://open.spotify.com/track/1SJ4ycWow4yz6z4oFz8NAG" );
-                expect( request.preSaveCalled.entity.getLoaded() ).toBeFalse();
+                expect( request.preSaveCalled.entity.isLoaded() ).toBeFalse();
                 structDelete( request, "preSaveCalled" );
             } );
 

--- a/tests/specs/integration/BaseEntity/FillSpec.cfc
+++ b/tests/specs/integration/BaseEntity/FillSpec.cfc
@@ -4,17 +4,17 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
         describe( "Fill Spec", function() {
             it( "can fill many properties at once", function() {
                 var user = getInstance( "User" );
-                expect( user.getAttribute( "username" ) ).toBe( "" );
-                expect( user.getAttribute( "first_name" ) ).toBe( "" );
-                expect( user.getAttribute( "last_name" ) ).toBe( "" );
+                expect( user.retrieveAttribute( "username" ) ).toBe( "" );
+                expect( user.retrieveAttribute( "first_name" ) ).toBe( "" );
+                expect( user.retrieveAttribute( "last_name" ) ).toBe( "" );
                 user.fill( {
                     "username" = "JaneDoe",
                     "first_name" = "Jane",
                     "last_name" = "Doe"
                 } );
-                expect( user.getAttribute( "username" ) ).toBe( "JaneDoe" );
-                expect( user.getAttribute( "first_name" ) ).toBe( "Jane" );
-                expect( user.getAttribute( "last_name" ) ).toBe( "Doe" );
+                expect( user.retrieveAttribute( "username" ) ).toBe( "JaneDoe" );
+                expect( user.retrieveAttribute( "first_name" ) ).toBe( "Jane" );
+                expect( user.retrieveAttribute( "last_name" ) ).toBe( "Doe" );
             } );
 
             it( "throws an error when trying to fill non-existant properties", function() {

--- a/tests/specs/integration/BaseEntity/GetSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GetSpec.cfc
@@ -4,7 +4,8 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
         describe( "Get Spec", function() {
             it( "finds an entity by the primary key", function() {
                 var user = getInstance( "User" ).find( 1 );
-                expect( user.getLoaded() ).toBeTrue( "The user instance should be found and loaded, but was not." );
+                expect( user.isLoaded() ).toBeTrue( "The user instance should be found and loaded, but was not." );
+                debug( user.get_Key() );
             } );
 
             it( "it returns null if the record cannot be found", function() {
@@ -33,11 +34,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
             describe( "loaded", function() {
                 it( "a new entity returns false when asked if it loaded", function() {
-                    expect( getInstance( "User" ).getLoaded() ).toBeFalse();
+                    expect( getInstance( "User" ).isLoaded() ).toBeFalse();
                 } );
 
                 it( "an entity loaded from the database returns true when asked if it loaded", function() {
-                    expect( getInstance( "User" ).find( 1 ).getLoaded() ).toBeTrue();
+                    expect( getInstance( "User" ).find( 1 ).isLoaded() ).toBeTrue();
                 } );
             } );
 

--- a/tests/specs/integration/BaseEntity/MetadataSpec.cfc
+++ b/tests/specs/integration/BaseEntity/MetadataSpec.cfc
@@ -13,55 +13,55 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             describe( "full name", function() {
                 it( "calculates the full name from the metadata", function() {
                     var post = getInstance( "User" );
-                    expect( post.getFullName() ).toBe( "app.models.User" );
+                    expect( post.get_FullName() ).toBe( "app.models.User" );
                 } );
             } );
 
             describe( "entity name", function() {
                 it( "determines the entity name from the metadata if an `entityname` attribute is present", function() {
                     var post = getInstance( "Post" );
-                    expect( post.getEntityName() ).toBe( "MyPost" );
+                    expect( post.get_EntityName() ).toBe( "MyPost" );
                 } );
 
                 it( "calculates the entity name from the file name if no `entityname` attribute is present", function() {
                     var post = getInstance( "User" );
-                    expect( post.getEntityName() ).toBe( "User" );
+                    expect( post.get_EntityName() ).toBe( "User" );
                 } );
             } );
 
             describe( "mapping name", function() {
                 it( "takes the mapping name from the file name", function() {
                     var post = getInstance( "Post" );
-                    expect( post.getMapping() ).toBe( "Post" );
+                    expect( post.get_Mapping() ).toBe( "Post" );
                 } );
             } );
 
             describe( "table name", function() {
                 it( "determines the table name from the metadata if a `table` attribute is present", function() {
                     var post = getInstance( "Post" );
-                    expect( post.getTable() ).toBe( "my_posts" );
+                    expect( post.get_Table() ).toBe( "my_posts" );
                 } );
 
                 it( "calculates the table name from the entity name if no `table` attribute is present", function() {
                     var post = getInstance( "User" );
-                    expect( post.getTable() ).toBe( "users" );
+                    expect( post.get_Table() ).toBe( "users" );
                 } );
 
                 it( "uses the snake case plural version of the component name", function() {
                     var phoneNumber = getInstance( "PhoneNumber" );
-                    expect( phoneNumber.getTable() ).toBe( "phone_numbers" );
+                    expect( phoneNumber.get_Table() ).toBe( "phone_numbers" );
                 } );
             } );
 
             describe( "primary key", function() {
-                it( "uses the `variables.key` value if set", function() {
+                it( "uses the `variables._key` value if set", function() {
                     var post = getInstance( "Post" );
-                    expect( post.getKey() ).toBe( "post_pk" );
+                    expect( post.get_Key() ).toBe( "post_pk" );
                 } );
 
-                it( "uses the `id` as the `variables.key` value by default", function() {
+                it( "uses the `id` as the `variables._key` value by default", function() {
                     var user = getInstance( "User" );
-                    expect( user.getKey() ).toBe( "id" );
+                    expect( user.get_Key() ).toBe( "id" );
                 } );
             } );
         } );

--- a/tests/specs/integration/BaseEntity/ReadOnlyPropertySpec.cfc
+++ b/tests/specs/integration/BaseEntity/ReadOnlyPropertySpec.cfc
@@ -20,17 +20,17 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 } ).toThrow( type = "QuickReadOnlyException" );
             } );
 
-            it( "prevents setAttribute from being called on a read-only property", function() {
+            it( "prevents assignAttribute from being called on a read-only property", function() {
                 var link = getInstance( "Link" ).findOrFail( 1 );
                 expect( function() {
-                    link.setAttribute( "createdDate", now() );
+                    link.assignAttribute( "createdDate", now() );
                 } ).toThrow( type = "QuickReadOnlyException" );
             } );
 
-            it( "prevents setAttributesData from being called containing a read-only property", function() {
+            it( "prevents assignAttributesData from being called containing a read-only property", function() {
                 var link = getInstance( "Link" ).findOrFail( 1 );
                 expect( function() {
-                    link.setAttributesData( { createdDate = now() } );
+                    link.assignAttributesData( { createdDate = now() } );
                 } ).toThrow( type = "QuickReadOnlyException" );
             } );
 

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
@@ -28,17 +28,17 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 newPost.setBody( "A new post by me!" );
                 var user = getInstance( "User" ).find( 1 );
                 newPost.author().associate( user ).save();
-                expect( newPost.getAttribute( "user_id" ) ).toBe( user.getId() );
+                expect( newPost.retrieveAttribute( "user_id" ) ).toBe( user.getId() );
                 expect( user.posts().count() ).toBe( 3 );
             } );
 
             it( "can disassociate the existing entity", function() {
                 var post = getInstance( "Post" ).find( 1 );
-                expect( post.getAttribute( "user_id" ) ).notToBe( "" );
-                var userId = post.getAttribute( "user_id" );
+                expect( post.retrieveAttribute( "user_id" ) ).notToBe( "" );
+                var userId = post.retrieveAttribute( "user_id" );
                 expect( getInstance( "User" ).find( userId ).posts().count() ).toBe( 2 );
                 post.author().disassociate().save();
-                expect( post.getAttribute( "user_id" ) ).toBe( "" );
+                expect( post.retrieveAttribute( "user_id" ) ).toBe( "" );
                 expect( getInstance( "User" ).find( userId ).posts().count() ).toBe( 1 );
             } );
         } );

--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -12,11 +12,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             it( "can save and associate new entities", function() {
                 var newPost = getInstance( "Post" );
                 newPost.setBody( "A new post by me!" );
-                expect( newPost.getLoaded() ).toBeFalse();
+                expect( newPost.isLoaded() ).toBeFalse();
                 var user = getInstance( "User" ).find( 1 );
                 newPost = user.posts().save( newPost );
-                expect( newPost.getLoaded() ).toBeTrue();
-                expect( newPost.getAttribute( "user_id" ) ).toBe( user.getId() );
+                expect( newPost.isLoaded() ).toBeTrue();
+                expect( newPost.retrieveAttribute( "user_id" ) ).toBe( user.getId() );
             } );
 
             it( "can create new related entities directly", function() {
@@ -25,8 +25,8 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 var newPost = user.posts().create( {
                     "body" = "A new post created directly here!"
                 } );
-                expect( newPost.getLoaded() ).toBeTrue();
-                expect( newPost.getAttribute( "user_id" ) ).toBe( user.getId() );
+                expect( newPost.isLoaded() ).toBeTrue();
+                expect( newPost.retrieveAttribute( "user_id" ) ).toBe( user.getId() );
                 expect( newPost.getBody() ).toBe( "A new post created directly here!" );
                 expect( user.getPosts().get() ).toHaveLength( 3 );
             } );

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -32,7 +32,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                     newUser.setLastName( "User" );
                     newUser.setPassword( hash( "password" ) );
                     newUser.save();
-                    expect( newUser.getAttributesData() ).toHaveKey( "id" );
+                    expect( newUser.retrieveAttributesData() ).toHaveKey( "id" );
                 } );
 
                 it( "a saved entity is not dirty", function() {
@@ -191,16 +191,16 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                         var tagsToSync = [ existingTags[ 1 ], newTagA.getId(), newTagB ];
                         var tagIds = [
-                            existingTags[ 1 ].getKeyValue(),
-                            newTagA.getKeyValue(),
-                            newTagB.getKeyValue()
+                            existingTags[ 1 ].keyValue(),
+                            newTagA.keyValue(),
+                            newTagB.keyValue()
                         ];
 
                         post.tags().sync( [ existingTags[ 1 ], newTagA.getId(), newTagB ] );
 
                         expect( post.getTags().toArray() ).toBeArray();
                         expect( post.getTags().toArray() ).toHaveLength( 3 );
-                        expect( post.getTags().pluck( "keyValue" ).toArray() ).toBe( tagIds );
+                        expect( post.getTags().map( function( tag ) { return tag.keyValue(); } ).toArray() ).toBe( tagIds );
                     } );
                 } );
             } );


### PR DESCRIPTION
This commit changes almost all the internal property names and functions to better
avoid name clashes.  This involved prefixing all properties with an underscore
as well as eliminating almost all public methods that start with `set` or `get`.

BREAKING CHANGE: Any code that used internal functions of the `BaseEntity`
will need to update to the name function and property names.