### PR TITLE
Apparently this standard changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ component {
 component extends="quick.models.BaseEntity" {
 
     // the name of the table is the pluralized version of the model
-    // all fields in a table are mapped by default
-    // both of these points can be configured on a per-entity basis
+    // this can be configured on a per-entity basis
 
 }
 ```


### PR DESCRIPTION
Now the fields do not show up defacto, so this documentation needed to be changed.