### PR TITLE
update qb dependency

### DIFF
--- a/box.json
+++ b/box.json
@@ -18,7 +18,7 @@
     },
     "type":"modules",
     "dependencies":{
-        "qb":"^5.2.1",
+        "qb":"^6",
         "str":"^1.0.0",
         "cfcollection":"^3.6.1",
         "cbvalidation":"^1.3.1+51"

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -314,7 +314,7 @@ component accessors="true" {
                 }
                 return value;
             } ), getQueryOptions() );
-            getKeyType().postInsert( this, result );
+            getKeyType().postInsert( this, ! isNull( result.result ) ? result.result : result );
             setOriginalAttributes( getAttributesData() );
             setLoaded( true );
             fireEvent( "postInsert", { entity = this } );


### PR DESCRIPTION
Updating to qb v 6. Had to make a small update due to this commit in qb:

qb commit 7b12b021ea3d96d382761ac8a931885430ced3d0
- runQuery with returnObject = 'result' now returns an object with 'result' and 'query'