### PR TITLE
Change BaseEntity function deepEqual() to use compare() on strings

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -24,7 +24,7 @@ component accessors="true" {
     property name="key"             default="id";
     property name="attributes";
     property name="meta";
-    
+
     /*=====================================
     =            Instance Data            =
     =====================================*/
@@ -793,7 +793,7 @@ component accessors="true" {
         if (
             isNumeric( arguments.actual ) &&
             isNumeric( arguments.expected ) &&
-            toString( arguments.actual ) == toString( arguments.expected )
+            compare( toString( arguments.actual ), toString( arguments.expected ) ) == 0
         ) {
             return true;
         }
@@ -802,7 +802,7 @@ component accessors="true" {
         if (
             isSimpleValue( arguments.actual ) &&
             isSimpleValue( arguments.expected ) &&
-            arguments.actual == arguments.expected
+            compare( arguments.actual, arguments.expected ) == 0
         ) {
             return true;
         }
@@ -838,7 +838,7 @@ component accessors="true" {
         if (
             isCustomFunction( arguments.actual ) &&
             isCustomFunction( arguments.expected ) &&
-            arguments.actual.toString() == arguments.expected.toString()
+            compare( arguments.actual.toString(), arguments.expected.toString() ) == 0
         ) {
             return true;
         }
@@ -847,7 +847,7 @@ component accessors="true" {
         if (
             IsXmlDoc( arguments.actual ) &&
             IsXmlDoc( arguments.expected ) &&
-            toString( arguments.actual ) == toString( arguments.expected )
+            compare( toString( arguments.actual ), toString( arguments.expected ) ) == 0
         ) {
             return true;
         }

--- a/tests/specs/integration/BaseEntity/IsDirtySpec.cfc
+++ b/tests/specs/integration/BaseEntity/IsDirtySpec.cfc
@@ -1,0 +1,23 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+    function run() {
+        describe( "isDirty Spec", function() {
+            it( "can test to see if an updated entity differs from that created", function() {
+                var user = getInstance( "User" ).find( 1 );
+
+				user.fill( { "last_name" = "Peterson" } );
+				expect( user.isDirty() ).toBeFalse();
+
+				user.fill( { "last_name" = "peterson" } );
+				expect( user.isDirty() ).toBeTrue();
+
+				user.fill( { "last_name" = "Smith" } );
+				expect( user.isDirty() ).toBeTrue();
+
+				user.fill( { "last_name" = "Peterson" } );
+				expect( user.isDirty() ).toBeFalse();
+           } );
+        } );
+    }
+
+}


### PR DESCRIPTION
When checking for equality of strings, the "==" or "eq" operator doesn't distinguish between case. As a result, "A" == "a" would return "true".

Therefore the "==" test has been changed to compare(...) == 0 which does consider the case of the strings. As a result, compare( "A", "a") would return "-1", which means the two strings are not identical, even in case. Where as compare( "A", "A") would return "0".