### PR TITLE
Instance ready hook

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -13,6 +13,7 @@ component {
 
         interceptorSettings = {
             customInterceptionPoints = [
+                "quickInstanceReady",
                 "quickPreLoad",
                 "quickPostLoad",
                 "quickPreSave",

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -56,6 +56,7 @@ component accessors="true" {
 
     function onDIComplete() {
         metadataInspection();
+        fireEvent( "instanceReady", { entity = this } );
     }
 
     function keyType() {

--- a/tests/resources/app/models/Song.cfc
+++ b/tests/resources/app/models/Song.cfc
@@ -6,6 +6,10 @@ component extends="quick.models.BaseEntity" accessors="true" {
     property name="createdDate" column="created_date";
     property name="modifiedDate" column="modified_date";
 
+    function instanceReady( eventData ) {
+        request.instanceReadyCalled = eventData;
+    }
+
     function preLoad( eventData ) {
         request.preLoadCalled = eventData;
     }

--- a/tests/specs/integration/BaseEntity/Events/InstanceReadySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/InstanceReadySpec.cfc
@@ -1,0 +1,37 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+    function beforeAll() {
+        super.beforeAll();
+        var interceptorService = getWireBox().getInstance( dsl = "coldbox:interceptorService" );
+        interceptorService.registerInterceptor( interceptorObject = this );
+    }
+
+    function run() {
+        describe( "instanceReady spec", function() {
+            beforeEach( function() {
+                variables.interceptData = {};
+            } );
+
+            it( "announces an instanceReady interception point", function() {
+                var song = getInstance( "Song" ).findOrFail( 1 );
+                expect( variables ).toHaveKey( "quickInstanceReadyCalled" );
+                expect( variables.quickInstanceReadyCalled ).toBeStruct();
+                expect( variables.quickInstanceReadyCalled ).toHaveKey( "entity" );
+                structDelete( variables, "quickInstanceReadyCalled" );
+            } );
+
+            it( "calls any preLoad method on the component", function() {
+                var song = getInstance( "Song" ).findOrFail( 1 );
+                expect( request ).toHaveKey( "instanceReadyCalled" );
+                expect( request.instanceReadyCalled ).toBeStruct();
+                expect( request.instanceReadyCalled ).toHaveKey( "entity" );
+                structDelete( request, "instanceReadyCalled" );
+            } );
+        } );
+    }
+
+    function quickInstanceReady( event, interceptData, buffer, rc, prc ) {
+        variables.quickInstanceReadyCalled = arguments.interceptData;
+    }
+
+}


### PR DESCRIPTION
This PR adds an `instanceReady` hook and `quickInstanceReady` interception point. This is announced after the entity is created, autowired, and the metadata processed. This can be used to extend Quick entities. For instance, this can be used to hook in `cbvalidation` or `mementifier`. 