### PR TITLE
feat(Relationships): Add fetch methods to all Relationships

### DIFF
--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -22,11 +22,31 @@ component {
         return variables.related.get();
     }
 
+    function first() {
+        return variables.related.first();
+    }
+
+    function firstOrFail() {
+        return variables.related.firstOrFail();
+    }
+
+    function find( id ) {
+        return variables.related.find( arguments.id );
+    }
+
+    function findOrFail( id ) {
+        return variables.related.findOrFail( arguments.id );
+    }
+
+    function all() {
+        return variables.related.all();
+    }
+
     /**
     * get()
     * @hint wrapper for getResults() on relationship types that have them, which is most of them. get() implemented for consistency with QB and Quick
-    */ 
-    
+    */
+
     function get() {
         return getResults();
     }

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
@@ -51,13 +51,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 newPost.setBody( "A new post by me!" );
                 var user = getInstance( "User" ).find( 1 );
                 newPost.setAuthor( user );
-                writeDump( var = newPost, top = 2, abort = true );
                 newPost.getAuthor();
                 newPost.getAuthor();
                 newPost.getAuthor();
                 newPost.getAuthor();
                 expect( newPost.retrieveAttribute( "user_id" ) ).toBe( user.getId() );
-                writeDump( var = variables.queries, top = 2 );
                 expect( variables.queries ).toHaveLength( 1, "Only one query should have been executed." );
             } );
 

--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -99,6 +99,39 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( newPost.getBody() ).toBe( "A new post created directly here!" );
                 expect( user.fresh().getPosts() ).toHaveLength( 3 );
             } );
+
+            it( "can first off of the relationship", function() {
+                var user = getInstance( "User" ).find( 1 );
+                var post = user.posts().first();
+                expect( post.keyValue() ).toBe( 1245 );
+            } );
+
+            it( "can firstOrFail off of the relationship", function() {
+                var user = getInstance( "User" ).find( 2 );
+                expect( function() {
+                    var post = user.posts().firstOrFail( 7777 );
+                } ).toThrow( "EntityNotFound" );
+            } );
+
+            it( "can find off of the relationship", function() {
+                var user = getInstance( "User" ).find( 1 );
+                var post = user.posts().find( 523526 );
+                expect( post.keyValue() ).toBe( 523526 );
+            } );
+
+            it( "can findOrFail off of the relationship", function() {
+                var user = getInstance( "User" ).find( 1 );
+                expect( function() {
+                    var post = user.posts().findOrFail( 7777 );
+                } ).toThrow( "EntityNotFound" );
+            } );
+
+            it( "can all off of the relationship", function() {
+                var user = getInstance( "User" ).find( 1 );
+                var posts = user.posts().all();
+                expect( posts ).toBeArray();
+                expect( posts ).toHaveLength( 3 );
+            } );
         } );
     }
 


### PR DESCRIPTION
Fetch methods such as `first` and `find` no work as expected
on relationships.  These are most useful on one to many relationships
like `hasMany` or `belongsToMany`.