### PR TITLE
Fix Getting Started 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You need the following configured before using Quick:
 * Add a mapping for `quick` in your `Application.cfc`
 * Configure your `BaseGrammar` in `config/ColdBox.cfc`
 
-See [Getting Started](https://github.com/ortus-docs/quick-docs/blob/master/getting-started) for more details.
+See [Getting Started](https://quick.ortusbooks.com/getting-started) for more details.
 
 ### Supported Databases
 


### PR DESCRIPTION
Because there is no master branch in the quick-docs repo it was causing a 404, so linking to https://quick.ortusbooks.com/getting-started instead, as that seams to be the place you should go.