### PR TITLE
Ignore Non-Existent Attributes

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -144,15 +144,18 @@ component accessors="true" {
         return this;
     }
 
-    function fill( attributes ) {
+    function fill( attributes, ignoreNonExistentAttributes = false ) {
         for ( var key in arguments.attributes ) {
             var value = arguments.attributes[ key ];
             var rs = tryRelationshipSetter( "set#key#", { "1" = value } );
-            if ( ! isNull( rs ) ) { continue; }
-            guardAgainstNonExistentAttribute( key );
+			if ( ! isNull( rs ) ) { continue; }
+			if( ! arguments.ignoreNonExistentAttributes && ! hasAttribute( key ) ) {
+                guardAgainstNonExistentAttribute( key );
+			} else if( hasAttribute( key ) ) {
+                variables._data[ retrieveColumnForAlias( key ) ] = value;
+				invoke( this, "set#retrieveAliasForColumn( key )#", { 1 = value } );
+			}
             guardAgainstReadOnlyAttribute( key );
-            variables._data[ retrieveColumnForAlias( key ) ] = value;
-            invoke( this, "set#retrieveAliasForColumn( key )#", { 1 = value } );
         }
         return this;
     }
@@ -448,13 +451,13 @@ component accessors="true" {
         return this;
     }
 
-    function update( attributes = {} ) {
-        fill( arguments.attributes );
+    function update( attributes = {}, ignoreNonExistentAttributes = false ) {
+        fill( arguments.attributes, arguments.ignoreNonExistentAttributes );
         return save();
     }
 
-    function create( attributes = {} ) {
-        return newEntity().fill( arguments.attributes ).save();
+    function create( attributes = {}, ignoreNonExistentAttributes = false ) {
+        return newEntity().fill( arguments.attributes, arguments.ignoreNonExistentAttributes ).save();
     }
 
     function updateAll( attributes = {}, force = false ) {

--- a/tests/specs/integration/BaseEntity/CreateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CreateSpec.cfc
@@ -12,6 +12,18 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( user.isLoaded() ).toBeTrue();
                 expect( user.newEntity().where( "username", "JaneDoe" ).first() ).notToBeNull();
             } );
+
+            it( "can ignore non-existant properties", function() {
+                var user = getInstance( "User" ).create( {
+                    "username" = "JaneDoe",
+                    "first_name" = "Jane",
+                    "last_name" = "Doe",
+                    "password" = hash( "password" ),
+                    "non-existant-property" = "any-value"
+                }, true );
+                expect( user.isLoaded() ).toBeTrue();
+                expect( user.newEntity().where( "username", "JaneDoe" ).first() ).notToBeNull();
+            } );
         } );
     }
 

--- a/tests/specs/integration/BaseEntity/FillSpec.cfc
+++ b/tests/specs/integration/BaseEntity/FillSpec.cfc
@@ -25,6 +25,22 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                     } );
                 } ).toThrow( type = "AttributeNotFound" );
             } );
+
+            it( "can ignore non-existant properties", function() {
+                var user = getInstance( "User" );
+                expect( user.retrieveAttribute( "username" ) ).toBe( "" );
+                expect( user.retrieveAttribute( "first_name" ) ).toBe( "" );
+                expect( user.retrieveAttribute( "last_name" ) ).toBe( "" );
+                user.fill( {
+                    "username" = "JaneDoe",
+                    "first_name" = "Jane",
+                    "last_name" = "Doe",
+                    "non-existant-property" = "any-value"
+                }, true );
+                expect( user.retrieveAttribute( "username" ) ).toBe( "JaneDoe" );
+                expect( user.retrieveAttribute( "first_name" ) ).toBe( "Jane" );
+                expect( user.retrieveAttribute( "last_name" ) ).toBe( "Doe" );
+            } );
         } );
     }
 

--- a/tests/specs/integration/BaseEntity/UpdateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/UpdateSpec.cfc
@@ -16,6 +16,22 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( user.getFirstName() ).toBe( "Jane" );
                 expect( user.getLastName() ).toBe( "Doe" );
             } );
+
+            it( "can ignore non-existant properties", function() {
+                var user = getInstance( "User" ).find( 2 );
+                expect( user.getUsername() ).toBe( "johndoe" );
+                expect( user.getFirstName() ).toBe( "John" );
+                expect( user.getLastName() ).toBe( "Doe" );
+                user.update( {
+                    "username" = "janedoe",
+                    "first_name" = "Jane",
+                    "non-existant-property" = "any-value"
+                }, true );
+                user.refresh();
+                expect( user.getUsername() ).toBe( "janedoe" );
+                expect( user.getFirstName() ).toBe( "Jane" );
+                expect( user.getLastName() ).toBe( "Doe" );
+            } );
         } );
     }
 


### PR DESCRIPTION
Passing the complete `rc` scope to the methods `fill()`, `create()` and `update()` fails due to there being elements in the structure, such as event, that do not exist as properties of the entity. This feature enhancement adds a new argument, `ignoreNonExistentAttributes`, which defaults to `false` and therefore is a non-breaking change. When set to `true`, these methods will ignore any attributes that do not match to a property of the entity.