### PR TITLE
Composite keys

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1610,8 +1610,8 @@ component accessors="true" {
      */
     private BelongsTo function belongsTo(
         required string relationName,
-        string foreignKey,
-        string ownerKey,
+        any foreignKey,
+        any ownerKey,
         string relationMethodName
     ) {
         var related = variables._wirebox.getInstance(
@@ -1673,8 +1673,8 @@ component accessors="true" {
      */
     private HasOne function hasOne(
         required string relationName,
-        string foreignKey,
-        string localKey,
+        any foreignKey,
+        any localKey,
         string relationMethodName
     ) {
         var related = variables._wirebox.getInstance(
@@ -1728,8 +1728,8 @@ component accessors="true" {
      */
     private HasMany function hasMany(
         required string relationName,
-        string foreignKey,
-        string localKey,
+        any foreignKey,
+        any localKey,
         string relationMethodName
     ) {
         var related = variables._wirebox.getInstance(
@@ -1798,10 +1798,10 @@ component accessors="true" {
     private BelongsToMany function belongsToMany(
         required string relationName,
         string table,
-        string foreignPivotKey,
-        string relatedPivotKey,
-        string parentKey,
-        string relatedKey,
+        any foreignPivotKey,
+        any relatedPivotKey,
+        any parentKey,
+        any relatedKey,
         string relationMethodName
     ) {
         var related = variables._wirebox.getInstance(
@@ -1904,10 +1904,10 @@ component accessors="true" {
     private HasManyThrough function hasManyThrough(
         required string relationName,
         required string intermediateName,
-        string firstKey,
-        string secondKey,
-        string localKey,
-        string secondLocalKey,
+        any firstKey,
+        any secondKey,
+        any localKey,
+        any secondLocalKey,
         string relationMethodName
     ) {
         var related = variables._wirebox.getInstance(
@@ -1989,8 +1989,8 @@ component accessors="true" {
         required string relationName,
         required string name,
         string type,
-        string id,
-        string localKey,
+        any id,
+        any localKey,
         string relationMethodName
     ) {
         var related = variables._wirebox.getInstance(

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2907,12 +2907,12 @@ component accessors="true" {
                     meta[ "attributes" ] = generateAttributesFromProperties(
                         meta.originalMetadata.properties
                     );
-                    if ( !meta.attributes.keyExists( variables._key ) ) {
-                        arrayWrap( variables._key ).each( function( key ) {
+                    arrayWrap( variables._key ).each( function( key ) {
+                        if ( !meta.attributes.keyExists( key ) ) {
                             var keyProp = paramAttribute( { "name": key } );
                             meta.attributes[ keyProp.name ] = keyProp;
-                        } );
-                    }
+                        }
+                    } );
                     meta[ "casts" ] = generateCastsFromProperties(
                         meta.originalMetadata.properties
                     );

--- a/models/CBORMCompatEntity.cfc
+++ b/models/CBORMCompatEntity.cfc
@@ -65,8 +65,11 @@ component extends="quick.models.BaseEntity" accessors="true" {
     }
 
     function deleteById( id ) {
-        arguments.id = isArray( arguments.id ) ? arguments.id : [ arguments.id ];
-        retrieveQuery().whereIn( keyName(), arguments.id ).delete();
+        guardAgainstCompositePrimaryKeys();
+        arguments.id = isArray( arguments.id ) ? arguments.id : [
+            arguments.id
+        ];
+        retrieveQuery().whereIn( keyNames()[ 1 ], arguments.id ).delete();
         return this;
     }
 
@@ -82,7 +85,8 @@ component extends="quick.models.BaseEntity" accessors="true" {
 
     function exists( id ) {
         if ( !isNull( id ) ) {
-            retrieveQuery().where( keyName(), arguments.id );
+            guardAgainstCompositePrimaryKeys();
+            retrieveQuery().where( keyNames()[ 1 ], arguments.id );
         }
         return retrieveQuery().exists();
     }
@@ -127,8 +131,9 @@ component extends="quick.models.BaseEntity" accessors="true" {
             }
             return super.get();
         }
+        guardAgainstCompositePrimaryKeys();
         var ids = isArray( id ) ? id : listToArray( id, "," );
-        retrieveQuery().whereIn( keyName(), ids );
+        retrieveQuery().whereIn( keyNames()[ 1 ], ids );
         return super.get();
     }
 
@@ -157,6 +162,15 @@ component extends="quick.models.BaseEntity" accessors="true" {
 
     function newCriteria() {
         return CBORMCriteriaBuilderCompat.get().setEntity( this );
+    }
+
+    private void function guardAgainstCompositePrimaryKeys() {
+        if ( keyNames().len() > 1 ) {
+            throw(
+                type = "InvalidKeyLength",
+                message = "The CBORMCompatEntity cannot be used with composite primary keys."
+            );
+        }
     }
 
 }

--- a/models/CBORMCriteriaBuilderCompat.cfc
+++ b/models/CBORMCriteriaBuilderCompat.cfc
@@ -55,9 +55,10 @@ component accessors="true" {
     }
 
     function idEQ( id ) {
+        guardAgainstCompositePrimaryKeys();
         getEntity()
             .retrieveQuery()
-            .where( getEntity().keyName(), id );
+            .where( getEntity().keyNames()[ 1 ], id );
         return this;
     }
 
@@ -159,6 +160,15 @@ component accessors="true" {
     function onMissingMethod( missingMethodName, missingMethodArguments ) {
         invoke( variables._builder, missingMethodName, missingMethodArguments );
         return this;
+    }
+
+    private void function guardAgainstCompositePrimaryKeys() {
+        if ( getEntity().keyNames().len() > 1 ) {
+            throw(
+                type = "InvalidKeyLength",
+                message = "The CBORMCompatEntity cannot be used with composite primary keys."
+            );
+        }
     }
 
 }

--- a/models/KeyTypes/AutoIncrementingKeyType.cfc
+++ b/models/KeyTypes/AutoIncrementingKeyType.cfc
@@ -12,6 +12,12 @@ component implements="KeyType" {
      * @return   void
      */
     public void function preInsert( required any entity ) {
+        if ( arguments.entity.keyNames().len() > 1 ) {
+            throw(
+                type = "InvalidKeyLength",
+                message = "AutoIncrementingKeyType cannot be used with composite primary keys."
+            );
+        }
         return;
     }
 
@@ -27,17 +33,15 @@ component implements="KeyType" {
         required any entity,
         required struct result
     ) {
+        var keyName = arguments.entity.keyNames()[ 1 ];
         var generatedKey = arguments.result.result.keyExists(
-            arguments.entity.keyName()
-        ) ? arguments.result.result[ arguments.entity.keyName() ] : arguments.result.result.keyExists(
+            keyName
+        ) ? arguments.result.result[ keyName ] : arguments.result.result.keyExists(
             "generated_key"
         ) ? arguments.result.result[ "generated_key" ] : arguments.result.result[
             "generatedKey"
         ];
-        arguments.entity.assignAttribute(
-            arguments.entity.keyName(),
-            generatedKey
-        );
+        arguments.entity.assignAttribute( keyName, generatedKey );
     }
 
 }

--- a/models/KeyTypes/ReturningKeyType.cfc
+++ b/models/KeyTypes/ReturningKeyType.cfc
@@ -14,7 +14,7 @@ component implements="KeyType" {
     public void function preInsert( required any entity ) {
         arguments.entity
             .retrieveQuery()
-            .returning( arguments.entity.keyName() );
+            .returning( arguments.entity.keyNames() );
     }
 
     /**
@@ -29,10 +29,11 @@ component implements="KeyType" {
         required any entity,
         required struct result
     ) {
-        arguments.entity.assignAttribute(
-            arguments.entity.keyName(),
-            arguments.result.query[ arguments.entity.keyName() ]
-        );
+        arguments.entity
+            .keyNames()
+            .each( function( keyName ) {
+                entity.assignAttribute( keyName, result.query[ keyName ] );
+            } );
     }
 
 }

--- a/models/KeyTypes/UUIDKeyType.cfc
+++ b/models/KeyTypes/UUIDKeyType.cfc
@@ -4,24 +4,18 @@
 component implements="KeyType" {
 
     /**
-     * Sets the primary key to a random UUID.
+     * Sets the primary keys to random UUIDs.
      *
      * @entity   The entity that is being inserted.
      *
      * @return   void
      */
     public void function preInsert( required any entity ) {
-        if ( arguments.entity.keyNames().len() > 1 ) {
-            throw(
-                type = "InvalidKeyLength",
-                message = "AutoIncrementingKeyType cannot be used with composite primary keys."
-            );
-        }
-
-        arguments.entity.assignAttribute(
-            arguments.entity.keyNames()[ 1 ],
-            createUUID()
-        );
+        arguments.entity
+            .keyNames()
+            .each( function( keyName ) {
+                entity.assignAttribute( keyName, createUUID() );
+            } );
     }
 
     /**

--- a/models/KeyTypes/UUIDKeyType.cfc
+++ b/models/KeyTypes/UUIDKeyType.cfc
@@ -11,8 +11,15 @@ component implements="KeyType" {
      * @return   void
      */
     public void function preInsert( required any entity ) {
+        if ( arguments.entity.keyNames().len() > 1 ) {
+            throw(
+                type = "InvalidKeyLength",
+                message = "AutoIncrementingKeyType cannot be used with composite primary keys."
+            );
+        }
+
         arguments.entity.assignAttribute(
-            arguments.entity.keyName(),
+            arguments.entity.keyNames()[ 1 ],
             createUUID()
         );
     }

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -134,7 +134,19 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
     public struct function deleteAll( array ids = [] ) {
         getEntity().guardReadOnly();
         if ( !arrayIsEmpty( arguments.ids ) ) {
-            whereIn( getEntity().keyName(), arguments.ids );
+            where( function( q1 ) {
+                ids.each( function( id ) {
+                    var values = arrayWrap( id );
+                    getEntity().guardAgainstKeyLengthMismatch( values );
+                    q1.orWhere( function( q2 ) {
+                        getEntity()
+                            .keyNames()
+                            .each( function( keyName, i ) {
+                                q2.where( keyName, values[ i ] );
+                            } );
+                    } );
+                } );
+            } );
         }
         return delete();
     }

--- a/models/Relationships/PolymorphicHasOneOrMany.cfc
+++ b/models/Relationships/PolymorphicHasOneOrMany.cfc
@@ -19,8 +19,8 @@ component extends="quick.models.Relationships.HasOneOrMany" {
      * @parent              The parent entity instance for the relationship.
      * @type                The name of the column that contains the entity type
      *                      of the polymorphic relationship.
-     * @id                  The foreign key on the parent entity.
-     * @localKey            The local primary key on the parent entity.
+     * @ids                 The foreign key on the parent entity.
+     * @localKeys           The local primary key on the parent entity.
      *
      * @return              quick.models.Relationships.PolymorphicHasOneOrMany
      */
@@ -30,8 +30,8 @@ component extends="quick.models.Relationships.HasOneOrMany" {
         required string relationMethodName,
         required any parent,
         required string type,
-        required string id,
-        required string localKey,
+        required array ids,
+        required array localKeys,
         boolean withConstraints = true
     ) {
         variables.morphType = arguments.type;
@@ -42,8 +42,8 @@ component extends="quick.models.Relationships.HasOneOrMany" {
             relationName = arguments.relationName,
             relationMethodName = arguments.relationMethodName,
             parent = arguments.parent,
-            foreignKey = arguments.id,
-            localKey = arguments.localKey,
+            foreignKeys = arguments.ids,
+            localKeys = arguments.localKeys,
             withConstraints = arguments.withConstraints
         );
     }

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -244,5 +244,37 @@ component {
             )
         "
         );
+        queryExecute(
+            "
+            CREATE TABLE `composites` (
+                `a` int(11) NOT NULL,
+                `b` int(11) NOT NULL,
+                PRIMARY KEY (`a`, `b`)
+            )
+            "
+        );
+        queryExecute( "
+            INSERT INTO `composites` (`a`, `b`) VALUES (1, 1)
+        " );
+        queryExecute( "
+            INSERT INTO `composites` (`a`, `b`) VALUES (1, 2)
+        " );
+        queryExecute(
+            "
+            CREATE TABLE `composite_children` (
+                `id` int(11) NOT NULL AUTO_INCREMENT,
+                `composite_a` int(11) NOT NULL,
+                `composite_b` int(11) NOT NULL,
+                PRIMARY KEY (`id`)
+            )
+            "
+        );
+        queryExecute( "
+            INSERT INTO `composite_children` (`id`, `composite_a`, `composite_b`) VALUES (1, 1, 2)
+        " );
+        queryExecute( "
+            INSERT INTO `composite_children` (`id`, `composite_a`, `composite_b`) VALUES (2, 2, 2)
+        " );
+
     }
 }

--- a/tests/resources/app/models/Composite.cfc
+++ b/tests/resources/app/models/Composite.cfc
@@ -5,4 +5,8 @@ component table="composites" extends="quick.models.BaseEntity" {
 
     variables._key = [ "a", "b" ];
 
+    function keyType() {
+        return variables._wirebox.getInstance( "NullKeyType@quick" );
+    }
+
 }

--- a/tests/resources/app/models/Composite.cfc
+++ b/tests/resources/app/models/Composite.cfc
@@ -1,0 +1,8 @@
+component table="composites" extends="quick.models.BaseEntity" {
+
+    property name="a";
+    property name="b";
+
+    variables._key = [ "a", "b" ];
+
+}

--- a/tests/resources/app/models/CompositeChild.cfc
+++ b/tests/resources/app/models/CompositeChild.cfc
@@ -1,0 +1,14 @@
+component table="composite_children" extends="quick.models.BaseEntity" {
+
+    property name="id";
+    property name="composite_a";
+    property name="composite_b";
+
+    function parent() {
+        return belongsTo(
+            "Composite",
+            [ "composite_a", "composite_b" ],
+            [ "a", "b" ]
+        );
+    }
+}

--- a/tests/specs/integration/BaseEntity/Events/PostLoadSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PostLoadSpec.cfc
@@ -19,9 +19,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( variables ).toHaveKey( "quickPostLoadCalled" );
                 expect( variables.quickPostLoadCalled ).toBeStruct();
                 expect( variables.quickPostLoadCalled ).toHaveKey( "entity" );
-                expect( variables.quickPostLoadCalled.entity.keyValue() ).toBe(
-                    1
-                );
+                expect( variables.quickPostLoadCalled.entity.keyValues() ).toBe( [ 1 ] );
                 structDelete( variables, "quickPostLoadCalled" );
             } );
 
@@ -30,7 +28,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( request ).toHaveKey( "postLoadCalled" );
                 expect( request.postLoadCalled ).toBeStruct();
                 expect( request.postLoadCalled ).toHaveKey( "entity" );
-                expect( request.postLoadCalled.entity.keyValue() ).toBe( 1 );
+                expect( request.postLoadCalled.entity.keyValues() ).toBe( [ 1 ] );
                 structDelete( request, "postLoadCalled" );
             } );
         } );

--- a/tests/specs/integration/BaseEntity/Events/PreLoadSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PreLoadSpec.cfc
@@ -19,7 +19,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( variables ).toHaveKey( "quickPreLoadCalled" );
                 expect( variables.quickPreLoadCalled ).toBeStruct();
                 expect( variables.quickPreLoadCalled ).toHaveKey( "id" );
-                expect( variables.quickPreLoadCalled.id ).toBe( 1 );
+                expect( variables.quickPreLoadCalled.id ).toBe( [ 1 ] );
                 expect( variables.quickPreLoadCalled ).toHaveKey( "metadata" );
                 structDelete( variables, "quickPreLoadCalled" );
             } );
@@ -29,7 +29,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( request ).toHaveKey( "preLoadCalled" );
                 expect( request.preLoadCalled ).toBeStruct();
                 expect( request.preLoadCalled ).toHaveKey( "id" );
-                expect( request.preLoadCalled.id ).toBe( 1 );
+                expect( request.preLoadCalled.id ).toBe( [ 1 ] );
                 expect( request.preLoadCalled ).toHaveKey( "metadata" );
                 structDelete( request, "preLoadCalled" );
             } );

--- a/tests/specs/integration/BaseEntity/MetadataSpec.cfc
+++ b/tests/specs/integration/BaseEntity/MetadataSpec.cfc
@@ -53,12 +53,17 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             describe( "primary key", function() {
                 it( "uses the `variables._key` value if set", function() {
                     var post = getInstance( "Post" );
-                    expect( post.keyName() ).toBe( "post_pk" );
+                    expect( post.keyNames()[ 1 ] ).toBe( "post_pk" );
                 } );
 
                 it( "uses the `id` as the `variables._key` value by default", function() {
                     var user = getInstance( "User" );
-                    expect( user.keyName() ).toBe( "id" );
+                    expect( user.keyNames()[ 1 ] ).toBe( "id" );
+                } );
+
+                it( "can set a composite primary key", function() {
+                    var composite = getInstance( "Composite" );
+                    expect( composite.keyNames() ).toBe( [ "a", "b" ] );
                 } );
             } );
         } );

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
@@ -114,7 +114,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 var newPost = getInstance( "Post" );
                 newPost.setBody( "A new post by me!" );
                 var user = getInstance( "User" ).find( 1 );
-                newPost.setAuthor( user.keyValue() ).save();
+                newPost.setAuthor( user.keyValues() ).save();
                 expect( newPost.retrieveAttribute( "user_id" ) ).toBe(
                     user.getId()
                 );

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
@@ -154,6 +154,16 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                         .count()
                 ).toBe( 1 );
             } );
+
+            it( "can have a relationship with a composite foreign key", function() {
+                var compositeChild = getInstance( "CompositeChild" ).findOrFail(
+                    1
+                );
+                expect( compositeChild.getParent() ).toBeInstanceOf(
+                    "Composite"
+                );
+                expect( compositeChild.getParent().keyValues() ).toBe( [ 1, 2 ] );
+            } );
         } );
     }
 

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -38,6 +38,30 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 }
             } );
 
+            it( "can eager load a belongs to relationship using a composite key", function() {
+                var compositeChildren = getInstance( "CompositeChild" )
+                    .with( "parent" )
+                    .get();
+                expect( compositeChildren ).toBeArray();
+                expect( compositeChildren ).toHaveLength(
+                    2,
+                    "2 entities should have been loaded"
+                );
+                expect( compositeChildren[ 1 ].getParent() ).notToBeNull();
+                expect( compositeChildren[ 1 ].getParent() ).toBeInstanceOf(
+                    "Composite"
+                );
+                expect( compositeChildren[ 1 ].getParent().keyValues() ).toBe( [ 1, 2 ] );
+                expect( compositeChildren[ 2 ].getParent() ).toBeNull();
+
+                if ( arrayLen( variables.queries ) != 2 ) {
+                    expect( variables.queries ).toHaveLength(
+                        2,
+                        "Only two queries should have been executed. #arrayLen( variables.queries )# were instead."
+                    );
+                }
+            } );
+
             it( "does not eager load a belongs to empty record set", function() {
                 var posts = getInstance( "Post" )
                     .whereNull( "createdDate" )

--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -41,7 +41,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect( newPost.isLoaded() ).toBeTrue();
 
                 var user = getInstance( "User" ).find( 1 );
-                newPost = user.posts().save( newPost.keyValue() );
+                newPost = user.posts().save( newPost.keyValues() );
                 expect( newPost.isLoaded() ).toBeTrue();
                 expect( newPost.getAuthor().getId() ).toBe( user.getId() );
             } );
@@ -78,7 +78,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 ;
 
                 var user = getInstance( "User" ).find( 1 );
-                var posts = user.posts().saveMany( [ newPostA.keyValue(), newPostB ] );
+                var posts = user.posts().saveMany( [ newPostA.keyValues(), newPostB ] );
 
                 expect( posts[ 1 ].isLoaded() ).toBeTrue();
                 expect( posts[ 1 ].getAuthor().getId() ).toBe( user.getId() );
@@ -101,7 +101,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 var posts = user.fresh().getPosts();
                 expect( posts ).toBeArray();
                 expect( posts ).toHaveLength( 1 );
-                expect( posts[ 1 ].keyValue() ).toBe( newPost.keyValue() );
+                expect( posts[ 1 ].keyValues() ).toBe( newPost.keyValues() );
             } );
 
             it( "can create new related entities directly", function() {
@@ -121,7 +121,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             it( "can first off of the relationship", function() {
                 var user = getInstance( "User" ).find( 1 );
                 var post = user.posts().first();
-                expect( post.keyValue() ).toBe( 523526 );
+                expect( post.keyValues() ).toBe( [ 523526 ] );
             } );
 
             it( "can firstOrFail off of the relationship", function() {
@@ -134,7 +134,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
             it( "can find off of the relationship", function() {
                 var user = getInstance( "User" ).find( 1 );
                 var post = user.posts().find( 523526 );
-                expect( post.keyValue() ).toBe( 523526 );
+                expect( post.keyValues() ).toBe( [ 523526 ] );
             } );
 
             it( "can findOrFail off of the relationship", function() {

--- a/tests/specs/integration/BaseEntity/Relationships/OrderingByRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/OrderingByRelationshipsSpec.cfc
@@ -11,9 +11,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 expect( posts ).toBeArray();
                 expect( posts ).toHaveLength( 3 );
-                expect( posts[ 1 ].keyValue() ).toBe( 321 );
-                expect( posts[ 2 ].keyValue() ).toBe( 1245 );
-                expect( posts[ 3 ].keyValue() ).toBe( 523526 );
+                expect( posts[ 1 ].keyValues() ).toBe( [ 321 ] );
+                expect( posts[ 2 ].keyValues() ).toBe( [ 1245 ] );
+                expect( posts[ 3 ].keyValues() ).toBe( [ 523526 ] );
             } );
 
             it( "can order by a belongs to relationship descending", function() {
@@ -25,9 +25,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 expect( posts ).toBeArray();
                 expect( posts ).toHaveLength( 3 );
-                expect( posts[ 1 ].keyValue() ).toBe( 1245 );
-                expect( posts[ 2 ].keyValue() ).toBe( 523526 );
-                expect( posts[ 3 ].keyValue() ).toBe( 321 );
+                expect( posts[ 1 ].keyValues() ).toBe( [ 1245 ] );
+                expect( posts[ 2 ].keyValues() ).toBe( [ 523526 ] );
+                expect( posts[ 3 ].keyValues() ).toBe( [ 321 ] );
             } );
 
             it( "can order by a nested belongs to relationship descending", function() {
@@ -40,9 +40,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 expect( posts ).toBeArray();
                 expect( posts ).toHaveLength( 3 );
-                expect( posts[ 1 ].keyValue() ).toBe( 321 );
-                expect( posts[ 2 ].keyValue() ).toBe( 1245 );
-                expect( posts[ 3 ].keyValue() ).toBe( 523526 );
+                expect( posts[ 1 ].keyValues() ).toBe( [ 321 ] );
+                expect( posts[ 2 ].keyValues() ).toBe( [ 1245 ] );
+                expect( posts[ 3 ].keyValues() ).toBe( [ 523526 ] );
             } );
         } );
     }

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -242,9 +242,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 var tagsToSync = [ existingTags[ 1 ], newTagA.getId(), newTagB ];
                 var tagIds = [
-                    existingTags[ 1 ].keyValue(),
-                    newTagA.keyValue(),
-                    newTagB.keyValue()
+                    existingTags[ 1 ].keyValues(),
+                    newTagA.keyValues(),
+                    newTagB.keyValues()
                 ];
 
                 post.tags().sync( [ existingTags[ 1 ], newTagA.getId(), newTagB ] );
@@ -256,7 +256,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect(
                     post.getTags()
                         .map( function( tag ) {
-                            return tag.keyValue();
+                            return tag.keyValues();
                         } )
                         .toArray()
                 ).toBe( tagIds );
@@ -279,9 +279,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 var tagsToSync = [ existingTags[ 1 ], newTagA.getId(), newTagB ];
                 var tagIds = [
-                    existingTags[ 1 ].keyValue(),
-                    newTagA.keyValue(),
-                    newTagB.keyValue()
+                    existingTags[ 1 ].keyValues(),
+                    newTagA.keyValues(),
+                    newTagB.keyValues()
                 ];
 
                 post.setTags( [ existingTags[ 1 ], newTagA.getId(), newTagB ] );
@@ -293,7 +293,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
                 expect(
                     post.getTags()
                         .map( function( tag ) {
-                            return tag.keyValue();
+                            return tag.keyValues();
                         } )
                         .toArray()
                 ).toBe( tagIds );

--- a/tests/specs/integration/BaseServiceSpec.cfc
+++ b/tests/specs/integration/BaseServiceSpec.cfc
@@ -41,12 +41,12 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
                 it( "can find a specific record", function() {
                     var user = variables.service.find( 1 );
-                    expect( user.keyValue() ).toBe( 1 );
+                    expect( user.keyValues() ).toBe( [ 1 ] );
                 } );
 
                 it( "can find or fail a specific record", function() {
                     var user = variables.service.findOrFail( 1 );
-                    expect( user.keyValue() ).toBe( 1 );
+                    expect( user.keyValues() ).toBe( [ 1 ] );
                 } );
 
                 it( "can handle any qb methods", function() {

--- a/tests/specs/integration/GoodErrorMessagesSpec.cfc
+++ b/tests/specs/integration/GoodErrorMessagesSpec.cfc
@@ -4,10 +4,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
         describe( "good error messages", function() {
             it( "throws about unloaded entities when trying to retrieve the `keyValue`", function() {
                 expect( function() {
-                    getInstance( "User" ).keyValue();
+                    getInstance( "User" ).keyValues();
                 } ).toThrow(
                     type = "QuickEntityNotLoaded",
-                    regex = "This instance is not loaded so the \`keyValue\` cannot be retrieved\."
+                    regex = "This instance is not loaded so the \`keyValues\` cannot be retrieved\."
                 );
             } );
 


### PR DESCRIPTION
This is a major change that allows keys to be arrays for composite keys.  This applies to primary keys as well as all relationships (foreign keys, owner keys, etc.)  No code changes should be necessary.  All single values will be wrapped as needed.  The functions that are different are `keyName` -> `keyNames`, `keyValue` -> `keyValues`, `keyColumn` -> `keyColumns`, etc.

Closes #66 and #56 