### PR TITLE
Distinct fixes

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -415,11 +415,11 @@ component accessors="true" {
 	 * Syncs the values found in the variables scope (due to accessors) in to data
 	 */
 	private void function syncVariablesScopeWithData() {
-		retrieveAttributeNames( withVirtualColumns = false ).each( function( key ) {
+		for ( var key in retrieveAttributeNames( withVirtualColumns = false ) ) {
 			if ( variables.keyExists( key ) && !isReadOnlyAttribute( key ) ) {
 				assignAttribute( key, variables[ key ] );
 			}
-		} );
+		}
 	}
 
 	/**
@@ -526,16 +526,16 @@ component accessors="true" {
 			return this;
 		}
 
-		arguments.attributes.each( function( key, value ) {
-			variables._data[ retrieveColumnForAlias( key ) ] = isNull( value ) ? javacast( "null", "" ) : castValueForGetter(
+		for ( var key in arguments.attributes ) {
+			variables._data[ retrieveColumnForAlias( key ) ] = (!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )) ? javacast( "null", "" ) : castValueForGetter(
 				key,
-				value
+				arguments.attributes[ key ]
 			);
-			variables[ retrieveAliasForColumn( key ) ] = isNull( value ) ? javacast( "null", "" ) : castValueForGetter(
+			variables[ retrieveAliasForColumn( key ) ] = (!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )) ? javacast( "null", "" ) : castValueForGetter(
 				key,
-				value
+				arguments.attributes[ key ]
 			);
-		} );
+		}
 
 		return this;
 	}
@@ -982,9 +982,9 @@ component accessors="true" {
 		boolean ignoreNonExistentAttributes = false
 	) {
 		try {
-			arguments.attributes.each( function( key, value ) {
-				retrieveQuery().where( key, value );
-			} );
+			for ( var key in arguments.attributes ) {
+				retrieveQuery().where( key, arguments.attributes[ key ] );
+			}
 			return firstOrFail();
 		} catch ( EntityNotFound e ) {
 			arguments.attributes.append( arguments.newAttributes, true );
@@ -1012,9 +1012,9 @@ component accessors="true" {
 		struct newAttributes                = {},
 		boolean ignoreNonExistentAttributes = false
 	) {
-		arguments.attributes.each( function( key, value ) {
-			retrieveQuery().where( key, value );
-		} );
+		for ( var key in arguments.attributes ) {
+			retrieveQuery().where( key, arguments.attributes[ key ] );
+		}
 
 		try {
 			return firstOrFail();
@@ -1046,9 +1046,10 @@ component accessors="true" {
 		var data = retrieveQuery()
 			.from( tableName() )
 			.where( function( q ) {
-				keyNames().each( function( keyName, i ) {
-					q.where( keyName, id[ i ] );
-				} );
+				var allKeyNames = keyNames();
+				for ( var i = 1; i <= allKeyNames.len(); i++ ) {
+					q.where( allKeyNames[ i ], id[ i ] );
+				}
 			} )
 			.first();
 
@@ -1185,9 +1186,9 @@ component accessors="true" {
 			arguments.id = arrayWrap( arguments.id );
 			guardAgainstKeyLengthMismatch( arguments.id );
 			retrieveQuery().where( function( q ) {
-				keyColumns().each( function( keyColumn, i ) {
+				for ( var keyColumn in keyColumns() ) {
 					q.where( keyColumn, id[ 1 ] );
-				} );
+				}
 			} );
 		}
 		return retrieveQuery().exists();
@@ -1282,8 +1283,8 @@ component accessors="true" {
 		return variables
 			.resetQuery()
 			.where( function( q ) {
-				keyNames().each( function( keyName, i ) {
-					q.where( this.qualifyColumn( keyName ), keyValues()[ i ] );
+				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
+					q.where( keyName, keyValue );
 				} );
 			} )
 			.first();
@@ -1302,8 +1303,8 @@ component accessors="true" {
 			newQuery()
 				.from( tableName() )
 				.where( function( q ) {
-					keyNames().each( function( keyName, i ) {
-						q.where( this.qualifyColumn( keyName ), keyValues()[ i ] );
+					arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
+						q.where( this.qualifyColumn( keyName ), keyValue );
 					} );
 				} )
 				.first()
@@ -1331,8 +1332,8 @@ component accessors="true" {
 			fireEvent( "preUpdate", { entity : this } );
 			newQuery()
 				.where( function( q ) {
-					keyNames().each( function( keyName, i ) {
-						q.where( keyName, keyValues()[ i ] );
+					arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
+						q.where( keyName, keyValue );
 					} );
 				} )
 				.update(
@@ -1391,8 +1392,8 @@ component accessors="true" {
 		);
 		newQuery()
 			.where( function( q ) {
-				keyNames().each( function( keyName, i ) {
-					q.where( keyName, keyValues()[ i ] );
+				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
+					q.where( keyName, keyValue );
 				} );
 			} )
 			.delete();
@@ -1526,13 +1527,13 @@ component accessors="true" {
 	 * @return  quick.models.BaseEntity;
 	 */
 	public any function loadRelationship( required any name, boolean force = false ) {
-		arrayWrap( arguments.name ).each( function( n ) {
-			if ( force || !isRelationshipLoaded( arguments.n ) ) {
-				var relationship = invoke( this, arguments.n );
-				relationship.setRelationMethodName( arguments.n );
-				assignRelationship( arguments.n, relationship.get() );
+		for ( var n in arrayWrap( arguments.name ) ) {
+			if ( arguments.force || !isRelationshipLoaded( n ) ) {
+				var relationship = invoke( this, n );
+				relationship.setRelationMethodName( n );
+				assignRelationship( n, relationship.get() );
 			}
-		} );
+		}
 		return this;
 	}
 
@@ -2481,7 +2482,7 @@ component accessors="true" {
 	 * @return    quick.models.BaseEntity
 	 */
 	public any function withCount( required any relation ) {
-		arrayWrap( arguments.relation ).each( function( r ) {
+		for ( var r in arrayWrap( arguments.relation ) ) {
 			var relationName = r;
 			var callback     = function() {
 			};
@@ -2512,7 +2513,7 @@ component accessors="true" {
 					} );
 				} )
 			);
-		} );
+		}
 
 		return this;
 	}
@@ -2831,9 +2832,9 @@ component accessors="true" {
 	 * @return  quick.models.BaseEntity
 	 */
 	public any function withoutGlobalScope( required any name ) {
-		arrayWrap( arguments.name ).each( function( n ) {
-			variables._globalScopeExclusions.append( lCase( arguments.n ) );
-		} );
+		for ( var n in arrayWrap( arguments.name ) ) {
+			variables._globalScopeExclusions.append( lCase( n ) );
+		}
 		return this;
 	}
 
@@ -2883,7 +2884,7 @@ component accessors="true" {
 	 *
 	 * @return  void
 	 */
-	function setUpMementifier() {
+	private void function setUpMementifier() {
 		param this.memento = {};
 		var defaults       = {
 			"defaultIncludes" : retrieveAttributeNames( withVirtualAttributes = true ),
@@ -3010,12 +3011,12 @@ component accessors="true" {
 
 					param meta.originalMetadata.properties = [];
 					meta[ "attributes" ]                   = generateAttributesFromProperties( meta.originalMetadata.properties );
-					arrayWrap( variables._key ).each( function( key ) {
+					for ( var key in keyNames() ) {
 						if ( !meta.attributes.keyExists( key ) ) {
 							var keyProp                     = paramAttribute( { "name" : key } );
 							meta.attributes[ keyProp.name ] = keyProp;
 						}
-					} );
+					}
 					meta[ "casts" ] = generateCastsFromProperties( meta.originalMetadata.properties );
 					guardKeyHasNoDefaultValue( meta.attributes );
 					return meta;
@@ -3289,7 +3290,7 @@ component accessors="true" {
 	 * @throws  QuickEntityDefaultedKey
 	 */
 	private void function guardKeyHasNoDefaultValue( required struct attributes ) {
-		keyNames().each( function( keyName ) {
+		for ( var keyName in keyNames() ) {
 			if ( attributes.keyExists( keyName ) ) {
 				if ( attributes[ keyName ].keyExists( "default" ) ) {
 					throw(
@@ -3298,7 +3299,7 @@ component accessors="true" {
 					);
 				}
 			}
-		} );
+		}
 	}
 
 	/**
@@ -3544,24 +3545,25 @@ component accessors="true" {
 	 */
 	private any function mergeAttributesFromCastCache() {
 		syncVariablesScopeWithData();
-		variables._castCache.each( function( key, castedValue ) {
-			if ( !variables._casterCache.keyExists( arguments.key ) ) {
-				var castMapping                         = variables._casts[ arguments.key ];
-				variables._casterCache[ arguments.key ] = variables._wirebox.getInstance( dsl = castMapping );
+		for ( var key in variables._castCache ) {
+			var castedValue = variables._castCache[ key ];
+			if ( !variables._casterCache.keyExists( key ) ) {
+				var castMapping                         = variables._casts[ key ];
+				variables._casterCache[ key ] = variables._wirebox.getInstance( dsl = castMapping );
 			}
-			var caster = variables._casterCache[ arguments.key ];
+			var caster = variables._casterCache[ key ];
 			var attrs  = caster.set(
 				this,
-				arguments.key,
-				arguments.castedValue
+				key,
+				castedValue
 			);
 			if ( !isStruct( attrs ) ) {
-				attrs = { "#arguments.key#" : attrs };
+				attrs = { "#key#" : attrs };
 			}
-			attrs.each( function( column, value ) {
-				assignAttribute( column, value );
-			} );
-		} );
+			for ( var column in attrs ) {
+				assignAttribute( column, attrs[ column ] );
+			}
+		}
 		return this;
 	}
 
@@ -3602,6 +3604,56 @@ component accessors="true" {
 	 */
 	private array function arrayWrap( required any value ) {
 		return isArray( arguments.value ) ? arguments.value : [ arguments.value ];
+	}
+
+	/**
+	 * Accepts an array of arrays and calls a callback passing each item of
+	 * the same index from each of the arrays.
+	 *
+	 * @arrays    An array of arrays.  All arrays must have the same length.
+	 * @callback  The callback to call.  It will be passed an item from each
+	 *            array passed in at the same index.
+	 *
+	 * @throws    ArrayZipLengthMismatch
+	 *
+	 * @return    The original array of arrays passed in.
+	 */
+	private array function arrayZipEach( required array arrays, required any callback ) {
+		if ( arguments.arrays.isEmpty() ) {
+			return arguments.arrays;
+		}
+
+		var lengths = arguments.arrays.map( function( arr ) {
+			return arr.len();
+		} );
+		if ( unique( lengths ).len() > 1 ) {
+			throw(
+				type    = "ArrayZipLengthMismatch",
+				message = "The arrays do not have the same length. Lengths: [#serializeJSON( lengths )#]"
+			);
+		}
+
+		for ( var i = 1; i <= arguments.arrays[ 1 ].len(); i++ ) {
+			var args = {};
+			for ( var j = 1; j <= arguments.arrays.len(); j++ ) {
+				args[ j ] = arguments.arrays[ j ][ i ];
+			}
+			callback( argumentCollection = args );
+		}
+
+		return arguments.arrays;
+	}
+
+	/**
+	 * Returns an array of the unique items of an array.
+	 *
+	 * @items        An array of items.
+	 *
+	 * @doc_generic  any
+	 * @return       [any]
+	 */
+	public array function unique( required array items ) {
+		return arraySlice( createObject( "java", "java.util.HashSet" ).init( arguments.items ).toArray(), 1 );
 	}
 
 }

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -527,14 +527,12 @@ component accessors="true" {
 		}
 
 		for ( var key in arguments.attributes ) {
-			variables._data[ retrieveColumnForAlias( key ) ] = (!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )) ? javacast( "null", "" ) : castValueForGetter(
-				key,
-				arguments.attributes[ key ]
-			);
-			variables[ retrieveAliasForColumn( key ) ] = (!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )) ? javacast( "null", "" ) : castValueForGetter(
-				key,
-				arguments.attributes[ key ]
-			);
+			variables._data[ retrieveColumnForAlias( key ) ] = (
+				!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )
+			) ? javacast( "null", "" ) : castValueForGetter( key, arguments.attributes[ key ] );
+			variables[ retrieveAliasForColumn( key ) ] = (
+				!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )
+			) ? javacast( "null", "" ) : castValueForGetter( key, arguments.attributes[ key ] );
 		}
 
 		return this;
@@ -3548,15 +3546,11 @@ component accessors="true" {
 		for ( var key in variables._castCache ) {
 			var castedValue = variables._castCache[ key ];
 			if ( !variables._casterCache.keyExists( key ) ) {
-				var castMapping                         = variables._casts[ key ];
+				var castMapping               = variables._casts[ key ];
 				variables._casterCache[ key ] = variables._wirebox.getInstance( dsl = castMapping );
 			}
 			var caster = variables._casterCache[ key ];
-			var attrs  = caster.set(
-				this,
-				key,
-				castedValue
-			);
+			var attrs  = caster.set( this, key, castedValue );
 			if ( !isStruct( attrs ) ) {
 				attrs = { "#key#" : attrs };
 			}

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -359,6 +359,29 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	 *
 	 * @return  void
 	 */
+	public QuickBuilder function applyThroughExists( required QuickBuilder base ) {
+		arrayZipEach(
+			[
+				variables.foreignKeys,
+				variables.localKeys
+			],
+			function( foreignKey, localKey ) {
+				base.whereColumn(
+					variables.child.qualifyColumn( foreignKey ),
+					variables.related.qualifyColumn( localKey )
+				);
+			}
+		);
+		return variables.related.newQuery().reselectRaw( 1 ).whereExists( arguments.base );
+	}
+
+	/**
+	 * Applies the join for relationship in a `hasManyThrough` chain.
+	 *
+	 * @base    The query to apply the join to.
+	 *
+	 * @return  void
+	 */
 	public void function applyThroughJoin( required any base ) {
 		arguments.base.join( variables.child.tableName(), function( j ) {
 			arrayZipEach(

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -375,6 +375,19 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 		return variables.related.newQuery().reselectRaw( 1 ).whereExists( arguments.base );
 	}
 
+	public QuickBuilder function initialThroughConstraints() {
+		var base = variables.related.newQuery().reselectRaw( 1 );
+
+		arrayZipEach( [ variables.localKeys, variables.foreignKeys ], function( localKey, foreignKey ) {
+			base.where(
+				variables.related.qualifyColumn( localKey ),
+				variables.parent.retrieveAttribute( foreignKey )
+			);
+		} );
+
+		return base;
+	}
+
 	/**
 	 * Applies the join for relationship in a `hasManyThrough` chain.
 	 *

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -372,18 +372,27 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 				);
 			}
 		);
-		return variables.related.newQuery().reselectRaw( 1 ).whereExists( arguments.base );
+		return variables.related
+			.newQuery()
+			.reselectRaw( 1 )
+			.whereExists( arguments.base );
 	}
 
 	public QuickBuilder function initialThroughConstraints() {
 		var base = variables.related.newQuery().reselectRaw( 1 );
 
-		arrayZipEach( [ variables.localKeys, variables.foreignKeys ], function( localKey, foreignKey ) {
-			base.where(
-				variables.related.qualifyColumn( localKey ),
-				variables.parent.retrieveAttribute( foreignKey )
-			);
-		} );
+		arrayZipEach(
+			[
+				variables.localKeys,
+				variables.foreignKeys
+			],
+			function( localKey, foreignKey ) {
+				base.where(
+					variables.related.qualifyColumn( localKey ),
+					variables.parent.retrieveAttribute( foreignKey )
+				);
+			}
+		);
 
 		return base;
 	}

--- a/models/Relationships/BelongsToMany.cfc
+++ b/models/Relationships/BelongsToMany.cfc
@@ -560,7 +560,8 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	}
 
 	public QuickBuilder function initialThroughConstraints() {
-		var base = variables.related.newQuery()
+		var base = variables.related
+			.newQuery()
 			.reselectRaw( 1 )
 			.from( variables.table );
 
@@ -600,7 +601,8 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 		);
 
 		// nest in where exists for pivot table
-		arguments.base = variables.parent.newQuery()
+		arguments.base = variables.parent
+			.newQuery()
 			.reselectRaw( 1 )
 			.from( variables.table )
 			.whereExists( arguments.base );
@@ -617,7 +619,8 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 		);
 
 		// nest in where exists for base table
-		return variables.related.newQuery()
+		return variables.related
+			.newQuery()
 			.reselectRaw( 1 )
 			.whereExists( arguments.base );
 	}

--- a/models/Relationships/BelongsToMany.cfc
+++ b/models/Relationships/BelongsToMany.cfc
@@ -559,6 +559,69 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 		return this;
 	}
 
+	public QuickBuilder function initialThroughConstraints() {
+		var base = variables.related.newQuery()
+			.reselectRaw( 1 )
+			.from( variables.table );
+
+		arrayZipEach(
+			[
+				variables.relatedKeys,
+				getQualifiedRelatedPivotKeyNames()
+			],
+			function( relatedKey, pivotKey ) {
+				base.whereColumn( variables.related.qualifyColumn( relatedKey ), pivotKey );
+			}
+		);
+
+		return variables.related
+			.newQuery()
+			.reselectRaw( 1 )
+			.whereExists( base );
+	}
+
+	/**
+	 * Applies the exists for relationship in a `hasManyThrough` chain.
+	 *
+	 * @base    The query to apply the exists to.
+	 *
+	 * @return  void
+	 */
+	public QuickBuilder function applyThroughExists( required QuickBuilder base ) {
+		// apply compare constraints for pivot table
+		arrayZipEach(
+			[
+				variables.foreignKeys,
+				getQualifiedForeignPivotKeyNames()
+			],
+			function( foreignKey, pivotKey ) {
+				base.whereColumn( variables.parent.qualifyColumn( foreignKey ), pivotKey );
+			}
+		);
+
+		// nest in where exists for pivot table
+		arguments.base = variables.parent.newQuery()
+			.reselectRaw( 1 )
+			.from( variables.table )
+			.whereExists( arguments.base );
+
+		// apply compare constraints for base table
+		arrayZipEach(
+			[
+				variables.relatedKeys,
+				getQualifiedRelatedPivotKeyNames()
+			],
+			function( relatedKey, pivotKey ) {
+				base.whereColumn( variables.related.qualifyColumn( relatedKey ), pivotKey );
+			}
+		);
+
+		// nest in where exists for base table
+		return variables.related.newQuery()
+			.reselectRaw( 1 )
+			.whereExists( arguments.base );
+	}
+
 	/**
 	 * Applies the join for relationship in a `hasManyThrough` chain.
 	 *
@@ -567,7 +630,6 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	 * @return  void
 	 */
 	public void function applyThroughJoin( required any base ) {
-		arguments.base.distinct();
 		performJoin( arguments.base );
 		arguments.base.join( variables.parent.tableName(), function( j ) {
 			arrayZipEach(

--- a/models/Relationships/HasMany.cfc
+++ b/models/Relationships/HasMany.cfc
@@ -84,4 +84,29 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 		} );
 	}
 
+	/**
+	 * Applies the constraints for the final relationship in a `hasManyThrough` chain.
+	 *
+	 * @return  void
+	 */
+	public QueryBuilder function initialThroughConstraints() {
+		return variables.related
+			.newQuery()
+			.reselectRaw( 1 )
+			.where( function( q ) {
+				arrayZipEach(
+					[
+						variables.foreignKeys,
+						variables.localKeys
+					],
+					function( foreignKey, localKey ) {
+						q.where(
+							variables.related.qualifyColumn( foreignKey ),
+							variables.parent.retrieveAttribute( localKey )
+						);
+					}
+				);
+			} );
+	}
+
 }

--- a/models/Relationships/HasMany.cfc
+++ b/models/Relationships/HasMany.cfc
@@ -63,30 +63,6 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 	/**
 	 * Applies the constraints for the final relationship in a `hasManyThrough` chain.
 	 *
-	 * @base    The query to apply the constraints to.
-	 *
-	 * @return  void
-	 */
-	public void function applyThroughConstraints( required any base ) {
-		arguments.base.where( function( q ) {
-			arrayZipEach(
-				[
-					variables.foreignKeys,
-					variables.localKeys
-				],
-				function( foreignKey, localKey ) {
-					q.where(
-						variables.related.qualifyColumn( foreignKey ),
-						variables.parent.retrieveAttribute( localKey )
-					);
-				}
-			);
-		} );
-	}
-
-	/**
-	 * Applies the constraints for the final relationship in a `hasManyThrough` chain.
-	 *
 	 * @return  void
 	 */
 	public QueryBuilder function initialThroughConstraints() {

--- a/models/Relationships/HasManyThrough.cfc
+++ b/models/Relationships/HasManyThrough.cfc
@@ -73,16 +73,4 @@ component extends="quick.models.Relationships.HasOneOrManyThrough" {
 		return arguments.entities;
 	}
 
-	/**
-	 * Applies the constraints for the final relationship in a `HasOneOrManyThrough` chain.
-	 *
-	 * @base    The query to apply the constraints to.
-	 *
-	 * @return  void
-	 */
-	public void function applyThroughConstraints( required any base ) {
-		performJoin( arguments.base );
-		variables.closestToParent.applyThroughConstraints( arguments.base );
-	}
-
 }

--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -357,6 +357,35 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	 *
 	 * @return  void
 	 */
+	public QuickBuilder function applyThroughExists( any base = variables.related ) {
+		// apply compare constraints
+		arrayZipEach(
+			[
+				variables.foreignKeys,
+				variables.localKeys
+			],
+			function( foreignKey, localKey ) {
+				base.whereColumn(
+					variables.related.qualifyColumn( foreignKey ),
+					variables.parent.qualifyColumn( localKey )
+				);
+			}
+		);
+
+		// nest in exists
+		return variables.related
+			.newQuery()
+			.reselectRaw( 1 )
+			.whereExists( arguments.base );
+	}
+
+	/**
+	 * Applies the join for relationship in a `hasManyThrough` chain.
+	 *
+	 * @base    The query to apply the join to.
+	 *
+	 * @return  void
+	 */
 	public void function applyThroughJoin( required any base ) {
 		arguments.base.join( variables.parent.tableName(), function( j ) {
 			arrayZipEach(

--- a/models/Relationships/HasOneOrManyThrough.cfc
+++ b/models/Relationships/HasOneOrManyThrough.cfc
@@ -104,6 +104,16 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 		);
 	}
 
+	public QuickBuilder function applyThroughExists( required QuickBuilder base ) {
+		var selectedColumns = variables.related.getColumns();
+		return addNestedWhereExists(
+			variables.closestToParent
+				.getRelated()
+				.newQuery()
+				.reselectRaw( 1 )
+		).whereExists( arguments.base ).select( selectedColumns );
+	}
+
 	/**
 	 * Adds a join to the intermediate tables for the relationship.
 	 *

--- a/models/Relationships/HasOneOrManyThrough.cfc
+++ b/models/Relationships/HasOneOrManyThrough.cfc
@@ -82,7 +82,7 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	 */
 	public HasOneOrManyThrough function addConstraints() {
 		var selectedColumns = variables.related.getColumns();
-		var base = initialThroughConstraints();
+		var base            = initialThroughConstraints();
 		base.select( selectedColumns );
 		variables.related.populateQuery( base );
 		return this;
@@ -92,16 +92,14 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 		for ( var index = 2; index <= variables.relationships.len(); index++ ) {
 			var relationshipName = variables.relationships[ index ];
 			var relation         = variables.relationshipsMap[ relationshipName ];
-			arguments.base = relation.applyThroughExists( arguments.base );
+			arguments.base       = relation.applyThroughExists( arguments.base );
 		}
 		return arguments.base;
 	}
 
 
 	public QuickBuilder function initialThroughConstraints() {
-		return addNestedWhereExists(
-			variables.closestToParent.initialThroughConstraints()
-		);
+		return addNestedWhereExists( variables.closestToParent.initialThroughConstraints() );
 	}
 
 	public QuickBuilder function applyThroughExists( required QuickBuilder base ) {

--- a/models/Relationships/IRelationship.cfc
+++ b/models/Relationships/IRelationship.cfc
@@ -1,0 +1,160 @@
+interface displayname="IRelationship" {
+
+	/**
+	 * Sets the relation method name for this relationship.
+	 *
+	 * @name     The relation method name for this relationship.
+	 *
+	 * @return   IRelationship
+	 */
+	public IRelationship function setRelationMethodName( required string name );
+
+	/**
+	 * Retrieves the entities for eager loading.
+	 *
+	 * @doc_generic  quick.models.BaseEntity
+	 * @return       [quick.models.BaseEntity]
+	 */
+	public array function getEager();
+
+	/**
+	 * Gets the first matching record for the relationship.
+	 * Returns null if no record is found.
+	 *
+	 * @return   quick.models.BaseEntity
+	 */
+	public any function first();
+
+	/**
+	 * Gets the first matching record for the relationship.
+	 * Throws an exception if no record is found.
+	 *
+	 * @throws   EntityNotFound
+	 *
+	 * @return   quick.models.BaseEntity
+	 */
+	public any function firstOrFail();
+
+	/**
+	 * Finds the first matching record with a given id for the relationship.
+	 * Returns null if no record is found.
+	 *
+	 * @id       The id of the entity to find.
+	 *
+	 * @return   quick.models.BaseEntity
+	 */
+	public any function find( required any id );
+
+	/**
+	 * Finds the first matching record with a given id for the relationship.
+	 * Throws an exception if no record is found.
+	 *
+	 * @id       The id of the entity to find.
+	 *
+	 * @throws   EntityNotFound
+	 *
+	 * @return   quick.models.BaseEntity
+	 */
+	public any function findOrFail( required any id );
+
+	/**
+	 * Returns all results for the related entity.
+	 * Note: `all` resets any query restrictions, including relationship restrictions.
+	 *
+	 * @doc_generic  quick.models.BaseEntity
+	 * @return       [quick.models.BaseEntity]
+	 */
+	public array function all();
+
+	/**
+	 * Wrapper for `getResults()` on relationship types that have them.
+	 * `get()` implemented for consistency with qb and Quick.
+	 *
+	 * @return   quick.models.BaseEntity or [quick.models.BaseEntity]
+	 */
+	public any function get();
+
+	/**
+	 * Retrieves the values of the key from each entity passed.
+	 *
+	 * @entities  An array of entities to retrieve keys.
+	 * @key       The key to retrieve from each entity.
+	 *
+	 * @doc_generic  any
+	 * @return   [any]
+	 */
+	public array function getKeys( required array entities, required array keys );
+
+	/**
+	 * Checks if all of the keys (usually foreign keys) on the specified entity are null. Used to determine whether we should even run a relationship query or just return null.
+	 *
+	 * @fields An array of field names to check on the parent entity
+	 *
+	 * @return true if all keys are null; false if any foreign keys have a value
+	 */
+	public boolean function fieldsAreNull( required any entity, required array fields );
+
+	/**
+	 * Gets the query used to check for relation existance.
+	 *
+	 * @base    The base entity for the query.
+	 *
+	 * @return  quick.models.BaseEntity | qb.models.Query.QueryBuilder
+	 */
+	public any function addCompareConstraints( any base );
+
+	public any function nestCompareConstraints( required any base, required any nested );
+
+	/**
+	 * Returns the fully-qualified local key.
+	 *
+	 * @doc_generic  String
+	 * @return       [String]
+	 */
+	public array function getQualifiedLocalKeys();
+
+	/**
+	 * Returns the fully-qualified local key.
+	 *
+	 * @doc_generic  String
+	 * @return       [String]
+	 */
+	public array function getExistanceLocalKeys();
+
+	/**
+	 * Get the key to compare in the existence query.
+	 *
+	 * @doc_generic  String
+	 * @return       [String]
+	 */
+	public array function getExistenceCompareKeys();
+
+	/**
+	 * Returns the related entity for the relationship.
+	 */
+	public any function getRelated();
+
+	/**
+	 * Flags the entity to return a default entity if the relation returns null.
+	 *
+	 * @return  quick.models.Relationships.IRelationship
+	 */
+	public IRelationship function withDefault( any attributes );
+
+	/**
+	 * Applies a suffix to an alias for the relationship.
+	 *
+	 * @suffix   The suffix to append.
+	 *
+	 * @return  quick.models.Relationships.IRelationship
+	 */
+	public IRelationship function applyAliasSuffix( required string suffix );
+
+	/**
+	 * Retrieves the current query builder instance.
+	 *
+	 * @return  quick.models.QuickBuilder
+	 */
+	public QuickBuilder function retrieveQuery();
+
+}

--- a/models/Relationships/PolymorphicBelongsTo.cfc
+++ b/models/Relationships/PolymorphicBelongsTo.cfc
@@ -230,4 +230,19 @@ component extends="quick.models.Relationships.BelongsTo" accessors="true" {
 		return this;
 	}
 
+	public QuickBuilder function initialThroughConstraints() {
+		var base = variables.related
+			.newQuery()
+			.reselectRaw( 1 );
+
+		arrayZipEach( [ variables.localKeys, variables.foreignKeys ], function( localKey, foreignKey ) {
+			base.where(
+				variables.related.qualifyColumn( localKey ),
+				variables.parent.retrieveAttribute( foreignKey )
+			);
+		} );
+
+		return base;
+	}
+
 }

--- a/models/Relationships/PolymorphicBelongsTo.cfc
+++ b/models/Relationships/PolymorphicBelongsTo.cfc
@@ -231,16 +231,20 @@ component extends="quick.models.Relationships.BelongsTo" accessors="true" {
 	}
 
 	public QuickBuilder function initialThroughConstraints() {
-		var base = variables.related
-			.newQuery()
-			.reselectRaw( 1 );
+		var base = variables.related.newQuery().reselectRaw( 1 );
 
-		arrayZipEach( [ variables.localKeys, variables.foreignKeys ], function( localKey, foreignKey ) {
-			base.where(
-				variables.related.qualifyColumn( localKey ),
-				variables.parent.retrieveAttribute( foreignKey )
-			);
-		} );
+		arrayZipEach(
+			[
+				variables.localKeys,
+				variables.foreignKeys
+			],
+			function( localKey, foreignKey ) {
+				base.where(
+					variables.related.qualifyColumn( localKey ),
+					variables.parent.retrieveAttribute( foreignKey )
+				);
+			}
+		);
 
 		return base;
 	}

--- a/models/Relationships/PolymorphicHasMany.cfc
+++ b/models/Relationships/PolymorphicHasMany.cfc
@@ -61,18 +61,13 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 	}
 
 	public QuickBuilder function initialThroughConstraints() {
-		var base = variables.parent.newQuery()
+		var base = variables.parent
+			.newQuery()
 			.reselectRaw( 1 )
-			.where(
-				variables.related.qualifyColumn( variables.morphType ),
-				variables.morphMapping
-			);
+			.where( variables.related.qualifyColumn( variables.morphType ), variables.morphMapping );
 
 		variables.localKeys.each( function( localKey ) {
-			base.where(
-				variables.parent.qualifyColumn( localKey ),
-				variables.parent.retrieveAttribute( localKey )
-			);
+			base.where( variables.parent.qualifyColumn( localKey ), variables.parent.retrieveAttribute( localKey ) );
 		} );
 
 		arrayZipEach(
@@ -88,7 +83,8 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 			}
 		);
 
-		return variables.related.newQuery()
+		return variables.related
+			.newQuery()
 			.reselectRaw( 1 )
 			.whereExists( base );
 	}

--- a/models/Relationships/PolymorphicHasMany.cfc
+++ b/models/Relationships/PolymorphicHasMany.cfc
@@ -60,6 +60,39 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 		return matchMany( argumentCollection = arguments );
 	}
 
+	public QuickBuilder function initialThroughConstraints() {
+		var base = variables.parent.newQuery()
+			.reselectRaw( 1 )
+			.where(
+				variables.related.qualifyColumn( variables.morphType ),
+				variables.morphMapping
+			);
+
+		variables.localKeys.each( function( localKey ) {
+			base.where(
+				variables.parent.qualifyColumn( localKey ),
+				variables.parent.retrieveAttribute( localKey )
+			);
+		} );
+
+		arrayZipEach(
+			[
+				variables.foreignKeys,
+				variables.localKeys
+			],
+			function( foreignKey, localKey ) {
+				base.whereColumn(
+					variables.related.qualifyColumn( foreignKey ),
+					variables.parent.qualifyColumn( localKey )
+				);
+			}
+		);
+
+		return variables.related.newQuery()
+			.reselectRaw( 1 )
+			.whereExists( base );
+	}
+
 	/**
 	 * Applies the constraints for the final relationship in a `hasManyThrough` chain.
 	 *

--- a/tests/specs/integration/BaseEntity/Relationships/HasManyThroughSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManyThroughSpec.cfc
@@ -66,9 +66,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				var country  = getInstance( "Country" ).findOrFail( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
 				var comments = country.getComments();
 				expect( comments ).toBeArray();
-				expect( comments ).toHaveLength( 1 );
+				expect( comments ).toHaveLength( 2 );
 				expect( comments[ 1 ].getId() ).toBe( 1 );
+				expect( comments[ 1 ].getCommentableType() ).toBe( "Post" );
 				expect( comments[ 1 ].getBody() ).toBe( "I thought this post was great" );
+				expect( comments[ 2 ].getId() ).toBe( 3 );
+				expect( comments[ 2 ].getCommentableType() ).toBe( "Video" );
+				expect( comments[ 2 ].getBody() ).toBe( "What a great video! So fun!" );
 			} );
 
 			it( "can go up and down belongsTo and hasMany relationships", function() {


### PR DESCRIPTION
Using `DISTINCT` caused issues when trying to order by a relationship field.  This PR removes DISTINCT from the few relationships that were using them.