### PR TITLE
Feature/enable child subclass entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /modules
 
+.vscode
 !.engine/
 .engine/*
 !.engine/WEB-INF/

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -1,86 +1,88 @@
 component {
 
-    this.name = "quick";
-    this.author = "Eric Peterson";
-    this.webUrl = "https://github.com/coldbox-modules/quick";
-    this.dependencies = [ "qb", "str", "mementifier" ];
-    this.cfmapping = "quick";
+	this.name         = "quick";
+	this.author       = "Eric Peterson";
+	this.webUrl       = "https://github.com/coldbox-modules/quick";
+	this.dependencies = [ "qb", "str", "mementifier" ];
+	this.cfmapping    = "quick";
 
-    function configure() {
-        settings = {
-            "defaultGrammar" = "AutoDiscover@qb",
-            "preventDuplicateJoins" = true,
-            "metadataCache" = {
-                "name"                  : "quickMeta",
-                "provider"              : "coldbox.system.cache.providers.CacheBoxColdBoxProvider",
-                "properties"            : {
-                    "objectDefaultTimeout"  : 0, // no timeout
-                    "useLastAccessTimeouts" : false, // no last access timeout
-                    "maxObjects"            : 300,
-                    "objectStore"           : "ConcurrentStore"
-                }
+	function configure() {
+		settings = {
+			"defaultGrammar"        : "AutoDiscover@qb",
+			"preventDuplicateJoins" : true,
+			"metadataCache"         : {
+				"name"       : "quickMeta",
+				"provider"   : "coldbox.system.cache.providers.CacheBoxColdBoxProvider",
+				"properties" : {
+					"objectDefaultTimeout"  : 0, // no timeout
+					"useLastAccessTimeouts" : false, // no last access timeout
+					"maxObjects"            : 300,
+					"objectStore"           : "ConcurrentStore"
+				}
 			}
-        };
+		};
 
-        interceptorSettings = {
-            customInterceptionPoints = [
-                "quickInstanceReady",
-                "quickPreLoad",
-                "quickPostLoad",
-                "quickPreSave",
-                "quickPostSave",
-                "quickPreInsert",
-                "quickPostInsert",
-                "quickPreUpdate",
-                "quickPostUpdate",
-                "quickPreDelete",
-                "quickPostDelete"
-            ]
-        };
+		interceptorSettings = {
+			customInterceptionPoints : [
+				"quickInstanceReady",
+				"quickPreLoad",
+				"quickPostLoad",
+				"quickPreSave",
+				"quickPostSave",
+				"quickPreInsert",
+				"quickPostInsert",
+				"quickPreUpdate",
+				"quickPostUpdate",
+				"quickPreDelete",
+				"quickPostDelete"
+			]
+		};
 
-        binder.map( "quick.models.BaseEntity" )
-            .to( "#moduleMapping#.models.BaseEntity" );
+		binder.map( "quick.models.BaseEntity" ).to( "#moduleMapping#.models.BaseEntity" );
 
-        binder.getInjector().registerDSL( "quickService", "#moduleMapping#.dsl.QuickServiceDSL" );
-    }
+		binder.getInjector().registerDSL( "quickService", "#moduleMapping#.dsl.QuickServiceDSL" );
+	}
 
-    function onLoad() {
-        binder.map( alias = "QuickBuilder@quick", force = true )
-            .to( "#moduleMapping#.models.QuickBuilder" )
-            .initArg( name = "grammar", dsl = settings.defaultGrammar )
-            .initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
-            .initArg( name = "utils", dsl = "QueryUtils@qb" )
-            .initArg( name = "returnFormat", value = "array" );
+	function onLoad() {
+		binder
+			.map( alias = "QuickBuilder@quick", force = true )
+			.to( "#moduleMapping#.models.QuickBuilder" )
+			.initArg( name = "grammar", dsl = settings.defaultGrammar )
+			.initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
+			.initArg( name = "utils", dsl = "QueryUtils@qb" )
+			.initArg( name = "returnFormat", value = "array" );
 
-        if( isSimpleValue( settings.metadataCache ) ){
-            settings.metadataCache = { "name" : settings.metadataCache };
-        }
+		if ( isSimpleValue( settings.metadataCache ) ) {
+			settings.metadataCache = { "name" : settings.metadataCache };
+		}
 
-        if( settings.metadataCache.name != "quickMeta" ){
-            binder.map( "cachebox:quickMeta" )
-                    .toDSL( "cachebox:#settings.metadataCache.name#" );
-        } else {
-            controller.getCachebox().createCache( argumentCollection = settings.metadataCache );
-        }
-        
-    }
+		if ( settings.metadataCache.name != "quickMeta" ) {
+			binder.map( "cachebox:quickMeta" ).toDSL( "cachebox:#settings.metadataCache.name#" );
+		} else {
+			controller.getCachebox().createCache( argumentCollection = settings.metadataCache );
+		}
+	}
 
-    function onUnload(){
-        controller.getCachebox().getCache( settings.metadataCache.name ).clearAll();
-    }
+	function onUnload() {
+		controller
+			.getCachebox()
+			.getCache( settings.metadataCache.name )
+			.clearAll();
+	}
 
 
-    /**
-     * This interceptor ensures that the `_mapping` property for a Quick entity
-     * is correctly set to the mapping used in WireBox.
-     *
-     * @event          The current request context
-     * @interceptData  The intercept data for `afterInstanceAutowire`.
-     *                 { mapping, target, targetID, injector }
-     */
-    function beforeInstanceAutowire( event, interceptData ) {
-        if ( structKeyExists( interceptData.target, "isQuickEntity" ) ) {
-            interceptData.target.set_mapping( interceptData.targetID );
-        }
-    }
+	/**
+	 * This interceptor ensures that the `_mapping` property for a Quick entity
+	 * is correctly set to the mapping used in WireBox.
+	 *
+	 * @event          The current request context
+	 * @interceptData  The intercept data for `afterInstanceAutowire`.
+	 *                 { mapping, target, targetID, injector }
+	 */
+	function beforeInstanceAutowire( event, interceptData ) {
+		if ( structKeyExists( interceptData.target, "isQuickEntity" ) ) {
+			interceptData.target.set_mapping( interceptData.targetID );
+		}
+	}
+
 }

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -71,7 +71,7 @@ component {
                     return acc;
                  }, [] );
                 var meta = childClass.get_Meta();
-                var parentMeta = meta.parentEntity.meta;
+                var parentMeta = meta.parentDefinition.meta;
                 
                 if( !structKeyExists( parentMeta, "table" ) ) parentMeta = application.wirebox.getInstance( parentMeta.fullName ).get_Meta();
                 
@@ -79,10 +79,10 @@ component {
                     application.quickMeta.discriminators[ parentMeta.table ] = {};
                 }
 
-                application.quickMeta.discriminators[ parentMeta.table ][ meta.parentEntity.discriminatorValue ] = {
+                application.quickMeta.discriminators[ parentMeta.table ][ meta.parentDefinition.discriminatorValue ] = {
                     "mapping" : meta.fullName,
                     "table" : meta.table,
-                    "joincolumn" : meta.parentEntity.joinColumn,
+                    "joincolumn" : meta.parentDefinition.joinColumn,
                     "attributes" : childAttributes
                 };
             }

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -9,7 +9,17 @@ component {
     function configure() {
         settings = {
             "defaultGrammar" = "AutoDiscover@qb",
-            "preventDuplicateJoins" = true
+            "preventDuplicateJoins" = true,
+            "metadataCache" = {
+                "name"                  : "quickMeta",
+                "provider"              : "coldbox.system.cache.providers.CacheBoxColdBoxProvider",
+                "properties"            : {
+                    "objectDefaultTimeout"  : 0, // no timeout
+                    "useLastAccessTimeouts" : false, // no last access timeout
+                    "maxObjects"            : 300,
+                    "objectStore"           : "ConcurrentStore"
+                }
+			}
         };
 
         interceptorSettings = {
@@ -41,10 +51,22 @@ component {
             .initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
             .initArg( name = "utils", dsl = "QueryUtils@qb" )
             .initArg( name = "returnFormat", value = "array" );
+
+        if( isSimpleValue( settings.metadataCache ) ){
+            settings.metadataCache = { "name" : settings.metadataCache };
+        }
+
+        if( settings.metadataCache.name != "quickMeta" ){
+            binder.map( "cachebox:quickMeta" )
+                    .toDSL( "cachebox:#settings.metadataCache.name#" );
+        } else {
+            controller.getCachebox().createCache( argumentCollection = settings.metadataCache );
+        }
+        
     }
 
     function onUnload(){
-        structDelete( application, "quickMeta" );
+        controller.getCachebox().getCache( settings.metadataCache.name ).clearAll();
     }
 
     /**

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -69,48 +69,6 @@ component {
         controller.getCachebox().getCache( settings.metadataCache.name ).clearAll();
     }
 
-    /**
-     * This interception ensures that quick entity parent/child relationships are available to discriminated entities
-     * @event          The current request context
-     * @interceptData  The intercept data for `afterAspectsLoad`.
-     */
-    function afterAspectsLoad( event, interceptData ){
-        param application.quickMeta = {};
-        param application.quickMeta.discriminators = {};
-        
-        binder.getMappings().each( function( key, mapping ){
-            if( !mapping.isDiscovered() ){
-                mapping.process( binder, application.wirebox );
-            }
-            var meta = mapping.getObjectMetadata();
-            if( structKeyExists( meta, "joincolumn" ) && structKeyExists( meta, "discriminatorValue" ) ){
-                // retrieve the inheritance metadata and attributes
-                var childClass = application.wirebox.getInstance( meta.fullName );
-                var childAttributes = childClass.get_Attributes().reduce( function( acc, attr, data ){ 
-                    if( !data.isParentColumn && !data.virtual && !data.exclude ){
-                        acc.append( data );
-                    }
-                    return acc;
-                 }, [] );
-                var meta = childClass.get_Meta();
-                var parentMeta = meta.parentDefinition.meta;
-                
-                if( !structKeyExists( parentMeta, "table" ) ) parentMeta = application.wirebox.getInstance( parentMeta.fullName ).get_Meta();
-                
-                if( !structKeyExists( application.quickMeta.discriminators, parentMeta.table ) ){
-                    application.quickMeta.discriminators[ parentMeta.table ] = {};
-                }
-
-                application.quickMeta.discriminators[ parentMeta.table ][ meta.parentDefinition.discriminatorValue ] = {
-                    "mapping" : meta.fullName,
-                    "table" : meta.table,
-                    "joincolumn" : meta.parentDefinition.joinColumn,
-                    "attributes" : childAttributes
-                };
-            }
-        } );
-        
-    }
 
     /**
      * This interceptor ensures that the `_mapping` property for a Quick entity

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -452,12 +452,12 @@ component accessors="true" {
 			if ( value.virtual && !withVirtualAttributes ) {
 				return items;
 			}
-			items.append( 
-				asColumnNames 
-				? value.isParentColumn 
-					? ( variables._parentEntity.meta.table & "." & value.column ) 
-					: value.column 
-				: key 
+			items.append(
+				asColumnNames
+				 ? value.isParentColumn
+				 ? ( variables._parentEntity.meta.table & "." & value.column )
+				 : value.column
+				 : key
 			);
 			return items;
 		}, [] );
@@ -945,7 +945,7 @@ component accessors="true" {
 	 */
 	public any function first() {
 		activateGlobalScopes();
-	
+
 		var attrs = retrieveQuery().first();
 
 		return structIsEmpty( attrs ) ? javacast( "null", "" ) : handleTransformations( loadEntity( attrs ) );

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -689,7 +689,7 @@ component accessors="true" {
 	 */
 	public string function retrieveAliasForColumn( required string column ) {
 		for ( var alias in variables._attributes ) {
-			if ( arguments.column == variables._attributes[ alias ].column || arguments.column == listLast( variables._attributes[ alias ].column, "." ) ) {
+			if ( arguments.column == variables._attributes[ alias ].column ) {
 				return alias;
 			}
 		}
@@ -1058,8 +1058,9 @@ component accessors="true" {
 		);
 		activateGlobalScopes();
 
-		var data = newQuery()
-			.where( function( q ) {
+		var q = variables._hasParentEntity ? newQuery() : retrieveQuery();
+
+		var data = q.where( function( q ) {
 				var allKeyNames = keyNames();
 				for ( var i = 1; i <= allKeyNames.len(); i++ ) {
 					q.where( allKeyNames[ i ], id[ i ] );
@@ -1189,6 +1190,10 @@ component accessors="true" {
 
 	}
 
+	/**
+	 * Checks for the presence of children and loads the child entity if it exists
+	 * @entity   the reference entity to inspect
+	 **/
 	private any function loadChildIfExists( required BaseEntity entity = this ){
 		if( !variables._loadChildren ) return arguments.entity;
 		

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3175,15 +3175,6 @@ component accessors="true" {
 
 		if ( variables._hasParentEntity ) {
 			variables._parentEntity = variables._meta.parentEntity;
-
-			if ( structKeyExists( variables._parentEntity, "discriminatorColumn" ) ) {
-				variables[ "get" & variables._parentEntity.discriminatorColumn ] = function() {
-					return variables._data.keyExists( variables._parentEntity.discriminatorColumn ) ? variables._data[
-						variables._parentEntity.discriminatorColumn
-					] : javacast( "null", 0 );
-				};
-			}
-
 			variables._key = variables._parentEntity.joincolumn;
 		}
 

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -233,7 +233,7 @@ component accessors="true" {
 	public any function init( struct meta = {}, boolean shallow = false ) {
 		variables._loadShallow = arguments.shallow;
 		assignDefaultProperties();
-		variables._meta         = arguments.meta;
+		variables._meta = arguments.meta;
 		return this;
 	}
 
@@ -262,7 +262,7 @@ component accessors="true" {
 		param variables._hasParentEntity          = false;
 		param variables._parentDefinition         = {};
 		param variables._discriminators           = [];
-		param variables._loadChildren 			  = true;
+		param variables._loadChildren             = true;
 		variables._asMemento                      = false;
 		variables._asMementoSettings              = {};
 		return this;

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3618,8 +3618,6 @@ component accessors="true" {
 		any value,
 		boolean checkNullValues = true
 	) {
-		arguments.column = arguments.column;
-
 		// If that value is already a struct, pass it back unchanged.
 		if ( !isNull( arguments.value ) && isStruct( arguments.value ) ) {
 			return arguments.value;

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3297,7 +3297,7 @@ component accessors="true" {
 	}
 
 	public function getDiscriminations() {
-		return variables._cache.getOrSet( "quick-metadata:discriminations-#tableName()#", function() {
+		return variables._cache.getOrSet( "quick-metadata:#variables._mapping#-discriminations", function() {
 			return variables._discriminators.reduce( function( acc, dsl ) {
 				var childClass = variables._wirebox.getInstance(
 					dsl           = dsl,

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1193,6 +1193,11 @@ component accessors="true" {
 			variables._loadChildren
 			&&
 			isDiscriminatedParent()
+			&&
+			structKeyExists( 
+				getDiscriminations(),
+				data[ variables._meta.localMetadata.discriminatorColumn ]
+			)
 		) {
 			var childClass = variables._wirebox.getInstance(
 				getDiscriminations()[ data[ variables._meta.localMetadata.discriminatorColumn ] ].mapping

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2476,7 +2476,7 @@ component accessors="true" {
 				tableName()
 			)
 		) {
-			var q = variables._builder..newQuery();
+			var q = variables._builder.newQuery();
 
 			var columns        = retrieveQualifiedColumns();
 			var discriminators = application.quickMeta.discriminators[ tableName ];

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -631,9 +631,9 @@ component accessors="true" {
 	 */
 	public any function hydrate( required struct attributes, boolean ignoreNonExistentAttributes = false ) {
 		guardAgainstMissingKeys( arguments.attributes );
-		fill( argumentCollection = arguments );
-		markLoaded();
-		return this;
+		return fill( argumentCollection = arguments )
+			.assignOriginalAttributes( arguments.attributes )
+			.markLoaded();
 	}
 
 	/**

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -226,7 +226,7 @@ component accessors="true" {
 	 */
 	public any function init( struct meta = {} ) {
 		assignDefaultProperties();
-		variables._meta = arguments.meta;
+		variables._meta         = arguments.meta;
 		variables._loadChildren = true;
 		return this;
 	}
@@ -1060,7 +1060,8 @@ component accessors="true" {
 
 		var q = variables._hasParentEntity ? newQuery() : retrieveQuery();
 
-		var data = q.where( function( q ) {
+		var data = q
+			.where( function( q ) {
 				var allKeyNames = keyNames();
 				for ( var i = 1; i <= allKeyNames.len(); i++ ) {
 					q.where( allKeyNames[ i ], id[ i ] );
@@ -1182,21 +1183,26 @@ component accessors="true" {
 	 * @return  quick.models.BaseEntity
 	 */
 	private any function loadEntity( required struct data ) {
-
-		if( 
+		if (
 			variables._loadChildren
 			&&
-			variables._meta.localMetadata.keyExists( "discriminatorColumn" ) 
-			&& 
+			variables._meta.localMetadata.keyExists( "discriminatorColumn" )
+			&&
 			application.quickMeta.discriminators.keyExists( variables._meta.table )
 			&&
 			data.keyExists( variables._meta.localMetadata.discriminatorColumn )
 			&&
-			application.quickMeta.discriminators[ variables._meta.table ].keyExists( data[ variables._meta.localMetadata.discriminatorColumn ] )
-		){
-			var childClass = variables._wirebox.getInstance( application.quickMeta.discriminators[ variables._meta.table ][ data[ variables._meta.localMetadata.discriminatorColumn ] ].mapping );
-			
-			keyNames().each( function( key, i ){
+			application.quickMeta.discriminators[ variables._meta.table ].keyExists(
+				data[ variables._meta.localMetadata.discriminatorColumn ]
+			)
+		) {
+			var childClass = variables._wirebox.getInstance(
+				application.quickMeta.discriminators[ variables._meta.table ][
+					data[ variables._meta.localMetadata.discriminatorColumn ]
+				].mapping
+			);
+
+			keyNames().each( function( key, i ) {
 				data[ childClass.keyNames()[ i ] ] = data[ key ];
 			} );
 
@@ -1207,7 +1213,6 @@ component accessors="true" {
 				.assignOriginalAttributes( arguments.data )
 				.markLoaded();
 		}
-
 	}
 
 	/**
@@ -1361,22 +1366,22 @@ component accessors="true" {
 	 * @return  quick.models.BaseEntity
 	 */
 	public any function save() {
-		if( variables._hasParentEntity ){
-
-			if( isLoaded() ){
-				var parent = variables._wirebox.getInstance( variables._parentEntity.meta.fullName ).set_LoadChildren( false ).findOrFail( keyValues() );
+		if ( variables._hasParentEntity ) {
+			if ( isLoaded() ) {
+				var parent = variables._wirebox
+					.getInstance( variables._parentEntity.meta.fullName )
+					.set_LoadChildren( false )
+					.findOrFail( keyValues() );
 			} else {
 				var parent = variables._wirebox.getInstance( variables._parentEntity.meta.fullName );
 			}
 
 			parent.fill( getMemento(), true ).save();
-						
-			assignAttributesData(
-				{
-					"#variables._parentEntity.key#" : parent.keyValues()[1],
-					"#variables._parentEntity.joinColumn#" : parent.keyValues()[1]
-				}
-			);
+
+			assignAttributesData( {
+				"#variables._parentEntity.key#"        : parent.keyValues()[ 1 ],
+				"#variables._parentEntity.joinColumn#" : parent.keyValues()[ 1 ]
+			} );
 		}
 		guardNoAttributes();
 		guardReadOnly();
@@ -1418,11 +1423,11 @@ component accessors="true" {
 			guardEmptyAttributeData( attrs );
 
 			var result = retrieveQuery().insert( attrs );
-			
-			if( variables._hasParentEntity ){
+
+			if ( variables._hasParentEntity ) {
 				result.result[ variables._parentEntity.joincolumn ] = variables._data[ variables._parentEntity.joinColumn ];
 			}
-			retrieveKeyType().postInsert( this, result );	
+			retrieveKeyType().postInsert( this, result );
 			assignOriginalAttributes( retrieveAttributesData() );
 			markLoaded();
 			fireEvent( "postInsert", { entity : this } );
@@ -1457,13 +1462,14 @@ component accessors="true" {
 			} )
 			.delete();
 
-		if( variables._hasParentEntity ){
-			variables._wirebox.getInstance( variables._parentEntity.meta.fullName )
-								.set_LoadChildren( false )
-								.findOrFail( keyValues() )
-								.delete();
+		if ( variables._hasParentEntity ) {
+			variables._wirebox
+				.getInstance( variables._parentEntity.meta.fullName )
+				.set_LoadChildren( false )
+				.findOrFail( keyValues() )
+				.delete();
 		}
-		
+
 		variables._loaded = false;
 		fireEvent( "postDelete", { entity : this } );
 		return this;
@@ -2455,47 +2461,45 @@ component accessors="true" {
 			.setReturnFormat( "array" )
 			.setDefaultOptions( variables._queryOptions )
 			.from( tableName() );
-		
-		if( variables._hasParentEntity ){
 
+		if ( variables._hasParentEntity ) {
 			return variables._builder
-						.newQuery()
-						.select( retrieveQualifiedColumns() )
-						.join( variables._parentEntity.meta.table, variables._parentEntity.meta.table & "." & variables._parentEntity.key, this.qualifyColumn( variables._key ) );
-		} else if( variables._meta.keyExists( "discriminatorColumn" ) && application.quickMeta.discriminators.keyExists( tableName() ) ){
-			
+				.newQuery()
+				.select( retrieveQualifiedColumns() )
+				.join(
+					variables._parentEntity.meta.table,
+					variables._parentEntity.meta.table & "." & variables._parentEntity.key,
+					this.qualifyColumn( variables._key )
+				);
+		} else if (
+			variables._meta.keyExists( "discriminatorColumn" ) && application.quickMeta.discriminators.keyExists(
+				tableName()
+			)
+		) {
 			var q = variables._builder..newQuery();
 
-			var columns = retrieveQualifiedColumns();
+			var columns        = retrieveQualifiedColumns();
 			var discriminators = application.quickMeta.discriminators[ tableName ];
-			discriminators.each( 
-				function( discriminator, data ){
-					columns.append( 
-						data.attributes.map( 
-							function( attr ){ 
-								return data.table & '.' & attr.column;
-							} 
-						), true
-					);
-						
-					q.join(
-						data.table,
-						'=',
-						data.joincolumn,
-						'right outer'
-					);
-				} 
-			);
-			
+			discriminators.each( function( discriminator, data ) {
+				columns.append(
+					data.attributes.map( function( attr ) {
+						return data.table & "." & attr.column;
+					} ),
+					true
+				);
+
+				q.join(
+					data.table,
+					"=",
+					data.joincolumn,
+					"right outer"
+				);
+			} );
+
 			return q.select( columns );
-			
 		} else {
-			return 
-				variables._builder
-				.newQuery()
-				.select( retrieveQualifiedColumns() );
+			return variables._builder.newQuery().select( retrieveQualifiedColumns() );
 		}
-		
 	}
 
 	/**
@@ -2517,7 +2521,6 @@ component accessors="true" {
 	 */
 	public QueryBuilder function retrieveQuery() {
 		return variables._builder;
-
 	}
 
 	/**
@@ -3024,7 +3027,6 @@ component accessors="true" {
 	 * @return any
 	 */
 	private any function handleTransformations( entity ) {
-
 		if ( !variables._asMemento ) {
 			return arguments.entity;
 		}
@@ -3092,44 +3094,42 @@ component accessors="true" {
 							message = 'This instance is missing `accessors="true"` in the component metadata.  This is required for Quick to work properly.  Please add it to your component metadata and reinit your application.'
 						);
 					}
-					meta[ "fullName" ]                     = meta.originalMetadata.fullname;
-					param meta.originalMetadata.mapping    = listLast( meta.originalMetadata.fullname, "." );
-					meta[ "mapping" ]                      = meta.originalMetadata.mapping;
-					param meta.originalMetadata.entityName = listLast( meta.originalMetadata.name, "." );
-					meta[ "entityName" ]                   = meta.originalMetadata.entityName;
-					param meta.originalMetadata.table      = variables._str.plural( variables._str.snake( meta.entityName ) );
-					meta[ "table" ]                        = meta.originalMetadata.table;
-					param meta.originalMetadata.readonly   = false;
-					meta[ "readonly" ]                     = meta.originalMetadata.readonly;
-					param meta.originalMetadata.joincolumn = "";
+					meta[ "fullName" ]                             = meta.originalMetadata.fullname;
+					param meta.originalMetadata.mapping            = listLast( meta.originalMetadata.fullname, "." );
+					meta[ "mapping" ]                              = meta.originalMetadata.mapping;
+					param meta.originalMetadata.entityName         = listLast( meta.originalMetadata.name, "." );
+					meta[ "entityName" ]                           = meta.originalMetadata.entityName;
+					param meta.originalMetadata.table              = variables._str.plural( variables._str.snake( meta.entityName ) );
+					meta[ "table" ]                                = meta.originalMetadata.table;
+					param meta.originalMetadata.readonly           = false;
+					meta[ "readonly" ]                             = meta.originalMetadata.readonly;
+					param meta.originalMetadata.joincolumn         = "";
 					param meta.originalMetadata.discriminatorValue = "";
-					param meta.originalMetadata.extends    = "";
-					param meta.originalMetadata.functions  = [];
-					meta[ "hasParentEntity" ]              = !!len( meta.originalMetadata.joincolumn );
-					if( meta.hasParentEntity ){
-						
+					param meta.originalMetadata.extends            = "";
+					param meta.originalMetadata.functions          = [];
+					meta[ "hasParentEntity" ]                      = !!len( meta.originalMetadata.joincolumn );
+					if ( meta.hasParentEntity ) {
 						var reference = variables._wirebox.getInstance( meta.localMetadata.extends.fullName );
 
-						meta["parentEntity"] = {
-							"meta"      : reference.get_Meta(),
-							"key"       : reference.keyNames()[ 1 ],
+						meta[ "parentEntity" ] = {
+							"meta"       : reference.get_Meta(),
+							"key"        : reference.keyNames()[ 1 ],
 							"joincolumn" : meta.originalMetadata.joincolumn
 						};
 
-						if( len( meta.originalMetadata.discriminatorValue ) ){
-							try{
-								var parentMeta = getComponentMetadata( meta.parentEntity.meta.fullName );
-								meta.parentEntity[ "discriminatorValue" ] = meta.originalMetadata.discriminatorValue;
+						if ( len( meta.originalMetadata.discriminatorValue ) ) {
+							try {
+								var parentMeta                             = getComponentMetadata( meta.parentEntity.meta.fullName );
+								meta.parentEntity[ "discriminatorValue" ]  = meta.originalMetadata.discriminatorValue;
 								meta.parentEntity[ "discriminatorColumn" ] = parentMeta.discriminatorColumn;
-							} catch( any e ){
-								throw( 
-									type = "QuickChildInstantiationException", 
+							} catch ( any e ) {
+								throw(
+									type    = "QuickChildInstantiationException",
 									message = "Failed to instantiate child entity [#meta.fullName#]. This may be due to a configuration error in the parent/child relationships. The root cause was #e.message#",
-									detail = e.detail
+									detail  = e.detail
 								);
 							}
 						}
-			
 					}
 
 					var baseEntityFunctionNames = variables._cache.getOrSet( "quick-metadata:BaseEntity", function() {
@@ -3149,8 +3149,10 @@ component accessors="true" {
 
 					param meta.originalMetadata.properties = [];
 
-					meta[ "attributes" ] = generateAttributesFromProperties( meta.hasParentEntity ? meta.localMetadata.properties : meta.originalMetadata.properties );
-					if( structKeyExists( meta.localMetadata, "discriminatorColumn" ) ){
+					meta[ "attributes" ] = generateAttributesFromProperties(
+						meta.hasParentEntity ? meta.localMetadata.properties : meta.originalMetadata.properties
+					);
+					if ( structKeyExists( meta.localMetadata, "discriminatorColumn" ) ) {
 						meta.attributes[ meta.localMetaData.discriminatorColumn ] = paramAttribute( { "name" : meta.localMetaData.discriminatorColumn } );
 					}
 					arrayWrap( variables._key ).each( function( key ) {
@@ -3166,17 +3168,19 @@ component accessors="true" {
 			);
 		}
 
-		variables._fullName           = variables._meta.fullName;
-		variables._entityName         = variables._meta.entityName;
-		variables._table              = variables._meta.table;
-		variables._hasParentEntity    = variables._meta.hasParentEntity;
+		variables._fullName        = variables._meta.fullName;
+		variables._entityName      = variables._meta.entityName;
+		variables._table           = variables._meta.table;
+		variables._hasParentEntity = variables._meta.hasParentEntity;
 
-		if( variables._hasParentEntity ){
+		if ( variables._hasParentEntity ) {
 			variables._parentEntity = variables._meta.parentEntity;
-			
-			if( structKeyExists( variables._parentEntity, "discriminatorColumn" ) ){
-				variables[ "get" & variables._parentEntity.discriminatorColumn ] = function(){ 
-					return variables._data.keyExists( variables._parentEntity.discriminatorColumn ) ? variables._data[ variables._parentEntity.discriminatorColumn ] : javacast( "null", 0 );
+
+			if ( structKeyExists( variables._parentEntity, "discriminatorColumn" ) ) {
+				variables[ "get" & variables._parentEntity.discriminatorColumn ] = function() {
+					return variables._data.keyExists( variables._parentEntity.discriminatorColumn ) ? variables._data[
+						variables._parentEntity.discriminatorColumn
+					] : javacast( "null", 0 );
 				};
 			}
 
@@ -3262,7 +3266,7 @@ component accessors="true" {
 		return variables._attributes[ retrieveAliasForColumn( arguments.name ) ].virtual;
 	}
 
-	public boolean function isParentAttribute( required string column ){
+	public boolean function isParentAttribute( required string column ) {
 		return variables._attributes[ retrieveAliasForColumn( arguments.column ) ].isParentColumn;
 	}
 
@@ -3275,18 +3279,18 @@ component accessors="true" {
 	 * @return  An attribute struct with all the keys needed.
 	 */
 	private struct function paramAttribute( required struct attr ) {
-		param attr.column        = arguments.attr.name;
-		param attr.persistent    = true;
-		param attr.nullValue     = "";
-		param attr.convertToNull = true;
-		param attr.casts         = "";
-		param attr.readOnly      = false;
-		param attr.sqltype       = "";
-		param attr.insert        = true;
-		param attr.update        = true;
-		param attr.virtual       = false;
-		param attr.exclude       = false;
-		param attr.isParentColumn= false;
+		param attr.column         = arguments.attr.name;
+		param attr.persistent     = true;
+		param attr.nullValue      = "";
+		param attr.convertToNull  = true;
+		param attr.casts          = "";
+		param attr.readOnly       = false;
+		param attr.sqltype        = "";
+		param attr.insert         = true;
+		param attr.update         = true;
+		param attr.virtual        = false;
+		param attr.exclude        = false;
+		param attr.isParentColumn = false;
 		return arguments.attr;
 	}
 
@@ -3296,7 +3300,6 @@ component accessors="true" {
 	 * @attributes  The attributes to explode
 	 */
 	private any function explodeAttributesMetadata( required struct attributes ) {
-
 		for ( var alias in arguments.attributes ) {
 			var options                    = arguments.attributes[ alias ];
 			variables._attributes[ alias ] = options;
@@ -3305,29 +3308,34 @@ component accessors="true" {
 			}
 		}
 
-		if( variables._hasParentEntity ){
+		if ( variables._hasParentEntity ) {
 			explodeParentAttributes();
 		}
-		
+
 		return this;
 	}
 
 	/**
 	 * Appends parent attributes as first class attributes
-	**/
-	private function explodeParentAttributes(){
-
-		if( !variables._hasParentEntity ) return;
+	 **/
+	private function explodeParentAttributes() {
+		if ( !variables._hasParentEntity ) return;
 
 		variables._attributes[ variables._parentEntity.joincolumn ] = paramAttribute( { "name" : variables._parentEntity.joincolumn } );
 
-		variables._parentEntity.meta.attributes.keyArray().each( function( alias ){
-			variables._attributes[ alias ] = duplicate( variables._parentEntity.meta.attributes[ alias ] );
-			variables._attributes[ alias ].isParentColumn = true;
-		} );
+		variables._parentEntity.meta.attributes
+			.keyArray()
+			.each( function( alias ) {
+				variables._attributes[ alias ] = duplicate( variables._parentEntity.meta.attributes[ alias ] );
+				variables._attributes[ alias ].isParentColumn = true;
+			} );
 
-		if( structKeyExists( variables._parentEntity, "discriminatorColumn" ) ){
-			variables._attributes[ variables._parentEntity.discriminatorColumn ] = paramAttribute( { "name" : variables._parentEntity.discriminatorColumn, "column" : variables._parentEntity.discriminatorColumn, "isParentColumn" : true } );
+		if ( structKeyExists( variables._parentEntity, "discriminatorColumn" ) ) {
+			variables._attributes[ variables._parentEntity.discriminatorColumn ] = paramAttribute( {
+				"name"           : variables._parentEntity.discriminatorColumn,
+				"column"         : variables._parentEntity.discriminatorColumn,
+				"isParentColumn" : true
+			} );
 			assignAttribute( variables._parentEntity.discriminatorColumn, variables._parentEntity.discriminatorValue );
 		}
 	}
@@ -3610,7 +3618,6 @@ component accessors="true" {
 		any value,
 		boolean checkNullValues = true
 	) {
-
 		arguments.column = arguments.column;
 
 		// If that value is already a struct, pass it back unchanged.
@@ -3763,8 +3770,8 @@ component accessors="true" {
 	private boolean function canUpdateAttribute( required string name ) {
 		var alias = retrieveAliasForColumn( arguments.name );
 		return variables._attributes.keyExists( alias ) &&
-				variables._attributes[ alias ].update &&
-				!variables._attributes[ alias ].isParentColumn;
+		variables._attributes[ alias ].update &&
+		!variables._attributes[ alias ].isParentColumn;
 	}
 
 	/**
@@ -3777,7 +3784,7 @@ component accessors="true" {
 	private boolean function canInsertAttribute( required string name ) {
 		var alias = retrieveAliasForColumn( arguments.name );
 		return variables._attributes.keyExists( alias ) &&
-		variables._attributes[ alias ].insert && 
+		variables._attributes[ alias ].insert &&
 		!variables._attributes[ alias ].isParentColumn;
 	}
 

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -254,7 +254,7 @@ component accessors="true" {
 		param variables._loaded                   = false;
 		param variables._aliasPrefix              = "";
 		param variables._hasParentEntity          = false;
-		param variables._parentDefinition             = {};
+		param variables._parentDefinition         = {};
 		variables._asMemento                      = false;
 		variables._asMementoSettings              = {};
 		return this;
@@ -3114,7 +3114,7 @@ component accessors="true" {
 
 						if ( len( meta.originalMetadata.discriminatorValue ) ) {
 							try {
-								var parentMeta                             = getComponentMetadata( meta.parentDefinition.meta.fullName );
+								var parentMeta                                 = getComponentMetadata( meta.parentDefinition.meta.fullName );
 								meta.parentDefinition[ "discriminatorValue" ]  = meta.originalMetadata.discriminatorValue;
 								meta.parentDefinition[ "discriminatorColumn" ] = parentMeta.discriminatorColumn;
 							} catch ( any e ) {
@@ -3170,7 +3170,7 @@ component accessors="true" {
 
 		if ( variables._hasParentEntity ) {
 			variables._parentDefinition = variables._meta.parentDefinition;
-			variables._key          = variables._parentDefinition.joincolumn;
+			variables._key              = variables._parentDefinition.joincolumn;
 		}
 
 		param variables._queryOptions = {};
@@ -3305,27 +3305,27 @@ component accessors="true" {
     =       Subclass Inheritance      =
     =================================*/
 
-	public boolean function hasParentEntity(){
+	public boolean function hasParentEntity() {
 		return variables._hasParentEntity;
 	}
 
-	public boolean function isDiscriminatedChild(){
+	public boolean function isDiscriminatedChild() {
 		return hasParentEntity() && getParentDefinition().keyExists( "discriminatorValue" );
 	}
 
-	public boolean function isDiscriminatedParent(){
-		return variables._meta.keyExists( "discriminatorColumn" ) 
-				&& application.quickMeta.discriminators.keyExists( tableName() );
+	public boolean function isDiscriminatedParent() {
+		return variables._meta.keyExists( "discriminatorColumn" )
+		&& application.quickMeta.discriminators.keyExists( tableName() );
 	}
 
-	public function getParentDefinition(){
+	public function getParentDefinition() {
 		return hasParentEntity() ? variables._parentDefinition : javacast( "null", 0 );
 	}
 
 	/**
 	 * Appends parent attributes as first class attributes
 	 **/
-	 private function explodeParentAttributes() {
+	private function explodeParentAttributes() {
 		if ( !hasParentEntity() ) return;
 
 		var parentDefinition = getParentDefinition();
@@ -3335,7 +3335,7 @@ component accessors="true" {
 		parentDefinition.meta.attributes
 			.keyArray()
 			.each( function( alias ) {
-				// Note: bracket notation here on `attributes` as ACF 2016 will sometimes show a null for the dot notation key 
+				// Note: bracket notation here on `attributes` as ACF 2016 will sometimes show a null for the dot notation key
 				variables._attributes[ alias ] = duplicate( parentDefinition.meta[ "attributes" ][ alias ] );
 				variables._attributes[ alias ].isParentColumn = true;
 			} );

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -631,9 +631,7 @@ component accessors="true" {
 	 */
 	public any function hydrate( required struct attributes, boolean ignoreNonExistentAttributes = false ) {
 		guardAgainstMissingKeys( arguments.attributes );
-		return fill( argumentCollection = arguments )
-			.assignOriginalAttributes( arguments.attributes )
-			.markLoaded();
+		return fill( argumentCollection = arguments ).assignOriginalAttributes( arguments.attributes ).markLoaded();
 	}
 
 	/**
@@ -3175,7 +3173,7 @@ component accessors="true" {
 
 		if ( variables._hasParentEntity ) {
 			variables._parentEntity = variables._meta.parentEntity;
-			variables._key = variables._parentEntity.joincolumn;
+			variables._key          = variables._parentEntity.joincolumn;
 		}
 
 		param variables._queryOptions = {};

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1194,10 +1194,7 @@ component accessors="true" {
 			&&
 			isDiscriminatedParent()
 			&&
-			structKeyExists( 
-				getDiscriminations(),
-				data[ variables._meta.localMetadata.discriminatorColumn ]
-			)
+			structKeyExists( getDiscriminations(), data[ variables._meta.localMetadata.discriminatorColumn ] )
 		) {
 			var childClass = variables._wirebox.getInstance(
 				getDiscriminations()[ data[ variables._meta.localMetadata.discriminatorColumn ] ].mapping

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -234,7 +234,6 @@ component accessors="true" {
 		variables._loadShallow = arguments.shallow;
 		assignDefaultProperties();
 		variables._meta         = arguments.meta;
-		variables._loadChildren = true;
 		return this;
 	}
 
@@ -263,6 +262,7 @@ component accessors="true" {
 		param variables._hasParentEntity          = false;
 		param variables._parentDefinition         = {};
 		param variables._discriminators           = [];
+		param variables._loadChildren 			  = true;
 		variables._asMemento                      = false;
 		variables._asMementoSettings              = {};
 		return this;

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -722,7 +722,7 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 						getEntity().qualifyColumn( getEntity().keyNames()[ 1 ] ),
 						"=",
 						data.joincolumn,
-						"right outer"
+						"left outer"
 					);
 				} );
 		}

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -673,7 +673,9 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 			return arguments.column;
 		}
 
-		return listLast( getFrom(), " " ) & "." & getEntity().retrieveColumnForAlias( arguments.column );
+		return getEntity().isParentAttribute( arguments.column )
+				? getEntity().retrieveColumnForAlias( arguments.column )
+				: listLast( getFrom(), " " ) & "." & getEntity().retrieveColumnForAlias( arguments.column );
 	}
 
 	/**

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -674,7 +674,7 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 		}
 
 		return getEntity().isParentAttribute( arguments.column )
-		 ? getEntity().retrieveColumnForAlias( arguments.column )
+		 ? getEntity().get_Meta().parentEntity.meta.table & "." & getEntity().retrieveColumnForAlias( arguments.column )
 		 : listLast( getFrom(), " " ) & "." & getEntity().retrieveColumnForAlias( arguments.column );
 	}
 

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -701,7 +701,7 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 		return builder;
 	}
 
-	function applyInheritanceJoins( required QuickBuilder builder ){
+	function applyInheritanceJoins( required QuickBuilder builder ) {
 		var entity = getEntity();
 		// Apply and append any inheritance joins/colu
 		if ( entity.hasParentEntity() ) {
@@ -711,9 +711,7 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 				parentDefinition.meta.table & "." & parentDefinition.key,
 				entity.qualifyColumn( entity.keyNames()[ 1 ] )
 			);
-		} else if (
-			entity.isDiscriminatedParent()
-		) {
+		} else if ( entity.isDiscriminatedParent() ) {
 			var discriminators = application.quickMeta.discriminators[ entity.tableName() ];
 			discriminators.each( function( discriminator, data ) {
 				columns.append(

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -674,8 +674,8 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 		}
 
 		return getEntity().isParentAttribute( arguments.column )
-				? getEntity().retrieveColumnForAlias( arguments.column )
-				: listLast( getFrom(), " " ) & "." & getEntity().retrieveColumnForAlias( arguments.column );
+		 ? getEntity().retrieveColumnForAlias( arguments.column )
+		 : listLast( getFrom(), " " ) & "." & getEntity().retrieveColumnForAlias( arguments.column );
 	}
 
 	/**

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -20,7 +20,10 @@ component {
     this.datasource = "quick";
 
     function onRequestStart() {
+        setting requestTimeout="180";
         structDelete( application, "cbController" );
+        structDelete( application, "wirebox" );
+        URL.coverageEnabled = false;
         setUpDatabase();
     }
 
@@ -252,6 +255,7 @@ component {
               `body` text NOT NULL,
               `commentable_id` int(11) NOT NULL,
               `commentable_type` varchar(50) NOT NULL,
+              `designation` varchar(50) NOT NULL default 'public',
               `user_id` int(11) NOT NULL,
               `created_date` timestamp(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
               `modified_date` timestamp(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -267,6 +271,25 @@ component {
         queryExecute( "
             INSERT INTO `comments` (`id`, `body`, `commentable_id`, `commentable_type`, `user_id`, `created_date`, `modified_date`) VALUES (3, 'What a great video! So fun!', 1245, 'Video', 1, '2017-07-02 04:14:22', '2017-07-02 04:14:22')
         " );
+
+        queryExecute( "
+            CREATE TABLE `internalComments` (
+                `FK_comment` int(11) NOT NULL,
+                `reason`  text,
+                FOREIGN KEY (FK_comment)
+                    REFERENCES comments(id)
+                    ON UPDATE CASCADE ON DELETE CASCADE
+            )
+        " );
+
+        queryExecute( "
+            INSERT INTO `comments` (`id`, `body`, `commentable_id`, `designation`, `commentable_type`, `user_id`, `created_date`, `modified_date`) VALUES (4, 'This is an internal comment. It is very, very private.', 1245, 'internal', 'Post', 1, '2017-07-02 04:14:22', '2017-07-02 04:14:22' )
+        " );
+
+        queryExecute( "
+            INSERT INTO `internalComments` ( `FK_comment`, `reason` ) VALUES ( 4, 'Utra private, ya know?' );
+        ");
+
         queryExecute( "
             CREATE TABLE `tags` (
               `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -327,6 +350,25 @@ component {
         queryExecute( "
             INSERT INTO `songs` (`id`, `title`, `download_url`, `created_date`, `modified_date`) VALUES (2, 'Open Arms', 'https://open.spotify.com/track/1m2INxep6LfNa25OEg5jZl', '2017-07-28 02:07:00', '2017-07-28 02:07:00')
         " );
+
+        queryExecute( "
+            CREATE TABLE `jingles` (
+                `FK_song` int(11) NOT NULL,
+                `catchiness`  int(11),
+                FOREIGN KEY (FK_song)
+                    REFERENCES songs(id)
+                    ON UPDATE CASCADE ON DELETE CASCADE
+            )
+        " );
+
+        queryExecute( "
+            INSERT INTO `songs` (`id`, `title`, `download_url`, `created_date`, `modified_date`) VALUES (3, 'I Wish I Was an Oscar Mayer Weiner', 'https://open.spotify.com/track/2wyg2ln6p4gEkdqM2mueLn?si=kWBpdUz1TLymdmTro-xjtw', '2017-07-28 02:07:00', '2017-07-28 02:07:00')
+        " );
+
+        queryExecute( "
+            INSERT INTO `jingles` ( `FK_song`, `catchiness` ) VALUES ( 3, 3 );
+        ");
+
         queryExecute( "
             CREATE TABLE `phone_numbers` (
               `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/tests/resources/ModuleIntegrationSpec.cfc
+++ b/tests/resources/ModuleIntegrationSpec.cfc
@@ -5,9 +5,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
         getController().getModuleService()
             .registerAndActivateModule( "quick", "testingModuleRoot" );
-        
-        getController().getInterceptorService()
-            .processState( "afterAspectsLoad" );
+            
     }
 
     /**

--- a/tests/resources/ModuleIntegrationSpec.cfc
+++ b/tests/resources/ModuleIntegrationSpec.cfc
@@ -5,6 +5,9 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
         getController().getModuleService()
             .registerAndActivateModule( "quick", "testingModuleRoot" );
+        
+        getController().getInterceptorService()
+            .processState( "afterAspectsLoad" );
     }
 
     /**

--- a/tests/resources/app/models/Comment.cfc
+++ b/tests/resources/app/models/Comment.cfc
@@ -12,6 +12,10 @@ component
     property name="createdDate" column="created_date";
     property name="modifiedDate" column="modified_date";
 
+    variables._discriminators = [
+        "InternalComment"
+    ];
+
     function commentable() {
         return polymorphicBelongsTo( "commentable" );
     }

--- a/tests/resources/app/models/Comment.cfc
+++ b/tests/resources/app/models/Comment.cfc
@@ -1,4 +1,8 @@
-component extends="quick.models.BaseEntity" accessors="true" {
+component 
+    extends="quick.models.BaseEntity"
+    discriminatorColumn="designation" 
+    accessors="true" 
+{
 
     property name="id";
     property name="body";

--- a/tests/resources/app/models/Country.cfc
+++ b/tests/resources/app/models/Country.cfc
@@ -22,11 +22,11 @@ component extends="quick.models.BaseEntity" accessors="true" {
     }
 
     function comments() {
-        return hasManyThrough( [ "users", "posts", "comments" ] );
+        return hasManyThrough( [ "users", "posts", "comments" ] ).where( 'designation', 'public' );
     }
 
     function commentsUsingHasManyThrough() {
-        return hasManyThrough( [ "posts", "comments" ] );
+        return hasManyThrough( [ "posts", "comments" ] ).where( 'designation', 'public' );
     }
 
     function roles() {

--- a/tests/resources/app/models/InternalComment.cfc
+++ b/tests/resources/app/models/InternalComment.cfc
@@ -1,0 +1,9 @@
+component 
+    accessors="true"
+    extends="Comment"
+    table="internalComments"
+    joincolumn="FK_comment"
+    discriminatorValue="internal"
+{
+    property name="reason";
+}

--- a/tests/resources/app/models/Jingle.cfc
+++ b/tests/resources/app/models/Jingle.cfc
@@ -1,0 +1,8 @@
+component 
+    accessors="true"
+    extends="Song"
+    table="jingles"
+    joincolumn="FK_song"
+{
+    property name="catchiness";
+}

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -42,6 +42,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
 				expect( newJingle.getId() ).notToBeNull();
 				expect( newJingle.isLoaded() ).toBeTrue();
+
+				var jingle = getInstance( "Jingle" ).findOrFail( newJingle.getId() );
+
+				expect( jingle.getMemento() ).toBe( newJingle.getMemento() );
+
+				
+
 			} );
 
 			it( "can update a child entity", function() {

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -254,13 +254,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					.save();
 
 				var parentRetrieval = getInstance( "Comment" ).find( newComment.getId() );
-				expect( isInstanceOf( parentRetrieval, "InternalComment" ) ).toBeTrue();
+				expect( parentRetrieval ).toBeInstanceOf( "InternalComment" );
 			} );
 
 			it( "Will return an array of child classes when fetching multiple results from the parent class", function() {
 				var internalComments = getInstance( "Comment" ).where( "designation", "internal" ).get();
 				internalComments.each( function( comment ) {
-					expect( isInstanceOf( comment, "InternalComment" ) ).toBeTrue();
+					expect( comment, "InternalComment" ).toBeInstanceOf( "InternalComment" );
 				} );
 			} );
 		} );

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -46,9 +46,6 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				var jingle = getInstance( "Jingle" ).findOrFail( newJingle.getId() );
 
 				expect( jingle.getMemento() ).toBe( newJingle.getMemento() );
-
-				
-
 			} );
 
 			it( "can update a child entity", function() {

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -1,0 +1,297 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "Child Class Spec", function() {
+			it( "merges parent table and child table attributes int to entity", function() {
+                var jingle = getInstance( "Jingle" ).first();
+
+                expect( jingle.isLoaded() ).toBeTrue();
+
+                var memento = jingle.getMemento();
+
+                expect( memento )
+                    .toHaveKey( "id" )
+                    .toHaveKey( "title" )
+                    .toHaveKey( "catchiness" )
+                    .toHaveKey( "createdDate" )
+                    .toHaveKey( "modifiedDate" );
+
+                expect( jingle.getId() ).notToBeNull();
+                expect( jingle.isLoaded() ).toBeTrue();
+
+            } );
+            
+            it( "can create a child entity and populate the parent and child tables", function(){
+                var newJingle = getInstance( "Jingle" ).fill(
+                    {
+                        "title" : "Give me a Break",
+                        "downloadURL" : "https://www.youtube.com/watch?v=0nkcVz1mad0",
+                        "createdDate" : now(),
+                        "modifiedDate" : now(),
+                        "catchiness" : 2
+                    }
+                ).save();
+
+                var memento = newJingle.getMemento();
+
+                expect( memento )
+                    .toHaveKey( "id" )
+                    .toHaveKey( "title" )
+                    .toHaveKey( "catchiness" )
+                    .toHaveKey( "createdDate" )
+                    .toHaveKey( "modifiedDate" );
+
+                expect( newJingle.getId() ).notToBeNull();
+                expect( newJingle.isLoaded() ).toBeTrue();
+                
+            } );
+
+            it( "can update a child entity", function(){
+
+                var newJingle = getInstance( "Jingle" ).fill(
+                    {
+                        "title" : "Give me a Break",
+                        "downloadURL" : "https://www.youtube.com/watch?v=0nkcVz1mad0",
+                        "createdDate" : now(),
+                        "modifiedDate" : now(),
+                        "catchiness" : 2
+                    }
+                ).save();
+
+                transactionSetSavePoint( 'jingle-saved' );
+
+                var jingle = getInstance( "Jingle" ).findOrFail( newJingle.getId() );
+
+                jingle.setTitle( "Give me a Break ( The Kit Kat Bar Song )" );
+                jingle.setCatchiness( 1 );
+
+                jingle.save();
+                
+                jingle = getInstance( "Jingle" ).findOrFail( jingle.getId() );
+
+                var memento = jingle.getMemento();
+
+                expect( memento )
+                    .toHaveKey( "id" )
+                    .toHaveKey( "title" )
+                    .toHaveKey( "catchiness" )
+                    .toHaveKey( "createdDate" )
+                    .toHaveKey( "modifiedDate" );
+
+                expect( jingle.getTitle() ).toBe( "Give me a Break ( The Kit Kat Bar Song )" );
+                expect( jingle.getCatchiness() ).toBe( 1 );
+
+            } );
+
+            it( "can delete a child entity", function(){
+                var newJingle = getInstance( "Jingle" ).fill(
+                    {
+                        "title" : "Give me a Break",
+                        "downloadURL" : "https://www.youtube.com/watch?v=0nkcVz1mad0",
+                        "createdDate" : now(),
+                        "modifiedDate" : now(),
+                        "catchiness" : 2
+                    }
+                ).save();
+
+                transactionSetSavePoint( 'jingle-saved' );
+
+                getInstance( "Jingle" ).findOrFail( newJingle.getId() ).delete();
+
+                transactionSetSavePoint( 'jingle-deleted' );
+
+                expect( isNull( getInstance( "Jingle" ).find( newJingle.getId() ) ) ).toBeTrue();
+
+            });
+
+		} );
+        
+        describe( "Discriminated Class Spec", function(){
+            it( "Will fetch a discriminated entity and merge relationships", function(){
+                var comment = getInstance( "InternalComment" ).first();
+
+                expect( comment.isLoaded() ).toBeTrue();
+
+                var memento = comment.getMemento();
+
+                expect( memento )
+                    .toHaveKey( "id" )
+                    .toHaveKey( "body" );
+
+                expect( comment.getId() ).notToBeNull();
+                expect( comment.getDesignation() ).toBe( memento.designation );
+                expect( comment.isLoaded() ).toBeTrue();
+            } );
+
+            it( "Can query on parent values through the child", function(){
+                var newComment = getInstance( "InternalComment" ).fill(
+                    {
+                        "reason" : "I like to keep things private",
+                        "body" : "Lorem ipsum",
+                        "commentableId" : 1345,
+                        "commentableType" : 'Post',
+                        "userId" : getInstance( "User" ).first().getId(),
+                        "createdDate" : now(),
+                        "modifiedDate" : now()
+                    }
+                ).save();
+
+                var internals = getInstance( "InternalComment" ).where( 'body', 'Lorem ipsum' ).get();
+
+                expect( internals )
+                    .toBeArray()
+                    .toHaveLength( 1 );
+
+
+
+            });
+
+            it( "Can query on child entity values", function(){
+                var newComment = getInstance( "InternalComment" ).fill(
+                    {
+                        "reason" : "I like to keep things private",
+                        "body" : "Lorem ipsum",
+                        "commentableId" : 1345,
+                        "commentableType" : 'Post',
+                        "userId" : getInstance( "User" ).first().getId(),
+                        "createdDate" : now(),
+                        "modifiedDate" : now()
+                    }
+                ).save();
+
+                var internals = getInstance( "InternalComment" ).where( 'reason', "I like to keep things private" ).get();
+
+                expect( internals )
+                    .toBeArray()
+                    .toHaveLength( 1 );
+
+
+
+            });
+
+            it( "can create a discriminated entity and populate the parent and child tables", function(){
+                var newComment = getInstance( "InternalComment" ).fill(
+                    {
+                        "reason" : "I like to keep things private",
+                        "body" : "Lorem ipsum",
+                        "commentableId" : 1345,
+                        "commentableType" : 'Post',
+                        "userId" : getInstance( "User" ).first().getId(),
+                        "createdDate" : now(),
+                        "modifiedDate" : now()
+                    }
+                ).save();
+
+                transactionSetSavePoint( 'comment-saved' );
+
+                var memento = newComment.getMemento();
+
+                expect( memento )
+                    .toHaveKey( "id" )
+                    .toHaveKey( "body" )
+                    .toHaveKey( "reason" )
+                    .toHaveKey( "commentableId" )
+                    .toHaveKey( "commentableType" )
+                    .toHaveKey( "createdDate" )
+                    .toHaveKey( "modifiedDate" );
+
+                expect( newComment.getId() ).notToBeNull();
+                expect( newComment.isLoaded() ).toBeTrue();
+                
+            } );
+
+            it( "can update a child entity", function(){
+
+                var newComment = getInstance( "InternalComment" ).fill(
+                    {
+                        "reason" : "I like to keep things private",
+                        "body" : "Lorem ipsum",
+                        "commentableId" : 1345,
+                        "commentableType" : 'Post',
+                        "userId" : getInstance( "User" ).first().getId(),
+                        "createdDate" : now(),
+                        "modifiedDate" : now()
+                    }
+                ).save();
+
+                transactionSetSavePoint( 'comment-saved' );
+
+                var comment = getInstance( "InternalComment" ).findOrFail( newComment.getId() );
+
+                comment.setBody( "Lorem ipsum dolor" );
+                comment.setReason( "This is nonsense and I don't want anyone to see it." );
+
+                comment.save();
+                
+                comment = getInstance( "InternalComment" ).findOrFail( comment.getId() );
+
+                var memento = comment.getMemento();
+
+                expect( memento )
+                    .toHaveKey( "id" )
+                    .toHaveKey( "body" )
+                    .toHaveKey( "reason" )
+                    .toHaveKey( "commentableId" )
+                    .toHaveKey( "commentableType" )
+                    .toHaveKey( "createdDate" )
+                    .toHaveKey( "modifiedDate" );
+
+                expect( comment.getId() ).notToBeNull();
+                expect( comment.isLoaded() ).toBeTrue();
+
+                expect( comment.getBody() ).toBe( "Lorem ipsum dolor" );
+                expect( comment.getReason() ).toBe( "This is nonsense and I don't want anyone to see it." );
+
+            } );
+
+            it( "can delete a discriminated entity", function(){
+                var newComment = getInstance( "InternalComment" ).fill(
+                    {
+                        "reason" : "I like to keep things private",
+                        "body" : "Lorem ipsum",
+                        "commentableId" : 1345,
+                        "commentableType" : 'Post',
+                        "userId" : getInstance( "User" ).first().getId(),
+                        "createdDate" : now(),
+                        "modifiedDate" : now()
+                    }
+                ).save();
+
+                transactionSetSavePoint( 'comment-saved' );
+
+                getInstance( "InternalComment" ).findOrFail( newComment.getId() ).delete();
+
+                transactionSetSavePoint( 'comment-deleted' );
+
+                expect( isNull( getInstance( "InternalComment" ).find( newComment.getId() ) ) ).toBeTrue();
+
+            });
+
+            it( "Will return a child entity when retrieving a single entity from the parent", function(){
+                var newComment = getInstance( "InternalComment" ).fill(
+                    {
+                        "reason" : "I like to keep things private",
+                        "body" : "Lorem ipsum",
+                        "commentableId" : 1345,
+                        "commentableType" : 'Post',
+                        "userId" : getInstance( "User" ).first().getId(),
+                        "createdDate" : now(),
+                        "modifiedDate" : now()
+                    }
+                ).save();
+
+                var parentRetrieval = getInstance( "Comment" ).find( newComment.getId() );
+                expect( isInstanceOf( parentRetrieval, "InternalComment" ) ).toBeTrue();
+            });
+
+            it( "Will return an array of child classes when fetching multiple results from the parent class", function(){
+                var internalComments = getInstance( "Comment" ).where( 'designation', 'internal' ).get();
+                internalComments.each( function( comment ){
+                    expect( isInstanceOf( comment, "InternalComment" ) ).toBeTrue();
+                } );
+            } );
+            
+        } );
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -62,8 +62,6 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					} )
 					.save();
 
-				transactionSetSavepoint( "jingle-saved" );
-
 				var jingle = getInstance( "Jingle" ).findOrFail( newJingle.getId() );
 
 				jingle.setTitle( "Give me a Break ( The Kit Kat Bar Song )" );
@@ -97,11 +95,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					} )
 					.save();
 
-				transactionSetSavepoint( "jingle-saved" );
-
 				getInstance( "Jingle" ).findOrFail( newJingle.getId() ).delete();
-
-				transactionSetSavepoint( "jingle-deleted" );
 
 				expect( isNull( getInstance( "Jingle" ).find( newJingle.getId() ) ) ).toBeTrue();
 			} );
@@ -173,8 +167,6 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					} )
 					.save();
 
-				transactionSetSavepoint( "comment-saved" );
-
 				var memento = newComment.getMemento();
 
 				expect( memento )
@@ -202,8 +194,6 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 						"modifiedDate"    : now()
 					} )
 					.save();
-
-				transactionSetSavepoint( "comment-saved" );
 
 				var comment = getInstance( "InternalComment" ).findOrFail( newComment.getId() );
 
@@ -245,11 +235,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					} )
 					.save();
 
-				transactionSetSavepoint( "comment-saved" );
-
 				getInstance( "InternalComment" ).findOrFail( newComment.getId() ).delete();
-
-				transactionSetSavepoint( "comment-deleted" );
 
 				expect( isNull( getInstance( "InternalComment" ).find( newComment.getId() ) ) ).toBeTrue();
 			} );

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -3,295 +3,274 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 	function run() {
 		describe( "Child Class Spec", function() {
 			it( "merges parent table and child table attributes int to entity", function() {
-                var jingle = getInstance( "Jingle" ).first();
+				var jingle = getInstance( "Jingle" ).first();
 
-                expect( jingle.isLoaded() ).toBeTrue();
+				expect( jingle.isLoaded() ).toBeTrue();
 
-                var memento = jingle.getMemento();
+				var memento = jingle.getMemento();
 
-                expect( memento )
-                    .toHaveKey( "id" )
-                    .toHaveKey( "title" )
-                    .toHaveKey( "catchiness" )
-                    .toHaveKey( "createdDate" )
-                    .toHaveKey( "modifiedDate" );
+				expect( memento )
+					.toHaveKey( "id" )
+					.toHaveKey( "title" )
+					.toHaveKey( "catchiness" )
+					.toHaveKey( "createdDate" )
+					.toHaveKey( "modifiedDate" );
 
-                expect( jingle.getId() ).notToBeNull();
-                expect( jingle.isLoaded() ).toBeTrue();
+				expect( jingle.getId() ).notToBeNull();
+				expect( jingle.isLoaded() ).toBeTrue();
+			} );
 
-            } );
-            
-            it( "can create a child entity and populate the parent and child tables", function(){
-                var newJingle = getInstance( "Jingle" ).fill(
-                    {
-                        "title" : "Give me a Break",
-                        "downloadURL" : "https://www.youtube.com/watch?v=0nkcVz1mad0",
-                        "createdDate" : now(),
-                        "modifiedDate" : now(),
-                        "catchiness" : 2
-                    }
-                ).save();
+			it( "can create a child entity and populate the parent and child tables", function() {
+				var newJingle = getInstance( "Jingle" )
+					.fill( {
+						"title"        : "Give me a Break",
+						"downloadURL"  : "https://www.youtube.com/watch?v=0nkcVz1mad0",
+						"createdDate"  : now(),
+						"modifiedDate" : now(),
+						"catchiness"   : 2
+					} )
+					.save();
 
-                var memento = newJingle.getMemento();
+				var memento = newJingle.getMemento();
 
-                expect( memento )
-                    .toHaveKey( "id" )
-                    .toHaveKey( "title" )
-                    .toHaveKey( "catchiness" )
-                    .toHaveKey( "createdDate" )
-                    .toHaveKey( "modifiedDate" );
+				expect( memento )
+					.toHaveKey( "id" )
+					.toHaveKey( "title" )
+					.toHaveKey( "catchiness" )
+					.toHaveKey( "createdDate" )
+					.toHaveKey( "modifiedDate" );
 
-                expect( newJingle.getId() ).notToBeNull();
-                expect( newJingle.isLoaded() ).toBeTrue();
-                
-            } );
+				expect( newJingle.getId() ).notToBeNull();
+				expect( newJingle.isLoaded() ).toBeTrue();
+			} );
 
-            it( "can update a child entity", function(){
+			it( "can update a child entity", function() {
+				var newJingle = getInstance( "Jingle" )
+					.fill( {
+						"title"        : "Give me a Break",
+						"downloadURL"  : "https://www.youtube.com/watch?v=0nkcVz1mad0",
+						"createdDate"  : now(),
+						"modifiedDate" : now(),
+						"catchiness"   : 2
+					} )
+					.save();
 
-                var newJingle = getInstance( "Jingle" ).fill(
-                    {
-                        "title" : "Give me a Break",
-                        "downloadURL" : "https://www.youtube.com/watch?v=0nkcVz1mad0",
-                        "createdDate" : now(),
-                        "modifiedDate" : now(),
-                        "catchiness" : 2
-                    }
-                ).save();
+				transactionSetSavepoint( "jingle-saved" );
 
-                transactionSetSavePoint( 'jingle-saved' );
+				var jingle = getInstance( "Jingle" ).findOrFail( newJingle.getId() );
 
-                var jingle = getInstance( "Jingle" ).findOrFail( newJingle.getId() );
+				jingle.setTitle( "Give me a Break ( The Kit Kat Bar Song )" );
+				jingle.setCatchiness( 1 );
 
-                jingle.setTitle( "Give me a Break ( The Kit Kat Bar Song )" );
-                jingle.setCatchiness( 1 );
+				jingle.save();
 
-                jingle.save();
-                
-                jingle = getInstance( "Jingle" ).findOrFail( jingle.getId() );
+				jingle = getInstance( "Jingle" ).findOrFail( jingle.getId() );
 
-                var memento = jingle.getMemento();
+				var memento = jingle.getMemento();
 
-                expect( memento )
-                    .toHaveKey( "id" )
-                    .toHaveKey( "title" )
-                    .toHaveKey( "catchiness" )
-                    .toHaveKey( "createdDate" )
-                    .toHaveKey( "modifiedDate" );
+				expect( memento )
+					.toHaveKey( "id" )
+					.toHaveKey( "title" )
+					.toHaveKey( "catchiness" )
+					.toHaveKey( "createdDate" )
+					.toHaveKey( "modifiedDate" );
 
-                expect( jingle.getTitle() ).toBe( "Give me a Break ( The Kit Kat Bar Song )" );
-                expect( jingle.getCatchiness() ).toBe( 1 );
+				expect( jingle.getTitle() ).toBe( "Give me a Break ( The Kit Kat Bar Song )" );
+				expect( jingle.getCatchiness() ).toBe( 1 );
+			} );
 
-            } );
+			it( "can delete a child entity", function() {
+				var newJingle = getInstance( "Jingle" )
+					.fill( {
+						"title"        : "Give me a Break",
+						"downloadURL"  : "https://www.youtube.com/watch?v=0nkcVz1mad0",
+						"createdDate"  : now(),
+						"modifiedDate" : now(),
+						"catchiness"   : 2
+					} )
+					.save();
 
-            it( "can delete a child entity", function(){
-                var newJingle = getInstance( "Jingle" ).fill(
-                    {
-                        "title" : "Give me a Break",
-                        "downloadURL" : "https://www.youtube.com/watch?v=0nkcVz1mad0",
-                        "createdDate" : now(),
-                        "modifiedDate" : now(),
-                        "catchiness" : 2
-                    }
-                ).save();
+				transactionSetSavepoint( "jingle-saved" );
 
-                transactionSetSavePoint( 'jingle-saved' );
+				getInstance( "Jingle" ).findOrFail( newJingle.getId() ).delete();
 
-                getInstance( "Jingle" ).findOrFail( newJingle.getId() ).delete();
+				transactionSetSavepoint( "jingle-deleted" );
 
-                transactionSetSavePoint( 'jingle-deleted' );
-
-                expect( isNull( getInstance( "Jingle" ).find( newJingle.getId() ) ) ).toBeTrue();
-
-            });
-
+				expect( isNull( getInstance( "Jingle" ).find( newJingle.getId() ) ) ).toBeTrue();
+			} );
 		} );
-        
-        describe( "Discriminated Class Spec", function(){
-            it( "Will fetch a discriminated entity and merge relationships", function(){
-                var comment = getInstance( "InternalComment" ).first();
 
-                expect( comment.isLoaded() ).toBeTrue();
+		describe( "Discriminated Class Spec", function() {
+			it( "Will fetch a discriminated entity and merge relationships", function() {
+				var comment = getInstance( "InternalComment" ).first();
 
-                var memento = comment.getMemento();
+				expect( comment.isLoaded() ).toBeTrue();
 
-                expect( memento )
-                    .toHaveKey( "id" )
-                    .toHaveKey( "body" );
+				var memento = comment.getMemento();
 
-                expect( comment.getId() ).notToBeNull();
-                expect( comment.getDesignation() ).toBe( memento.designation );
-                expect( comment.isLoaded() ).toBeTrue();
-            } );
+				expect( memento ).toHaveKey( "id" ).toHaveKey( "body" );
 
-            it( "Can query on parent values through the child", function(){
-                var newComment = getInstance( "InternalComment" ).fill(
-                    {
-                        "reason" : "I like to keep things private",
-                        "body" : "Lorem ipsum",
-                        "commentableId" : 1345,
-                        "commentableType" : 'Post',
-                        "userId" : getInstance( "User" ).first().getId(),
-                        "createdDate" : now(),
-                        "modifiedDate" : now()
-                    }
-                ).save();
+				expect( comment.getId() ).notToBeNull();
+				expect( comment.getDesignation() ).toBe( memento.designation );
+				expect( comment.isLoaded() ).toBeTrue();
+			} );
 
-                var internals = getInstance( "InternalComment" ).where( 'body', 'Lorem ipsum' ).get();
+			it( "Can query on parent values through the child", function() {
+				var newComment = getInstance( "InternalComment" )
+					.fill( {
+						"reason"          : "I like to keep things private",
+						"body"            : "Lorem ipsum",
+						"commentableId"   : 1345,
+						"commentableType" : "Post",
+						"userId"          : getInstance( "User" ).first().getId(),
+						"createdDate"     : now(),
+						"modifiedDate"    : now()
+					} )
+					.save();
 
-                expect( internals )
-                    .toBeArray()
-                    .toHaveLength( 1 );
+				var internals = getInstance( "InternalComment" ).where( "body", "Lorem ipsum" ).get();
 
+				expect( internals ).toBeArray().toHaveLength( 1 );
+			} );
 
+			it( "Can query on child entity values", function() {
+				var newComment = getInstance( "InternalComment" )
+					.fill( {
+						"reason"          : "I like to keep things private",
+						"body"            : "Lorem ipsum",
+						"commentableId"   : 1345,
+						"commentableType" : "Post",
+						"userId"          : getInstance( "User" ).first().getId(),
+						"createdDate"     : now(),
+						"modifiedDate"    : now()
+					} )
+					.save();
 
-            });
+				var internals = getInstance( "InternalComment" )
+					.where( "reason", "I like to keep things private" )
+					.get();
 
-            it( "Can query on child entity values", function(){
-                var newComment = getInstance( "InternalComment" ).fill(
-                    {
-                        "reason" : "I like to keep things private",
-                        "body" : "Lorem ipsum",
-                        "commentableId" : 1345,
-                        "commentableType" : 'Post',
-                        "userId" : getInstance( "User" ).first().getId(),
-                        "createdDate" : now(),
-                        "modifiedDate" : now()
-                    }
-                ).save();
+				expect( internals ).toBeArray().toHaveLength( 1 );
+			} );
 
-                var internals = getInstance( "InternalComment" ).where( 'reason', "I like to keep things private" ).get();
+			it( "can create a discriminated entity and populate the parent and child tables", function() {
+				var newComment = getInstance( "InternalComment" )
+					.fill( {
+						"reason"          : "I like to keep things private",
+						"body"            : "Lorem ipsum",
+						"commentableId"   : 1345,
+						"commentableType" : "Post",
+						"userId"          : getInstance( "User" ).first().getId(),
+						"createdDate"     : now(),
+						"modifiedDate"    : now()
+					} )
+					.save();
 
-                expect( internals )
-                    .toBeArray()
-                    .toHaveLength( 1 );
+				transactionSetSavepoint( "comment-saved" );
 
+				var memento = newComment.getMemento();
 
+				expect( memento )
+					.toHaveKey( "id" )
+					.toHaveKey( "body" )
+					.toHaveKey( "reason" )
+					.toHaveKey( "commentableId" )
+					.toHaveKey( "commentableType" )
+					.toHaveKey( "createdDate" )
+					.toHaveKey( "modifiedDate" );
 
-            });
+				expect( newComment.getId() ).notToBeNull();
+				expect( newComment.isLoaded() ).toBeTrue();
+			} );
 
-            it( "can create a discriminated entity and populate the parent and child tables", function(){
-                var newComment = getInstance( "InternalComment" ).fill(
-                    {
-                        "reason" : "I like to keep things private",
-                        "body" : "Lorem ipsum",
-                        "commentableId" : 1345,
-                        "commentableType" : 'Post',
-                        "userId" : getInstance( "User" ).first().getId(),
-                        "createdDate" : now(),
-                        "modifiedDate" : now()
-                    }
-                ).save();
+			it( "can update a child entity", function() {
+				var newComment = getInstance( "InternalComment" )
+					.fill( {
+						"reason"          : "I like to keep things private",
+						"body"            : "Lorem ipsum",
+						"commentableId"   : 1345,
+						"commentableType" : "Post",
+						"userId"          : getInstance( "User" ).first().getId(),
+						"createdDate"     : now(),
+						"modifiedDate"    : now()
+					} )
+					.save();
 
-                transactionSetSavePoint( 'comment-saved' );
+				transactionSetSavepoint( "comment-saved" );
 
-                var memento = newComment.getMemento();
+				var comment = getInstance( "InternalComment" ).findOrFail( newComment.getId() );
 
-                expect( memento )
-                    .toHaveKey( "id" )
-                    .toHaveKey( "body" )
-                    .toHaveKey( "reason" )
-                    .toHaveKey( "commentableId" )
-                    .toHaveKey( "commentableType" )
-                    .toHaveKey( "createdDate" )
-                    .toHaveKey( "modifiedDate" );
+				comment.setBody( "Lorem ipsum dolor" );
+				comment.setReason( "This is nonsense and I don't want anyone to see it." );
 
-                expect( newComment.getId() ).notToBeNull();
-                expect( newComment.isLoaded() ).toBeTrue();
-                
-            } );
+				comment.save();
 
-            it( "can update a child entity", function(){
+				comment = getInstance( "InternalComment" ).findOrFail( comment.getId() );
 
-                var newComment = getInstance( "InternalComment" ).fill(
-                    {
-                        "reason" : "I like to keep things private",
-                        "body" : "Lorem ipsum",
-                        "commentableId" : 1345,
-                        "commentableType" : 'Post',
-                        "userId" : getInstance( "User" ).first().getId(),
-                        "createdDate" : now(),
-                        "modifiedDate" : now()
-                    }
-                ).save();
+				var memento = comment.getMemento();
 
-                transactionSetSavePoint( 'comment-saved' );
+				expect( memento )
+					.toHaveKey( "id" )
+					.toHaveKey( "body" )
+					.toHaveKey( "reason" )
+					.toHaveKey( "commentableId" )
+					.toHaveKey( "commentableType" )
+					.toHaveKey( "createdDate" )
+					.toHaveKey( "modifiedDate" );
 
-                var comment = getInstance( "InternalComment" ).findOrFail( newComment.getId() );
+				expect( comment.getId() ).notToBeNull();
+				expect( comment.isLoaded() ).toBeTrue();
 
-                comment.setBody( "Lorem ipsum dolor" );
-                comment.setReason( "This is nonsense and I don't want anyone to see it." );
+				expect( comment.getBody() ).toBe( "Lorem ipsum dolor" );
+				expect( comment.getReason() ).toBe( "This is nonsense and I don't want anyone to see it." );
+			} );
 
-                comment.save();
-                
-                comment = getInstance( "InternalComment" ).findOrFail( comment.getId() );
+			it( "can delete a discriminated entity", function() {
+				var newComment = getInstance( "InternalComment" )
+					.fill( {
+						"reason"          : "I like to keep things private",
+						"body"            : "Lorem ipsum",
+						"commentableId"   : 1345,
+						"commentableType" : "Post",
+						"userId"          : getInstance( "User" ).first().getId(),
+						"createdDate"     : now(),
+						"modifiedDate"    : now()
+					} )
+					.save();
 
-                var memento = comment.getMemento();
+				transactionSetSavepoint( "comment-saved" );
 
-                expect( memento )
-                    .toHaveKey( "id" )
-                    .toHaveKey( "body" )
-                    .toHaveKey( "reason" )
-                    .toHaveKey( "commentableId" )
-                    .toHaveKey( "commentableType" )
-                    .toHaveKey( "createdDate" )
-                    .toHaveKey( "modifiedDate" );
+				getInstance( "InternalComment" ).findOrFail( newComment.getId() ).delete();
 
-                expect( comment.getId() ).notToBeNull();
-                expect( comment.isLoaded() ).toBeTrue();
+				transactionSetSavepoint( "comment-deleted" );
 
-                expect( comment.getBody() ).toBe( "Lorem ipsum dolor" );
-                expect( comment.getReason() ).toBe( "This is nonsense and I don't want anyone to see it." );
+				expect( isNull( getInstance( "InternalComment" ).find( newComment.getId() ) ) ).toBeTrue();
+			} );
 
-            } );
+			it( "Will return a child entity when retrieving a single entity from the parent", function() {
+				var newComment = getInstance( "InternalComment" )
+					.fill( {
+						"reason"          : "I like to keep things private",
+						"body"            : "Lorem ipsum",
+						"commentableId"   : 1345,
+						"commentableType" : "Post",
+						"userId"          : getInstance( "User" ).first().getId(),
+						"createdDate"     : now(),
+						"modifiedDate"    : now()
+					} )
+					.save();
 
-            it( "can delete a discriminated entity", function(){
-                var newComment = getInstance( "InternalComment" ).fill(
-                    {
-                        "reason" : "I like to keep things private",
-                        "body" : "Lorem ipsum",
-                        "commentableId" : 1345,
-                        "commentableType" : 'Post',
-                        "userId" : getInstance( "User" ).first().getId(),
-                        "createdDate" : now(),
-                        "modifiedDate" : now()
-                    }
-                ).save();
+				var parentRetrieval = getInstance( "Comment" ).find( newComment.getId() );
+				expect( isInstanceOf( parentRetrieval, "InternalComment" ) ).toBeTrue();
+			} );
 
-                transactionSetSavePoint( 'comment-saved' );
-
-                getInstance( "InternalComment" ).findOrFail( newComment.getId() ).delete();
-
-                transactionSetSavePoint( 'comment-deleted' );
-
-                expect( isNull( getInstance( "InternalComment" ).find( newComment.getId() ) ) ).toBeTrue();
-
-            });
-
-            it( "Will return a child entity when retrieving a single entity from the parent", function(){
-                var newComment = getInstance( "InternalComment" ).fill(
-                    {
-                        "reason" : "I like to keep things private",
-                        "body" : "Lorem ipsum",
-                        "commentableId" : 1345,
-                        "commentableType" : 'Post',
-                        "userId" : getInstance( "User" ).first().getId(),
-                        "createdDate" : now(),
-                        "modifiedDate" : now()
-                    }
-                ).save();
-
-                var parentRetrieval = getInstance( "Comment" ).find( newComment.getId() );
-                expect( isInstanceOf( parentRetrieval, "InternalComment" ) ).toBeTrue();
-            });
-
-            it( "Will return an array of child classes when fetching multiple results from the parent class", function(){
-                var internalComments = getInstance( "Comment" ).where( 'designation', 'internal' ).get();
-                internalComments.each( function( comment ){
-                    expect( isInstanceOf( comment, "InternalComment" ) ).toBeTrue();
-                } );
-            } );
-            
-        } );
+			it( "Will return an array of child classes when fetching multiple results from the parent class", function() {
+				var internalComments = getInstance( "Comment" ).where( "designation", "internal" ).get();
+				internalComments.each( function( comment ) {
+					expect( isInstanceOf( comment, "InternalComment" ) ).toBeTrue();
+				} );
+			} );
+		} );
 	}
 
 }

--- a/tests/specs/integration/BaseEntity/MetadataSpec.cfc
+++ b/tests/specs/integration/BaseEntity/MetadataSpec.cfc
@@ -65,43 +65,36 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				} );
 			} );
 
-			describe( "parent meta", function(){
-				it( "can detect a discriminated entity", function(){
+			describe( "parent meta", function() {
+				it( "can detect a discriminated entity", function() {
 					var discriminated = getInstance( "InternalComment" );
 					debug( discriminated.get_Meta() );
 
-					expect( discriminated.get_Meta() )
-						.toHaveKey( "parentEntity" )
-						.toHaveKey( "hasParentEntity" );
+					expect( discriminated.get_Meta() ).toHaveKey( "parentEntity" ).toHaveKey( "hasParentEntity" );
 
-					expect( discriminated.get_Meta().hasParentEntity ).toBe( true);
+					expect( discriminated.get_Meta().hasParentEntity ).toBe( true );
 					expect( discriminated.get_Meta().parentEntity )
-												.toBeStruct()
-												.toHaveKey( "meta" )
-												.toHaveKey( "joincolumn" )
-												.toHaveKey( "discriminatorValue" )
-												.toHaveKey( "discriminatorColumn" );
-
+						.toBeStruct()
+						.toHaveKey( "meta" )
+						.toHaveKey( "joincolumn" )
+						.toHaveKey( "discriminatorValue" )
+						.toHaveKey( "discriminatorColumn" );
 				} );
 
-				it( "can detect a non-discriminated child subclass", function(){
+				it( "can detect a non-discriminated child subclass", function() {
 					var discriminated = getInstance( "Jingle" );
 					debug( discriminated.get_Meta() );
 
-					expect( discriminated.get_Meta() )
-						.toHaveKey( "parentEntity" )
-						.toHaveKey( "hasParentEntity" );
+					expect( discriminated.get_Meta() ).toHaveKey( "parentEntity" ).toHaveKey( "hasParentEntity" );
 
-					expect( discriminated.get_Meta().hasParentEntity ).toBe( true);
+					expect( discriminated.get_Meta().hasParentEntity ).toBe( true );
 					expect( discriminated.get_Meta().parentEntity )
-												.toBeStruct()
-												.toHaveKey( "meta" )
-												.toHaveKey( "joincolumn" )
-												.notToHaveKey( "discriminatorValue" )
-												.notToHaveKey( "discriminatorColumn" );
-
+						.toBeStruct()
+						.toHaveKey( "meta" )
+						.toHaveKey( "joincolumn" )
+						.notToHaveKey( "discriminatorValue" )
+						.notToHaveKey( "discriminatorColumn" );
 				} );
-
 			} );
 		} );
 	}

--- a/tests/specs/integration/BaseEntity/MetadataSpec.cfc
+++ b/tests/specs/integration/BaseEntity/MetadataSpec.cfc
@@ -70,10 +70,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					var discriminated = getInstance( "InternalComment" );
 					debug( discriminated.get_Meta() );
 
-					expect( discriminated.get_Meta() ).toHaveKey( "parentEntity" ).toHaveKey( "hasParentEntity" );
+					expect( discriminated.get_Meta() ).toHaveKey( "parentDefinition" ).toHaveKey( "hasParentEntity" );
 
 					expect( discriminated.get_Meta().hasParentEntity ).toBe( true );
-					expect( discriminated.get_Meta().parentEntity )
+					expect( discriminated.get_Meta().parentDefinition )
 						.toBeStruct()
 						.toHaveKey( "meta" )
 						.toHaveKey( "joincolumn" )
@@ -85,10 +85,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					var discriminated = getInstance( "Jingle" );
 					debug( discriminated.get_Meta() );
 
-					expect( discriminated.get_Meta() ).toHaveKey( "parentEntity" ).toHaveKey( "hasParentEntity" );
+					expect( discriminated.get_Meta() ).toHaveKey( "parentDefinition" ).toHaveKey( "hasParentEntity" );
 
 					expect( discriminated.get_Meta().hasParentEntity ).toBe( true );
-					expect( discriminated.get_Meta().parentEntity )
+					expect( discriminated.get_Meta().parentDefinition )
 						.toBeStruct()
 						.toHaveKey( "meta" )
 						.toHaveKey( "joincolumn" )

--- a/tests/specs/integration/BaseEntity/MetadataSpec.cfc
+++ b/tests/specs/integration/BaseEntity/MetadataSpec.cfc
@@ -64,6 +64,45 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					expect( composite.keyNames() ).toBe( [ "a", "b" ] );
 				} );
 			} );
+
+			describe( "parent meta", function(){
+				it( "can detect a discriminated entity", function(){
+					var discriminated = getInstance( "InternalComment" );
+					debug( discriminated.get_Meta() );
+
+					expect( discriminated.get_Meta() )
+						.toHaveKey( "parentEntity" )
+						.toHaveKey( "hasParentEntity" );
+
+					expect( discriminated.get_Meta().hasParentEntity ).toBe( true);
+					expect( discriminated.get_Meta().parentEntity )
+												.toBeStruct()
+												.toHaveKey( "meta" )
+												.toHaveKey( "joincolumn" )
+												.toHaveKey( "discriminatorValue" )
+												.toHaveKey( "discriminatorColumn" );
+
+				} );
+
+				it( "can detect a non-discriminated child subclass", function(){
+					var discriminated = getInstance( "Jingle" );
+					debug( discriminated.get_Meta() );
+
+					expect( discriminated.get_Meta() )
+						.toHaveKey( "parentEntity" )
+						.toHaveKey( "hasParentEntity" );
+
+					expect( discriminated.get_Meta().hasParentEntity ).toBe( true);
+					expect( discriminated.get_Meta().parentEntity )
+												.toBeStruct()
+												.toHaveKey( "meta" )
+												.toHaveKey( "joincolumn" )
+												.notToHaveKey( "discriminatorValue" )
+												.notToHaveKey( "discriminatorColumn" );
+
+				} );
+
+			} );
 		} );
 	}
 

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -253,7 +253,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can eager load polymorphic belongs to relationships", function() {
-				var comments = getInstance( "Comment" ).with( "commentable" ).get();
+				var comments = getInstance( "Comment" ).where( 'designation', 'public' ).with( "commentable" ).get();
 
 				expect( comments ).toBeArray();
 				expect( comments ).toHaveLength( 3 );
@@ -274,6 +274,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can eager load polymorphic has many relationships", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				variables.queries = [];
+
 				var posts = getInstance( "Post" ).with( "comments" ).get();
 
 				expect( posts ).toBeArray();
@@ -295,6 +299,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can eager load a nested relationship", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				variables.queries = [];
 				var users = getInstance( "User" )
 					.with( "posts.comments" )
 					.latest()

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -253,7 +253,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can eager load polymorphic belongs to relationships", function() {
-				var comments = getInstance( "Comment" ).where( 'designation', 'public' ).with( "commentable" ).get();
+				var comments = getInstance( "Comment" )
+					.where( "designation", "public" )
+					.with( "commentable" )
+					.get();
 
 				expect( comments ).toBeArray();
 				expect( comments ).toHaveLength( 3 );
@@ -275,7 +278,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
 			it( "can eager load polymorphic has many relationships", function() {
 				// delete our internal comments to allow the test to pass:
-				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
 				variables.queries = [];
 
 				var posts = getInstance( "Post" ).with( "comments" ).get();
@@ -300,9 +307,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
 			it( "can eager load a nested relationship", function() {
 				// delete our internal comments to allow the test to pass:
-				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
 				variables.queries = [];
-				var users = getInstance( "User" )
+				var users         = getInstance( "User" )
 					.with( "posts.comments" )
 					.latest()
 					.get();

--- a/tests/specs/integration/BaseEntity/Relationships/PolymorphicHasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/PolymorphicHasManySpec.cfc
@@ -3,6 +3,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 	function run() {
 		describe( "Polymorphic Has Many Spec", function() {
 			it( "can get the related polymorphic entities", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				variables.queries = [];
+				
 				var postA         = getInstance( "Post" ).find( 1245 );
 				var postAComments = postA.getComments();
 				expect( postAComments ).toBeArray();

--- a/tests/specs/integration/BaseEntity/Relationships/PolymorphicHasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/PolymorphicHasManySpec.cfc
@@ -4,9 +4,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 		describe( "Polymorphic Has Many Spec", function() {
 			it( "can get the related polymorphic entities", function() {
 				// delete our internal comments to allow the test to pass:
-				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
 				variables.queries = [];
-				
+
 				var postA         = getInstance( "Post" ).find( 1245 );
 				var postAComments = postA.getComments();
 				expect( postAComments ).toBeArray();

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -74,11 +74,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					it( "applies count constraints to the final relationship in a nested relationship existence check", function() {
 						var users = getInstance( "User" ).has( "posts.comments", "=", 1 ).get();
 						expect( users ).toBeArray();
-						expect( users ).toHaveLength( 2 );
+						expect( users ).toHaveLength( 1 );
 
 						var users = getInstance( "User" ).has( "posts.comments", ">", 1 ).get();
 						expect( users ).toBeArray();
-						expect( users ).toBeEmpty();
+						expect( users ).toHaveLength( 1 );
 					} );
 
 					it( "applies whereHas constraints to the final relationship in a nested relationship existence check", function() {
@@ -274,11 +274,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					it( "applies count constraints to the final relationship in a nested relationship absence check", function() {
 						var users = getInstance( "User" ).doesntHave( "posts.comments", "=", 1 ).get();
 						expect( users ).toBeArray();
-						expect( users ).toHaveLength( 2 );
+						expect( users ).toHaveLength( 3 );
 
 						var users = getInstance( "User" ).doesntHave( "posts.comments", ">", 1 ).get();
 						expect( users ).toBeArray();
-						expect( users ).toHaveLength( 4 );
+						expect( users ).toHaveLength( 3 );
 					} );
 
 					it( "applies whereDoesntHave constraints to the final relationship in a nested relationship existence check", function() {

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -72,11 +72,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					} );
 
 					it( "applies count constraints to the final relationship in a nested relationship existence check", function() {
-
 						debug( getInstance( "User" ).has( "posts.comments", "=", 1 ).toSQL() );
-						
+
 						var users = getInstance( "User" ).has( "posts.comments", "=", 1 ).get();
-						debug( var=queryExecute( "SELECT user_id, count(*) from comments GROUP BY user_id" ), top=2 );
+						debug(
+							var = queryExecute( "SELECT user_id, count(*) from comments GROUP BY user_id" ),
+							top = 2
+						);
 						expect( users ).toBeArray();
 						expect( users ).toHaveLength( 1 );
 

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -72,7 +72,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 					} );
 
 					it( "applies count constraints to the final relationship in a nested relationship existence check", function() {
+
+						debug( getInstance( "User" ).has( "posts.comments", "=", 1 ).toSQL() );
+						
 						var users = getInstance( "User" ).has( "posts.comments", "=", 1 ).get();
+						debug( var=queryExecute( "SELECT user_id, count(*) from comments GROUP BY user_id" ), top=2 );
 						expect( users ).toBeArray();
 						expect( users ).toHaveLength( 1 );
 

--- a/tests/specs/integration/BaseEntity/Relationships/RelationshipsCountSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/RelationshipsCountSpec.cfc
@@ -12,6 +12,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can add a subselect for the count of a relationship without loading the relationship", function() {
+
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				variables.queries = [];
+				
 				var posts = getInstance( "Post" )
 					.withCount( "comments" )
 					.orderBy( "createdDate" )
@@ -59,7 +64,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				expect( posts[ 4 ].getPost_Pk() ).toBe( 7777 );
 			} );
 
-			it( "can add multiple counts at once", function() {
+			it( "can add multiple counts at once", function() {// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				variables.queries = [];
+
 				var posts = getInstance( "Post" )
 					.withCount( [ "comments", "tags" ] )
 					.orderBy( "createdDate" )
@@ -110,6 +118,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can constrain counts at runtime", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				variables.queries = [];
+
 				var posts = getInstance( "Post" )
 					.withCount( {
 						"comments" : function( q ) {
@@ -148,6 +160,10 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can alias the counts attribute name", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				variables.queries = [];
+
 				var posts = getInstance( "Post" )
 					.withCount( "comments AS comments_count" )
 					.orderBy( "createdDate" )

--- a/tests/specs/integration/BaseEntity/Relationships/RelationshipsCountSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/RelationshipsCountSpec.cfc
@@ -12,11 +12,14 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			} );
 
 			it( "can add a subselect for the count of a relationship without loading the relationship", function() {
-
 				// delete our internal comments to allow the test to pass:
-				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
 				variables.queries = [];
-				
+
 				var posts = getInstance( "Post" )
 					.withCount( "comments" )
 					.orderBy( "createdDate" )
@@ -64,8 +67,13 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				expect( posts[ 4 ].getPost_Pk() ).toBe( 7777 );
 			} );
 
-			it( "can add multiple counts at once", function() {// delete our internal comments to allow the test to pass:
-				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+			it( "can add multiple counts at once", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
 				variables.queries = [];
 
 				var posts = getInstance( "Post" )
@@ -119,7 +127,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
 			it( "can constrain counts at runtime", function() {
 				// delete our internal comments to allow the test to pass:
-				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
 				variables.queries = [];
 
 				var posts = getInstance( "Post" )
@@ -161,7 +173,11 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
 			it( "can alias the counts attribute name", function() {
 				// delete our internal comments to allow the test to pass:
-				getInstance( "InternalComment" ).get().each( function( comment ){ comment.delete(); } );
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
 				variables.queries = [];
 
 				var posts = getInstance( "Post" )

--- a/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
@@ -14,6 +14,7 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			it( "can add a subquery to an entity", function() {
 				var elpete = getInstance( "User" ).withLatestPostId().findOrFail( 1 );
 				expect( elpete.getLatestPostId() ).notToBeNull();
+
 				expect( elpete.getLatestPostId() ).toBe( 523526 );
 				expect( variables.queries ).toHaveLength(
 					1,


### PR DESCRIPTION
This pull request implements the ability to apply an object-oriented approach to database design by allowing for discriminated and child class entities as Quick entities.  This feature is implemented in CFORM but not in Quick.

A separate documentation pull request will be forthcoming.  

In short:

By adding a `joincolumn` component attribute to an entity which extends another entity, the child class' table will extend the parent's table.  When loading the child class all attributes from the parent will also be loaded.

By adding a `discriminatorColumn` to the parent and a `discriminatorValue` to the child class, the entity will become discriminated with the discriminator column auto-populated on the parent.  When parents are loaded and a discriminated child exists, the child entity will be provided in collections and individual entity requests.