### PR TITLE
Respect defined sqltypes in relationship methods

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3661,6 +3661,7 @@ component accessors="true" {
 		any value,
 		boolean checkNullValues = true
 	) {
+		arguments.column = listLast( arguments.column, "." );
 		// If that value is already a struct, pass it back unchanged.
 		if ( !isNull( arguments.value ) && isStruct( arguments.value ) ) {
 			return arguments.value;

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1087,7 +1087,10 @@ component accessors="true" {
 			.where( function( q ) {
 				var allKeyNames = keyNames();
 				for ( var i = 1; i <= allKeyNames.len(); i++ ) {
-					q.where( allKeyNames[ i ], id[ i ] );
+					q.where(
+						allKeyNames[ i ],
+						generateQueryParamStruct( allKeyNames[ i ], id[ i ] )
+					);
 				}
 			} )
 			.first();

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1087,10 +1087,7 @@ component accessors="true" {
 			.where( function( q ) {
 				var allKeyNames = keyNames();
 				for ( var i = 1; i <= allKeyNames.len(); i++ ) {
-					q.where(
-						allKeyNames[ i ],
-						generateQueryParamStruct( allKeyNames[ i ], id[ i ] )
-					);
+					q.where( allKeyNames[ i ], generateQueryParamStruct( allKeyNames[ i ], id[ i ] ) );
 				}
 			} )
 			.first();

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -123,7 +123,10 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 				function( localKey, foreignKey ) {
 					q.where(
 						variables.related.qualifyColumn( localKey ),
-						variables.child.retrieveAttribute( foreignKey )
+						variables.related.generateQueryParamStruct(
+							localKey,
+							variables.child.retrieveAttribute( foreignKey )
+						)
 					);
 				}
 			);
@@ -439,7 +442,10 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 				function( foreignKey, localKey ) {
 					q.where(
 						variables.related.qualifyColumn( localKey ),
-						variables.child.retrieveAttribute( foreignKey )
+						variables.related.generateQueryParamStruct(
+							localKey,
+							variables.child.retrieveAttribute( foreignKey )
+						)
 					);
 				}
 			);

--- a/models/Relationships/BelongsToMany.cfc
+++ b/models/Relationships/BelongsToMany.cfc
@@ -156,7 +156,11 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 							keys,
 							variables.parentKeys
 						],
-						function( foreignPivotKeyName, keyValue, parentKey ) {
+						function(
+							foreignPivotKeyName,
+							keyValue,
+							parentKey
+						) {
 							q2.where(
 								foreignPivotKeyName,
 								variables.parent.generateQueryParamStruct( parentKey, keyValue )
@@ -343,7 +347,11 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 						foreignPivotKeyValues,
 						variables.parentKeys
 					],
-					function( foreignPivotKey, foreignPivotKeyValue, parentKey ) {
+					function(
+						foreignPivotKey,
+						foreignPivotKeyValue,
+						parentKey
+					) {
 						q.where(
 							foreignPivotKey,
 							variables.parent.generateQueryParamStruct( parentKey, foreignPivotKeyValue )
@@ -354,17 +362,19 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 			.where( function( q1 ) {
 				parseIds( arrayWrap( id ) ).each( function( ids ) {
 					q1.orWhere( function( q2 ) {
-						arrayZipEach( [
-							variables.relatedPivotKeys,
-							ids,
-							variables.relatedKeys
-						],
-						function( relatedPivotKey, id, relatedKey ) {
-							q2.where(
-								relatedPivotKey,
-								variables.related.generateQueryParamStruct( relatedKey, id )
-							);
-						} );
+						arrayZipEach(
+							[
+								variables.relatedPivotKeys,
+								ids,
+								variables.relatedKeys
+							],
+							function( relatedPivotKey, id, relatedKey ) {
+								q2.where(
+									relatedPivotKey,
+									variables.related.generateQueryParamStruct( relatedKey, id )
+								);
+							}
+						);
 					} );
 				} );
 			} )
@@ -411,7 +421,11 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 						foreignPivotKeyValues,
 						variables.foreignKeys
 					],
-					function( foreignPivotKey, foreignPivotKeyValue, foreignKey ) {
+					function(
+						foreignPivotKey,
+						foreignPivotKeyValue,
+						foreignKey
+					) {
 						q.where(
 							foreignPivotKey,
 							variables.parent.generateQueryParamStruct( foreignKey, foreignPivotKeyValue )
@@ -491,7 +505,10 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 					val,
 					relatedKey
 				) {
-					insertRecord[ foreignPivotKey ] = variables.parent.generateQueryParamStruct( foreignKey, foreignPivotKeyValue );
+					insertRecord[ foreignPivotKey ] = variables.parent.generateQueryParamStruct(
+						foreignKey,
+						foreignPivotKeyValue
+					);
 					insertRecord[ relatedPivotKey ] = variables.related.generateQueryParamStruct( relatedKey, val );
 				}
 			);

--- a/models/Relationships/BelongsToMany.cfc
+++ b/models/Relationships/BelongsToMany.cfc
@@ -703,8 +703,8 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 				function( localKey, parentKey ) {
 					q.where(
 						variables.related.qualifyColumn( localKey ),
-						variables.parent.generateQueryParamStruct(
-							parentKey,
+						variables.related.generateQueryParamStruct(
+							localKey,
 							variables.parent.retrieveAttribute( parentKey )
 						)
 					);

--- a/models/Relationships/BelongsToMany.cfc
+++ b/models/Relationships/BelongsToMany.cfc
@@ -703,7 +703,7 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 				function( localKey, parentKey ) {
 					q.where(
 						variables.related.qualifyColumn( localKey ),
-						variables.related.generateQueryParamStruct(
+						variables.parent.generateQueryParamStruct(
 							parentKey,
 							variables.parent.retrieveAttribute( parentKey )
 						)

--- a/models/Relationships/BelongsToThrough.cfc
+++ b/models/Relationships/BelongsToThrough.cfc
@@ -298,7 +298,10 @@ component extends="quick.models.Relationships.BaseRelationship" {
 				function( foreignKey, localKey ) {
 					q.where(
 						variables.related.qualifyColumn( foreignKey ),
-						variables.parent.retrieveAttribute( localKey )
+						variables.parent.generateQueryParamStruct(
+							localKey,
+							variables.parent.retrieveAttribute( localKey )
+						)
 					);
 				}
 			);

--- a/models/Relationships/BelongsToThrough.cfc
+++ b/models/Relationships/BelongsToThrough.cfc
@@ -298,8 +298,8 @@ component extends="quick.models.Relationships.BaseRelationship" {
 				function( foreignKey, localKey ) {
 					q.where(
 						variables.related.qualifyColumn( foreignKey ),
-						variables.parent.generateQueryParamStruct(
-							localKey,
+						variables.related.generateQueryParamStruct(
+							foreignKey,
 							variables.parent.retrieveAttribute( localKey )
 						)
 					);

--- a/models/Relationships/HasMany.cfc
+++ b/models/Relationships/HasMany.cfc
@@ -78,7 +78,10 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 					function( foreignKey, localKey ) {
 						q.where(
 							variables.related.qualifyColumn( foreignKey ),
-							variables.parent.retrieveAttribute( localKey )
+							variables.related.generateQueryParamStruct(
+								foreignKey,
+								variables.parent.retrieveAttribute( localKey )
+							)
 						);
 					}
 				);

--- a/models/Relationships/HasOne.cfc
+++ b/models/Relationships/HasOne.cfc
@@ -97,7 +97,10 @@ component extends="quick.models.Relationships.HasOneOrMany" {
 				function( foreignKey, localKey ) {
 					q.where(
 						variables.related.qualifyColumn( foreignKey ),
-						variables.parent.retrieveAttribute( localKey )
+						variables.related.generateQueryParamStruct(
+							foreignKey,
+							variables.parent.retrieveAttribute( localKey )
+						)
 					);
 				}
 			);

--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -67,7 +67,10 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 					getParentKeys()
 				],
 				function( keyName, parentKey ) {
-					q.where( keyName, parentKey ).whereNotNull( keyName );
+					q.where(
+						variables.related.qualifyColumn( keyName ),
+						variables.related.generateQueryParamStruct( keyName, parentKey )
+					).whereNotNull( keyName );
 				}
 			);
 		} );

--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -68,9 +68,10 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 				],
 				function( keyName, parentKey ) {
 					q.where(
-						variables.related.qualifyColumn( keyName ),
-						variables.related.generateQueryParamStruct( keyName, parentKey )
-					).whereNotNull( keyName );
+							variables.related.qualifyColumn( keyName ),
+							variables.related.generateQueryParamStruct( keyName, parentKey )
+						)
+						.whereNotNull( keyName );
 				}
 			);
 		} );

--- a/models/Relationships/HasOneThrough.cfc
+++ b/models/Relationships/HasOneThrough.cfc
@@ -93,7 +93,10 @@ component extends="quick.models.Relationships.HasOneOrManyThrough" {
 				function( foreignKey, localKey ) {
 					q.where(
 						variables.related.qualifyColumn( foreignKey ),
-						variables.parent.retrieveAttribute( localKey )
+						variables.related.generateQueryParamStruct(
+							foreignKey,
+							variables.parent.retrieveAttribute( localKey )
+						)
 					);
 				}
 			);

--- a/models/Relationships/PolymorphicBelongsTo.cfc
+++ b/models/Relationships/PolymorphicBelongsTo.cfc
@@ -160,7 +160,10 @@ component extends="quick.models.Relationships.BelongsTo" accessors="true" {
 				gatherKeysByType( type ).each( function( keys ) {
 					q1.orWhere( function( q2 ) {
 						arrayZipEach( [ localKeys, keys ], function( localKey, keyValue ) {
-							q2.where( localKey, keyValue );
+							q2.where(
+								instance.qualifyColumn( arguments.localKey ),
+								instance.generateQueryParamStruct( arguments.localKey, arguments.keyValue )
+							);
 						} );
 					} );
 				} );
@@ -247,7 +250,10 @@ component extends="quick.models.Relationships.BelongsTo" accessors="true" {
 			function( localKey, foreignKey ) {
 				base.where(
 					variables.related.qualifyColumn( localKey ),
-					variables.parent.retrieveAttribute( foreignKey )
+					variables.related.generateQueryParamStruct(
+						localKey,
+						variables.parent.retrieveAttribute( foreignKey )
+					)
 				);
 			}
 		);

--- a/models/Relationships/PolymorphicHasMany.cfc
+++ b/models/Relationships/PolymorphicHasMany.cfc
@@ -64,10 +64,19 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 		var base = variables.parent
 			.newQuery()
 			.reselectRaw( 1 )
-			.where( variables.related.qualifyColumn( variables.morphType ), variables.morphMapping );
+			.where(
+				variables.related.qualifyColumn( variables.morphType ),
+				variables.related.generateQueryParamStruct( variables.morphType, variables.morphMapping )
+			);
 
 		variables.localKeys.each( function( localKey ) {
-			base.where( variables.parent.qualifyColumn( localKey ), variables.parent.retrieveAttribute( localKey ) );
+			base.where(
+				variables.parent.qualifyColumn( localKey ),
+				variables.parent.generateQueryParamStruct(
+					localKey,
+					variables.parent.retrieveAttribute( localKey )
+				)
+			);
 		} );
 
 		arrayZipEach(
@@ -98,7 +107,10 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 	 */
 	public void function applyThroughConstraints( required any base ) {
 		arguments.base
-			.where( variables.related.qualifyColumn( variables.morphType ), variables.morphMapping )
+			.where(
+				variables.related.qualifyColumn( variables.morphType ),
+				variables.related.generateQueryParamStruct( variables.morphType, variables.morphMapping )
+			)
 			.where( function( q ) {
 				arrayZipEach(
 					[
@@ -108,7 +120,10 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 					function( foreignKey, localKey ) {
 						q.where(
 							variables.related.qualifyColumn( foreignKey ),
-							variables.parent.retrieveAttribute( localKey )
+							variables.related.generateQueryParamStruct(
+								foreignKey,
+								variables.parent.retrieveAttribute( localKey )
+							)
 						);
 					}
 				);

--- a/models/Relationships/PolymorphicHasMany.cfc
+++ b/models/Relationships/PolymorphicHasMany.cfc
@@ -72,10 +72,7 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 		variables.localKeys.each( function( localKey ) {
 			base.where(
 				variables.parent.qualifyColumn( localKey ),
-				variables.parent.generateQueryParamStruct(
-					localKey,
-					variables.parent.retrieveAttribute( localKey )
-				)
+				variables.parent.generateQueryParamStruct( localKey, variables.parent.retrieveAttribute( localKey ) )
 			);
 		} );
 

--- a/models/Relationships/PolymorphicHasOneOrMany.cfc
+++ b/models/Relationships/PolymorphicHasOneOrMany.cfc
@@ -71,7 +71,10 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 	 */
 	public PolymorphicHasOneOrMany function addConstraints() {
 		super.addConstraints();
-		variables.related.where( variables.morphType, variables.morphMapping );
+		variables.related.where(
+			variables.related.qualifyColumn( variables.morphType ),
+			variables.related.generateQueryParamStruct( variables.morphType, variables.morphMapping )
+		);
 		return this;
 	}
 
@@ -86,7 +89,10 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 		if ( !super.addEagerConstraints( arguments.entities ) ) {
 			return false;
 		}
-		variables.related.where( variables.morphType, variables.morphMapping );
+		variables.related.where(
+			variables.related.qualifyColumn( variables.morphType ),
+			variables.related.generateQueryParamStruct( variables.morphType, variables.morphMapping )
+		);
 		return true;
 	}
 
@@ -99,7 +105,10 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 	 */
 	public any function addCompareConstraints( any base = variables.related ) {
 		return tap( super.addCompareConstraints( arguments.base ), function( q ) {
-			q.where( variables.related.qualifyColumn( variables.morphType ), variables.morphMapping );
+			q.where(
+				variables.related.qualifyColumn( variables.morphType ),
+				variables.related.generateQueryParamStruct( variables.morphType, variables.morphMapping )
+			);
 		} );
 	}
 
@@ -119,7 +128,10 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 				],
 				function( foreignKey, localKey ) {
 					j.on( variables.related.qualifyColumn( foreignKey ), variables.parent.qualifyColumn( localKey ) );
-					j.where( variables.related.qualifyColumn( variables.morphType ), variables.morphMapping );
+					j.where(
+						variables.related.qualifyColumn( variables.morphType ),
+						variables.related.generateQueryParamStruct( variables.morphType, variables.morphMapping )
+					);
 				}
 			);
 		} );

--- a/tests/specs/integration/BaseEntity/Relationships/RelationshipLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/RelationshipLoadingSpec.cfc
@@ -56,16 +56,19 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 			it( "can load a relationship based off of a subselect column", function() {
 				controller.getInterceptorService().registerInterceptor( interceptorObject = this );
 
-				var users = getInstance( "User" ).withLatestPost().orderByAsc( "id" ).get();
+				var users = getInstance( "User" )
+					.withLatestPost()
+					.orderByAsc( "id" )
+					.get();
 				expect( users ).toHaveLength( 4 );
 
 				var elpete = users[ 1 ];
 				expect( elpete.getDynamicLatestPost() ).notToBeNull();
 				expect( elpete.getDynamicLatestPost().getPost_Pk() ).toBe( 523526 );
-				
+
 				var johndoe = users[ 2 ];
 				expect( johndoe.getDynamicLatestPost() ).toBeNull();
-				
+
 				var janedoe = users[ 3 ];
 				expect( janedoe.getDynamicLatestPost() ).toBeNull();
 


### PR DESCRIPTION
Use generateQueryParamStruct throughout relationship components to ensure defined sqltypes on entities are being respected