### PR TITLE
feat(BaseEntity): Add new simplePaginate method

### DIFF
--- a/box.json
+++ b/box.json
@@ -21,7 +21,7 @@
     },
     "type":"modules",
     "dependencies":{
-        "qb":"^8.0.0",
+        "qb":"^8.4.5",
         "str":"^1.0.0",
         "mementifier":"^2.1.0+100"
     },

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -963,6 +963,21 @@ component accessors="true" {
 	}
 
 	/**
+	 * Returns a Simple Pagination Collection of entities.
+	 *
+	 * @page     The page of results to return.
+	 * @maxRows  The number of rows to return.
+	 *
+	 * @return   A Simple Pagination Collection object of the entities.
+	 */
+	public any function simplePaginate( numeric page = 1, numeric maxRows = 25 ) {
+		activateGlobalScopes();
+		return tap( retrieveQuery().simplePaginate( page, maxRows ), function( p ) {
+			p.results = handleTransformations( eagerLoadRelations( p.results.map( variables.loadEntity ) ) );
+		} );
+	}
+
+	/**
 	 * Returns the first matching entity for the configured query.
 	 * If no records are found, it returns null instead.
 	 *

--- a/tests/specs/integration/BaseEntity/GetSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GetSpec.cfc
@@ -146,12 +146,38 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 
 				var p = getInstance( "A" ).orderBy( "id" ).paginate();
 				expect( p.pagination.page ).toBe( 1, "Page number should be 1" );
+				expect( p.pagination.totalRecords ).toBe( 45 );
+				expect( p.pagination.totalPages ).toBe( 2 );
 				expect( p.results ).toHaveLength( 25 );
 				expect( p.results[ 1 ].getId() ).toBe( 1, "First entity id should be 1" );
 				expect( p.results[ p.results.len() ].getId() ).toBe( 25 );
 
 				p = getInstance( "A" ).orderBy( "id" ).paginate( 2 );
 				expect( p.pagination.page ).toBe( 2, "Page number should be 2" );
+				expect( p.pagination.totalRecords ).toBe( 45 );
+				expect( p.pagination.totalPages ).toBe( 2 );
+				expect( p.results ).toHaveLength( 20 );
+				expect( p.results[ 1 ].getId() ).toBe( 26, "First entity id should be 26" );
+				expect( p.results[ p.results.len() ].getId() ).toBe( 45 );
+			} );
+
+			it( "can simple paginate a Quick query", function() {
+				queryExecute( "TRUNCATE TABLE `a`" );
+				for ( var i = 1; i <= 45; i++ ) {
+					// create A
+					var a = getInstance( "A" ).create( { "name" : "Instance #i#" } );
+				}
+
+				var p = getInstance( "A" ).orderBy( "id" ).simplePaginate();
+				expect( p.pagination.page ).toBe( 1, "Page number should be 1" );
+				expect( p.pagination.hasMore ).toBeTrue( "Pagination should indicate there are more records" );
+				expect( p.results ).toHaveLength( 25 );
+				expect( p.results[ 1 ].getId() ).toBe( 1, "First entity id should be 1" );
+				expect( p.results[ p.results.len() ].getId() ).toBe( 25 );
+
+				p = getInstance( "A" ).orderBy( "id" ).simplePaginate( 2 );
+				expect( p.pagination.page ).toBe( 2, "Page number should be 2" );
+				expect( p.pagination.hasMore ).toBeFalse( "Pagination should indicate there are no more records" );
 				expect( p.results ).toHaveLength( 20 );
 				expect( p.results[ 1 ].getId() ).toBe( 26, "First entity id should be 26" );
 				expect( p.results[ p.results.len() ].getId() ).toBe( 45 );


### PR DESCRIPTION
This uses qb's new `simplePaginate` method to bypass calling `count`
to improve performance.  The `pagination` struct response is different
when using `simplePaginate`.  Refer to https://qb.ortusbooks.com/query-builder/executing-queries/retrieving-results#simplepaginate
for more information.