### PR TITLE
Fix discriminators

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3742,6 +3742,9 @@ component accessors="true" {
 	public boolean function isNullValue( required string key, any value ) {
 		param arguments.value = invoke( this, "get" & arguments.key );
 		var alias             = retrieveAliasForColumn( arguments.key );
+		if ( !isSimpleValue( arguments.value ) ) {
+			return false;
+		}
 		return variables._nullValues.keyExists( alias ) &&
 		compare( variables._nullValues[ alias ], arguments.value ) == 0;
 	}

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -421,7 +421,7 @@ component accessors="true" {
 			if ( withoutKey && arrayContainsNoCase( keyNames(), retrieveAliasForColumn( key ) ) ) {
 				return acc;
 			}
-			if ( isNull( value ) || ( isNullValue( key, value ) && withNulls ) ) {
+			if ( isNull( value ) || ( isNullAttribute( key ) && withNulls ) ) {
 				acc[ aliased ? retrieveAliasForColumn( key ) : retrieveColumnForAlias( key ) ] = javacast( "null", "" );
 			} else {
 				acc[ aliased ? retrieveAliasForColumn( key ) : retrieveColumnForAlias( key ) ] = value;
@@ -570,6 +570,9 @@ component accessors="true" {
 	 */
 	public any function populateAttributes( struct attributes = {} ) {
 		for ( var key in arguments.attributes ) {
+			if ( !hasAttribute( key ) ) {
+				continue;
+			}
 			variables._data[ retrieveColumnForAlias( key ) ] = (
 				!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )
 			) ? javacast( "null", "" ) : castValueForGetter( key, arguments.attributes[ key ] );

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3261,7 +3261,8 @@ component accessors="true" {
 	}
 
 	public boolean function isVirtualAttribute( name ) {
-		return variables._attributes[ retrieveAliasForColumn( arguments.name ) ].virtual;
+		return variables._attributes.keyExists( retrieveAliasForColumn( arguments.name ) ) &&
+		variables._attributes[ retrieveAliasForColumn( arguments.name ) ].virtual;
 	}
 
 	public boolean function isParentAttribute( required string column ) {

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3357,16 +3357,17 @@ component accessors="true" {
 						return acc;
 					}, [] );
 
+				var childColumns = childClass
+					.retrieveQualifiedColumns()
+					.filter( function( column ) {
+						return listFirst( column, "." ) == childMeta.table;
+					} );
 				acc[ childMeta.discriminatorValue ] = {
 					"mapping"      : childMeta.fullName,
 					"table"        : childMeta.table,
 					"joincolumn"   : childClass.qualifyColumn( childMeta.joinColumn ),
 					"attributes"   : childAttributes,
-					"childColumns" : childClass
-						.retrieveQualifiedColumns()
-						.filter( function( column ) {
-							return listFirst( column, "." ) == childMeta.table;
-						} )
+					"childColumns" : childColumns
 				};
 				return acc;
 			}, {} );

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2502,7 +2502,7 @@ component accessors="true" {
 			.setReturnFormat( "array" )
 			.setDefaultOptions( variables._queryOptions )
 			.from( tableName() )
-			.select( retrieveQualifiedColumns() );
+			.addSelect( retrieveQualifiedColumns() );
 	}
 
 	/**
@@ -3358,10 +3358,15 @@ component accessors="true" {
 					}, [] );
 
 				acc[ childMeta.discriminatorValue ] = {
-					"mapping"    : childMeta.fullName,
-					"table"      : childMeta.table,
-					"joincolumn" : childMeta.joinColumn,
-					"attributes" : childAttributes
+					"mapping"      : childMeta.fullName,
+					"table"        : childMeta.table,
+					"joincolumn"   : childClass.qualifyColumn( childMeta.joinColumn ),
+					"attributes"   : childAttributes,
+					"childColumns" : childClass
+						.retrieveQualifiedColumns()
+						.filter( function( column ) {
+							return listFirst( column, "." ) == childMeta.table;
+						} )
 				};
 				return acc;
 			}, {} );

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -724,6 +724,7 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 						data.joincolumn,
 						"left outer"
 					);
+					builder.addSelect( data.childColumns );
 				} );
 		}
 	}

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -324,7 +324,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				var internalComments = parentClass.where( "designation", "internal" ).get();
 				internalComments.each( function( comment ) {
 					expect( comment ).toBeInstanceOf( "InternalComment" );
-					expect( comment.hasAttribute( "reason" ) ).toBeTrue( "InternalComments should have a reason field." );
+					expect( comment.hasAttribute( "reason" ) ).toBeTrue(
+						"InternalComments should have a reason field."
+					);
 					expect( comment.isNullAttribute( "reason" ) ).toBeFalse( "The reason field should not be null." );
 				} );
 			} );

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -323,7 +323,9 @@ component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
 				expect( parentClass.isDiscriminatedParent() ).toBeTrue();
 				var internalComments = parentClass.where( "designation", "internal" ).get();
 				internalComments.each( function( comment ) {
-					expect( comment, "InternalComment" ).toBeInstanceOf( "InternalComment" );
+					expect( comment ).toBeInstanceOf( "InternalComment" );
+					expect( comment.hasAttribute( "reason" ) ).toBeTrue( "InternalComments should have a reason field." );
+					expect( comment.isNullAttribute( "reason" ) ).toBeFalse( "The reason field should not be null." );
 				} );
 			} );
 		} );


### PR DESCRIPTION
This fixes cases where a child entity would not have it's own data, just the parent data, when loaded as a discriminated entity.  It also ensures all columns are properly qualified since there are many joins going on here.