### PR TITLE
Add include and exclude arguments to fill method

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -579,9 +579,29 @@ component accessors="true" {
 	 *
 	 * @return                       quick.models.BaseEntity
 	 */
-	public any function fill( struct attributes = {}, boolean ignoreNonExistentAttributes = false ) {
-		for ( var key in arguments.attributes ) {
-			guardAgainstReadOnlyAttribute( key );
+	public any function fill( 
+        struct attributes = {}, 
+        boolean ignoreNonExistentAttributes = false, 
+        any include=[],
+        any exclude = []
+    ) {
+		// if they passed in a list instead of an array for include or exclude, convert it to an array
+        if ( isSimpleValue( arguments.include ) ) {
+            arguments.include = listToArray( arguments.include );
+        }
+        if ( isSimpleValue( arguments.exclude ) ) {
+            arguments.exclude = listToArray( arguments.exclude );
+        }
+        for ( var key in arguments.attributes ) {
+			// Include List?
+			if ( include.len() && !include.findNoCase( key ) ) {
+				continue;
+			}
+            // exclude list?
+            if ( exclude.len() && exclude.findNoCase( key ) ) {
+				continue;
+			}
+            guardAgainstReadOnlyAttribute( key );
 			if ( isNull( arguments.attributes[ key ] ) || !structKeyExists( arguments.attributes, key ) ) {
 				if ( hasAttribute( key ) ) {
 					clearAttribute( key, true );

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -579,34 +579,34 @@ component accessors="true" {
 	 *
 	 * @return                       quick.models.BaseEntity
 	 */
-	public any function fill( 
-		struct attributes = {}, 
-		boolean ignoreNonExistentAttributes = false, 
-		any include = [],
-		any exclude = []
+	public any function fill(
+		struct attributes                   = {},
+		boolean ignoreNonExistentAttributes = false,
+		any include                         = [],
+		any exclude                         = []
 	) {
 		// if they passed in a list instead of an array for include or exclude, convert it to an array
-        	if ( isSimpleValue( arguments.include ) ) {
-            		arguments.include = listToArray( arguments.include );
-        	}
-        
+		if ( isSimpleValue( arguments.include ) ) {
+			arguments.include = listToArray( arguments.include );
+		}
+
 		if ( isSimpleValue( arguments.exclude ) ) {
-            		arguments.exclude = listToArray( arguments.exclude );
-        	}
-        
+			arguments.exclude = listToArray( arguments.exclude );
+		}
+
 		for ( var key in arguments.attributes ) {
 			// Include List?
 			if ( include.len() && !include.findNoCase( key ) ) {
 				continue;
 			}
-			
-            		// exclude list?
-            		if ( exclude.len() && exclude.findNoCase( key ) ) {
+
+			// exclude list?
+			if ( exclude.len() && exclude.findNoCase( key ) ) {
 				continue;
 			}
-			
-            		guardAgainstReadOnlyAttribute( key );
-			
+
+			guardAgainstReadOnlyAttribute( key );
+
 			if ( isNull( arguments.attributes[ key ] ) || !structKeyExists( arguments.attributes, key ) ) {
 				if ( hasAttribute( key ) ) {
 					clearAttribute( key, true );

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -580,28 +580,33 @@ component accessors="true" {
 	 * @return                       quick.models.BaseEntity
 	 */
 	public any function fill( 
-        struct attributes = {}, 
-        boolean ignoreNonExistentAttributes = false, 
-        any include=[],
-        any exclude = []
-    ) {
+		struct attributes = {}, 
+		boolean ignoreNonExistentAttributes = false, 
+		any include = [],
+		any exclude = []
+	) {
 		// if they passed in a list instead of an array for include or exclude, convert it to an array
-        if ( isSimpleValue( arguments.include ) ) {
-            arguments.include = listToArray( arguments.include );
-        }
-        if ( isSimpleValue( arguments.exclude ) ) {
-            arguments.exclude = listToArray( arguments.exclude );
-        }
-        for ( var key in arguments.attributes ) {
+        	if ( isSimpleValue( arguments.include ) ) {
+            		arguments.include = listToArray( arguments.include );
+        	}
+        
+		if ( isSimpleValue( arguments.exclude ) ) {
+            		arguments.exclude = listToArray( arguments.exclude );
+        	}
+        
+		for ( var key in arguments.attributes ) {
 			// Include List?
 			if ( include.len() && !include.findNoCase( key ) ) {
 				continue;
 			}
-            // exclude list?
-            if ( exclude.len() && exclude.findNoCase( key ) ) {
+			
+            		// exclude list?
+            		if ( exclude.len() && exclude.findNoCase( key ) ) {
 				continue;
 			}
-            guardAgainstReadOnlyAttribute( key );
+			
+            		guardAgainstReadOnlyAttribute( key );
+			
 			if ( isNull( arguments.attributes[ key ] ) || !structKeyExists( arguments.attributes, key ) ) {
 				if ( hasAttribute( key ) ) {
 					clearAttribute( key, true );


### PR DESCRIPTION
This enhancement to `fill()` simulates Wirebox's `populateFromStruct()` ability to  `include` or `exclude` fields when populating.  @elpete, This PR was updated to allow for a simple list or an array to be passed for either argument.