### PR TITLE
Execute retrieveQuery against relationship query

### DIFF
--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -321,7 +321,7 @@ component accessors="true" {
 	 * @return  qb.models.Query.QueryBuilder
 	 */
 	public QuickBuilder function retrieveQuery() {
-		return variables.relationshipBuilder;
+		return variables.relationshipBuilder.retrieveQuery();
 	}
 
 	/**

--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -320,7 +320,7 @@ component accessors="true" {
 	 *
 	 * @return  qb.models.Query.QueryBuilder
 	 */
-	public QuickBuilder function retrieveQuery() {
+	public any function retrieveQuery() {
 		return variables.relationshipBuilder.retrieveQuery();
 	}
 


### PR DESCRIPTION
Fixed regression in v5 where retrieveQuery() does not return the query backing relationship instances.

Looking at v4. When calling retrieveQuery() on the relationship instance, the same method is called on the related entity Instance. In v5, the retrieveQuery() method will simply return the related entity instance.

See issue #194 