### PR TITLE
Fixed multiple v5 regressions

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2293,6 +2293,20 @@ component accessors="true" {
 		return this;
 	}
 
+
+    /**
+	 * If the quickbuilder instance exists return it, else create it, cache it and return it
+	 *
+	 * @return  quick.models.QuickBuilder
+	 */
+	public QuickBuilder function getQuickBuilder() {
+		if(!isDefined('variables._quickBuilder')){
+			variables._quickBuilder = newQuery();
+		}
+
+		return variables._quickBuilder;
+	}
+
 	/**
 	 * Forwards a missing method call on to qb.
 	 *
@@ -2303,7 +2317,8 @@ component accessors="true" {
 	 */
 	private any function forwardToQB( required string missingMethodName, struct missingMethodArguments = {} ) {
 		return invoke(
-			newQuery(),
+            //create the builder instance if it has not be instantiated yet
+			getQuickBuilder(),
 			arguments.missingMethodName,
 			arguments.missingMethodArguments
 		);

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2294,13 +2294,13 @@ component accessors="true" {
 	}
 
 
-    /**
+	/**
 	 * If the quickbuilder instance exists return it, else create it, cache it and return it
 	 *
 	 * @return  quick.models.QuickBuilder
 	 */
 	public QuickBuilder function getQuickBuilder() {
-		if(!isDefined('variables._quickBuilder')){
+		if ( !isDefined( "variables._quickBuilder" ) ) {
 			variables._quickBuilder = newQuery();
 		}
 
@@ -2317,7 +2317,7 @@ component accessors="true" {
 	 */
 	private any function forwardToQB( required string missingMethodName, struct missingMethodArguments = {} ) {
 		return invoke(
-            //create the builder instance if it has not be instantiated yet
+			// create the builder instance if it has not be instantiated yet
 			getQuickBuilder(),
 			arguments.missingMethodName,
 			arguments.missingMethodArguments

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -364,7 +364,7 @@ component accessors="true" {
 			true
 		);
 
-		return this;
+		return getEntity();
 	}
 
 	/**

--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -320,8 +320,8 @@ component accessors="true" {
 	 *
 	 * @return  qb.models.Query.QueryBuilder
 	 */
-	public QuickBuilder function retrieveQuery() {
-		return variables.relationshipBuilder;
+	public any function retrieveQuery() {
+		return variables.relationshipBuilder.retrieveQuery();
 	}
 
 	/**


### PR DESCRIPTION
in reference to issue #198. In the `forwardToQB` method, instead of creating a new quickBuilder each time this method is called cache the builder in the entity. This allows you to correctly chain where clauses. Performance is not impacted as in v4 a quickBuilder was injected into every quick entity class. This will still only instantiate the quick builder when needed

in reference to issue #194. When calling retrieveQuery on a relationship instance the relationshipBuilder is returned directly  instead of calling retrieveQuery on the actual relationshipBuilder instance. 

In addition there is a regression in v5 when calling `.with()` on an entity. In v4 the quick entity is returned whereas in v5 a quickBuilder is returned. This is causing issues as I have my own BaseEntity class which implements additional logic to constrain queries, further breaking method chaining. I solved this by returning the entity instead of the QuickBuidler. This will still work as method calls intended for the quickbuilder will be forwarded onto the quickBuilder in the `onMissingMethod` in the BaseEntity class