### PR TITLE
Proposal to add ability to set default ReturnFormat in coldbox modules.

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -9,6 +9,7 @@ component {
 	function configure() {
 		settings = {
 			"defaultGrammar"        : "AutoDiscover@qb",
+			"defaultReturnFormat"	: "array",
 			"preventDuplicateJoins" : true,
 			"metadataCache"         : {
 				"name"       : "quickMeta",
@@ -44,6 +45,14 @@ component {
 	}
 
 	function onLoad() {
+
+		//bind QuickBuilder model
+		binder
+			.map( alias = "QuickBuilder@quick", force = true )
+			.to( "#moduleMapping#.models.QuickBuilder" )
+			.initArg( name = "defaultReturnFormat", value = settings.defaultReturnFormat );
+
+		//bind QuickQB model
 		binder
 			.map( alias = "QuickQB@quick", force = true )
 			.to( "#moduleMapping#.models.QuickQB" )

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -52,6 +52,13 @@ component {
 			.to( "#moduleMapping#.models.QuickBuilder" )
 			.initArg( name = "defaultReturnFormat", value = settings.defaultReturnFormat );
 
+		//bind CBORMCriteriaBuilderCompat model
+		binder
+			.map( alias = "CBORMCriteriaBuilderCompat@quick", force = true )
+			.to( "#moduleMapping#.models.CBORMCriteriaBuilderCompat" )
+			.initArg( name = "defaultReturnFormat", value = settings.defaultReturnFormat );
+
+
 		//bind QuickQB model
 		binder
 			.map( alias = "QuickQB@quick", force = true )

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1989,7 +1989,6 @@ component accessors="true" {
 		var newBuilder = variables._wirebox
 			.getInstance( "QuickBuilder@quick" )
 			.setEntity( this )
-			.setReturnFormat( "array" )
 			.setDefaultOptions( variables._queryOptions )
 			.from( tableName() )
 			.addSelect( retrieveQualifiedColumns() );

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3031,7 +3031,13 @@ component accessors="true" {
 	 * @return  Boolean
 	 */
 	public boolean function isNullValue( required string key, any value ) {
-		param arguments.value = invoke( this, "get" & arguments.key );
+
+		if(!isDefined('arguments.value')){
+			//if invoke returns an actual null balue to cfparam 'default' argument an exception will be raised
+			//so we use isDefined() instead
+			arguments.value = invoke( this, "get" & arguments.key );
+		}
+
 		if ( isNull( arguments.value ) ) {
 			return true;
 		}

--- a/models/CBORMCompatEntity.cfc
+++ b/models/CBORMCompatEntity.cfc
@@ -159,7 +159,6 @@ component extends="quick.models.BaseEntity" accessors="true" {
 		return variables._wirebox
 			.getInstance( "CBORMCriteriaBuilderCompat@quick" )
 			.setEntity( this )
-			.setReturnFormat( "array" )
 			.setDefaultOptions( variables._queryOptions )
 			.from( tableName() )
 			.addSelect( retrieveQualifiedColumns() );

--- a/models/CBORMCriteriaBuilderCompat.cfc
+++ b/models/CBORMCriteriaBuilderCompat.cfc
@@ -5,11 +5,11 @@ component extends="quick.models.QuickBuilder" accessors="true" {
 
 	property name="entity";
 
-	function init( entity, query ) {
+	function init( entity, query, defaultReturnFormat='array' ) {
 		if ( !isNull( arguments.entity ) ) {
 			variables.entity = arguments.entity;
 		}
-		return super.init();
+		return super.init(defaultReturnFormat);
 	}
 
 	function getSQL() {

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -52,7 +52,7 @@ component accessors="true" {
 	 */
 	this.isQuickBuilder = true;
 
-	function init(defaultReturnFormat) {
+	function init( defaultReturnFormat='array' ) {
 		variables._eagerLoad             = [];
 		variables._globalScopesApplied   = false;
 		variables._asMemento             = false;

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -41,7 +41,7 @@ component accessors="true" {
 	/**
 	 * Default return format to use when calling .retrieveQuery on the qb instance
 	 */
-	property name="_defaultReturnFormat" default="array";	
+	property name="_returnFormat" default="array";	
 
 	property name="_asMemento" default="false";
 	property name="_asMementoSettings";
@@ -52,14 +52,13 @@ component accessors="true" {
 	 */
 	this.isQuickBuilder = true;
 
-
 	function init(defaultReturnFormat) {
 		variables._eagerLoad             = [];
 		variables._globalScopesApplied   = false;
 		variables._asMemento             = false;
 		variables._asMementoSettings     = {};
 		variables._globalScopeExclusions = [];
-		variables._defaultReturnFormat = arguments.defaultReturnFormat;
+		variables._returnFormat = arguments.defaultReturnFormat;
 		return this;
 	}
 
@@ -1103,13 +1102,13 @@ component accessors="true" {
 	 * @return  QuickBuilder
 	 */
 	public any function setReturnFormat(required string format) {
-		variables._defaultReturnFormat = arguments.format;
+		variables._returnFormat = arguments.format;
 		return this;
 	}
 
 
 	public any function retrieveQuery() {
-		variables.qb.setReturnFormat(variables._defaultReturnFormat);
+		variables.qb.setReturnFormat(variables._returnFormat);
 		return variables.qb;
 	}
 

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -38,6 +38,11 @@ component accessors="true" {
 	 */
 	property name="_wirebox" inject="wirebox";
 
+	/**
+	 * Default return format to use when calling .retrieveQuery on the qb instance
+	 */
+	property name="_defaultReturnFormat" default="array";	
+
 	property name="_asMemento" default="false";
 	property name="_asMementoSettings";
 
@@ -47,12 +52,14 @@ component accessors="true" {
 	 */
 	this.isQuickBuilder = true;
 
-	function init() {
+
+	function init(defaultReturnFormat) {
 		variables._eagerLoad             = [];
 		variables._globalScopesApplied   = false;
 		variables._asMemento             = false;
 		variables._asMementoSettings     = {};
 		variables._globalScopeExclusions = [];
+		variables._defaultReturnFormat = arguments.defaultReturnFormat;
 		return this;
 	}
 
@@ -1086,7 +1093,23 @@ component accessors="true" {
 			.from( getEntity().tableName() );
 	}
 
+
+
+	/**
+	 * Sets the returnFormet for retrieveQuery. This will not change the underlying qb instance returnFormat as quick needs this to be an array.
+	 *
+	 * @format The return format. Query or Array.
+	 *
+	 * @return  QuickBuilder
+	 */
+	public any function setReturnFormat(required string format) {
+		variables._defaultReturnFormat = arguments.format;
+		return this;
+	}
+
+
 	public any function retrieveQuery() {
+		variables.qb.setReturnFormat(variables._defaultReturnFormat);
 		return variables.qb;
 	}
 

--- a/tests/resources/app/config/Coldbox.cfc
+++ b/tests/resources/app/config/Coldbox.cfc
@@ -47,7 +47,8 @@
 
 		moduleSettings = {
 			"quick" = {
-				"defaultGrammar" = "MySQLGrammar@qb"
+				"defaultGrammar" = "MySQLGrammar@qb",
+				"defaultReturnFormat" = 'query'
             }
 		};
 

--- a/tests/specs/integration/BaseEntity/RetrieveQuerySpec.cfc
+++ b/tests/specs/integration/BaseEntity/RetrieveQuerySpec.cfc
@@ -1,0 +1,65 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "RetrieveQuery Spec", function() {
+			it( "Can call retrieveQuery and expect a query using default coldbox.cfc settings", function() {
+				var users = getInstance( "User" )
+					.retrieveQuery()
+					.get();
+
+				expect( users ).toBeQuery( "Return format should be a query" );
+				expect( users ).toHaveLength(5);
+			} );
+
+			it( "Can set return format to query and retrieve a query", function() {
+				var users = getInstance( "User" )
+					.setReturnFormat('query')
+					.retrieveQuery()
+					.get();
+
+				expect( users ).toBeQuery( "Return format should be a query" );
+				expect( users ).toHaveLength(5);
+			} );
+
+			it( "Can set return format to array and retrieve a array", function() {
+				var users = getInstance( "User" )
+					.setReturnFormat('array')
+					.retrieveQuery()
+					.get();
+
+				expect( users ).toBeArray( "Return format should be an array" );
+				expect( users ).toHaveLength(5);
+			} );
+
+
+			it( "Can set return format to query and retrieve a quick entity", function() {
+				 //NB! NB! NB!
+				 //This test purposefully calls setReturn format AFTER the where clause
+				var users = getInstance( "User" )
+					.where( "username", "elpete" )
+					.setReturnFormat('query')
+					.get();
+
+				expect( users ).toHaveLength( 1, "One user should be returned." );
+				expect( users[ 1 ].getId() ).toBe( 1 );
+				expect( users[ 1 ].getUsername() ).toBe( "elpete" );
+			});
+
+			it( "Can set return format to array and retrieve a quick entity", function() {
+				 //NB! NB! NB!
+				 //This test purposefully calls setReturn format BEFORE the where clause
+				var users = getInstance( "User" )
+					.setReturnFormat('array')
+					.where( "username", "elpete" )
+					.get();
+
+				expect( users ).toHaveLength( 1, "One user should be returned." );
+				expect( users[ 1 ].getId() ).toBe( 1 );
+				expect( users[ 1 ].getUsername() ).toBe( "elpete" );
+			});
+
+
+		} );
+	}
+
+}


### PR DESCRIPTION
in reference to #186

It seems quick needs to set the underlying qb instance's returnFormat to an `array` to function correctly. Currently you have to call `setReturnFormat()` on each quick instance if you want to retrieve a query. I am proposing the following changes to allow a user to set the default return format in the coldbox.cfc module settings.

The QuickBuilder will now track its own internal returnFormat. When calling retrieveQuery() on an entity it will set the return format for the underlying qb instance before returning it to the user. I also implemented a setReturnFormat() in the QuickBuilder class so this method call is not forwarded onto the QuickQB instance.

Thoughts?