### PR TITLE
Fix a bug when calling isNullValue

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3032,7 +3032,14 @@ component accessors="true" {
 	 * @return  Boolean
 	 */
 	public boolean function isNullValue( required string key, any value ) {
-		param arguments.value = invoke( this, "get" & arguments.key );
+
+		if(!isDefined('arguments.value')){
+			//There is potential for the value of a column to be an actuall null value
+			//We must use isDefined instead of cfparam as returning a null value from invoke
+			//into the 'default' argument of cfparam will raise an exception
+			arguments.value = invoke( this, "get" & arguments.key );
+		}
+
 		if ( isNull( arguments.value ) ) {
 			return true;
 		}


### PR DESCRIPTION
By default when calling `getInstance('entity')` the properties for the given entity will be an actual null value. When retrieve an entity from the database, null fields in the database will be converted to empty strings in the entity.

If you create a new entity and then save it. Any properties that did not have their values set will still be null. This will cause an exception if you then try to retrieve a relationship which has `withDefault()` set. This is caused by cfparam raising an exception if you return null into the 'default' argument.

