### PR TITLE
fixup associativity for nested wheres

### DIFF
--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -617,4 +617,19 @@ component extends="qb.models.Query.QueryBuilder" accessors="true" {
 		return super.onMissingMethod( argumentCollection = arguments );
 	}
 
+	// override's super impl
+	// keep in sync with `super.whereNested`, or merge them somehow
+	public QueryBuilder function whereNested( required callback, combinator = "and" ) {
+        // We descend into a new QueryBuilder, but it is not an isolated thing and requires a fresh context,
+        // but it will by default inherit the current context.
+        // "relevant context" is assumed to be exactly "the available QueryBuilder object", we can push/pop it.
+
+        var query = forNestedWhere();                  // common with super
+		var saved_QB = this.getQuickBuilder().getQB(); // unique to this
+        this.getQuickBuilder().setQB( query );           // unique to this
+        callback( query );                             // common with super
+        this.getQuickBuilder().setQB( saved_QB );        // unique to this
+
+        return addNestedWhereQuery( query, combinator ); // common with super
+    }
 }

--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -188,4 +188,16 @@ component extends="quick.models.BaseEntity" accessors="true" {
 			} );
 	}
 
+	function scopeWithNestedWheresCombinedViaOr( qb ) {
+		qb
+			.orWhere((User) => User.withTwoFlatWheresCombinedViaAnd( "a", "b" ) )
+			.orWhere((User) => User.withTwoFlatWheresCombinedViaAnd( "c", "d" ) )
+    }
+
+    function scopeWithTwoFlatWheresCombinedViaAnd( qb, required string firstName, required string lastName ) {
+        qb
+			.whereFirstName( firstName )
+			.whereLastName( lastName );
+    }
+
 }

--- a/tests/specs/integration/Unitlike.cfc
+++ b/tests/specs/integration/Unitlike.cfc
@@ -1,0 +1,16 @@
+component extends="tests.resources.ModuleIntegrationSpec" appMapping="/app" {
+
+	function run() {
+		describe( "codegen", function() {
+			it( "Nested wheres have the expected associativity", function() {
+                var sql = getInstance( "User" )
+                    .reselect("*")
+                    .withNestedWheresCombinedViaOr()
+                    .toSql();
+
+                expect(sql).toBe("SELECT * FROM `users` WHERE ((`users`.`first_name` = ? AND `users`.`last_name` = ?) OR (`users`.`first_name` = ? AND `users`.`last_name` = ?))")
+			} );
+		} );
+	}
+
+}


### PR DESCRIPTION
`callback(query)` seems like a purely isolated functional thing, but it makes assumptions about its environment, and the existing qb object in the existing environment has where's piled up in it which we don't want to flatten with the nested result. It looks like updating the context (read: the available QB object) during descent into the callback, and then restoring the original context afterwards, keeps the two contexts from flattening their wheres together.

Fixes https://github.com/coldbox-modules/quick/issues/212