### PR TITLE
feat(QuickBuilder): Add support to run QuickBuilder queries as qb queries including eager loading

### DIFF
--- a/extras/QuickCollection.cfc
+++ b/extras/QuickCollection.cfc
@@ -77,7 +77,7 @@ component extends="cfcollection.models.Collection" {
 	 */
 	private void function eagerLoadRelation( required string relationName ) {
 		var relation         = invoke( get( 1 ), arguments.relationName ).resetQuery();
-		var hasMatches       = relation.addEagerConstraints( get() );
+		var hasMatches       = relation.addEagerConstraints( get(), get( 1 ) );
 		variables.collection = relation.match(
 			relation.initRelation( get(), arguments.relationName ),
 			hasMatches ? relation.getEager() : [],

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2643,18 +2643,19 @@ component accessors="true" {
 	 * @return  An attribute struct with all the keys needed.
 	 */
 	private struct function paramAttribute( required struct attr ) {
-		param attr.column         = arguments.attr.name;
-		param attr.persistent     = true;
-		param attr.nullValue      = "";
-		param attr.convertToNull  = true;
-		param attr.casts          = "";
-		param attr.readOnly       = false;
-		param attr.sqltype        = "";
-		param attr.insert         = true;
-		param attr.update         = true;
-		param attr.virtual        = false;
-		param attr.exclude        = false;
-		param attr.isParentColumn = false;
+		param attr.column                  = arguments.attr.name;
+		param attr.persistent              = true;
+		param attr.nullValue               = "";
+		param attr.convertToNull           = true;
+		param attr.casts                   = "";
+		param attr.readOnly                = false;
+		param attr.sqltype                 = "";
+		param attr.insert                  = true;
+		param attr.update                  = true;
+		param attr.virtual                 = false;
+		param attr.exclude                 = false;
+		param attr.isParentColumn          = false;
+		variables._nullValues[ attr.name ] = attr.nullValue;
 		return arguments.attr;
 	}
 
@@ -3095,6 +3096,7 @@ component accessors="true" {
 		if ( !isSimpleValue( arguments.value ) ) {
 			return false;
 		}
+
 		return variables._nullValues.keyExists( alias ) &&
 		compare( variables._nullValues[ alias ], arguments.value ) == 0;
 	}
@@ -3218,6 +3220,12 @@ component accessors="true" {
 		return variables._attributes.keyExists( alias ) &&
 		variables._attributes[ alias ].insert &&
 		!variables._attributes[ alias ].isParentColumn;
+	}
+
+	public boolean function canConvertToNull( required string name ) {
+		var alias = retrieveAliasForColumn( arguments.name );
+		return variables._attributes.keyExists( alias ) &&
+		variables._attributes[ alias ].convertToNull;
 	}
 
 	/**

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -532,8 +532,18 @@ component
 				"cfsqltype" : getEntity().attributeHasSqlType( arguments.column ) ? getEntity().retrieveSqlTypeForAttribute(
 					arguments.column
 				) : ( isNull( arguments.value ) ? "CF_SQL_VARCHAR" : getUtils().inferSqlType( arguments.value ) ),
-				"null"  : isNull( arguments.value ) || getEntity().isNullValue( arguments.column, arguments.value ),
-				"nulls" : isNull( arguments.value ) || getEntity().isNullValue( arguments.column, arguments.value )
+				"null" : isNull( arguments.value ) || (
+					getEntity().canConvertToNull( arguments.column ) && getEntity().isNullValue(
+						arguments.column,
+						arguments.value
+					)
+				),
+				"nulls" : isNull( arguments.value ) || (
+					getEntity().canConvertToNull( arguments.column ) && getEntity().isNullValue(
+						arguments.column,
+						arguments.value
+					)
+				)
 			};
 		} else {
 			return {

--- a/models/Relationships/BelongsToThrough.cfc
+++ b/models/Relationships/BelongsToThrough.cfc
@@ -105,8 +105,12 @@ component extends="quick.models.Relationships.BaseRelationship" {
 	 *
 	 * @return    quick.models.Relationships.BelongsToThrough
 	 */
-	public boolean function addEagerConstraints( required array entities ) {
-		var allKeys = getKeys( entities, variables.closestToParent.getLocalKeys() );
+	public boolean function addEagerConstraints( required array entities, required any baseEntity ) {
+		var allKeys = getKeys(
+			entities,
+			variables.closestToParent.getLocalKeys(),
+			arguments.baseEntity
+		);
 
 		if ( allKeys.isEmpty() ) {
 			return false;
@@ -258,7 +262,12 @@ component extends="quick.models.Relationships.BaseRelationship" {
 	 */
 	public array function initRelation( required array entities, required string relation ) {
 		return arguments.entities.map( function( entity ) {
-			return arguments.entity.assignRelationship( relation, javacast( "null", "" ) );
+			if ( structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+				arguments.entity.assignRelationship( relation, javacast( "null", "" ) );
+			} else {
+				arguments.entity[ relation ] = {};
+			}
+			return arguments.entity;
 		} );
 	}
 

--- a/models/Relationships/HasMany.cfc
+++ b/models/Relationships/HasMany.cfc
@@ -37,7 +37,12 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 	 */
 	public array function initRelation( required array entities, required string relation ) {
 		return arguments.entities.map( function( entity ) {
-			return arguments.entity.assignRelationship( relation, [] );
+			if ( structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+				arguments.entity.assignRelationship( relation, [] );
+			} else {
+				arguments.entity[ relation ] = [];
+			}
+			return arguments.entity;
 		} );
 	}
 

--- a/models/Relationships/HasManyThrough.cfc
+++ b/models/Relationships/HasManyThrough.cfc
@@ -38,7 +38,12 @@ component extends="quick.models.Relationships.HasOneOrManyThrough" {
 	 */
 	public array function initRelation( required array entities, required string relation ) {
 		return arguments.entities.map( function( entity ) {
-			return arguments.entity.assignRelationship( relation, [] );
+			if ( structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+				arguments.entity.assignRelationship( relation, [] );
+			} else {
+				arguments.entity[ relation ] = [];
+			}
+			return arguments.entity;
 		} );
 	}
 
@@ -63,11 +68,17 @@ component extends="quick.models.Relationships.HasOneOrManyThrough" {
 			var key = variables.closestToParent
 				.getLocalKeys()
 				.map( function( localKey ) {
-					return entity.retrieveAttribute( localKey );
+					return structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( localKey ) : entity[
+						localKey
+					];
 				} )
 				.toList();
 			if ( structKeyExists( dictionary, key ) ) {
-				entity.assignRelationship( relation, dictionary[ key ] );
+				if ( structKeyExists( entity, "isQuickEntity" ) ) {
+					entity.assignRelationship( relation, dictionary[ key ] );
+				} else {
+					entity[ relation ] = dictionary[ key ];
+				}
 			}
 		} );
 		return arguments.entities;

--- a/models/Relationships/HasOne.cfc
+++ b/models/Relationships/HasOne.cfc
@@ -57,7 +57,12 @@ component extends="quick.models.Relationships.HasOneOrMany" {
 	 */
 	public array function initRelation( required array entities, required string relation ) {
 		return arguments.entities.map( function( entity ) {
-			return arguments.entity.assignRelationship( relation, javacast( "null", "" ) );
+			if ( structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+				arguments.entity.assignRelationship( relation, javacast( "null", "" ) );
+			} else {
+				arguments.entity[ relation ] = {};
+			}
+			return arguments.entity;
 		} );
 	}
 

--- a/models/Relationships/HasOneOrManyThrough.cfc
+++ b/models/Relationships/HasOneOrManyThrough.cfc
@@ -150,8 +150,12 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	 *
 	 * @return    quick.models.Relationships.HasOneOrManyThrough
 	 */
-	public boolean function addEagerConstraints( required array entities ) {
-		var allKeys = getKeys( entities, variables.closestToParent.getLocalKeys() );
+	public boolean function addEagerConstraints( required array entities, required any baseEntity ) {
+		var allKeys = getKeys(
+			entities,
+			variables.closestToParent.getLocalKeys(),
+			arguments.baseEntity
+		);
 		if ( allKeys.isEmpty() ) {
 			return false;
 		}
@@ -210,7 +214,9 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	 */
 	public struct function buildDictionary( required array results ) {
 		return arguments.results.reduce( function( dict, result ) {
-			var key = result.retrieveAttribute( "__QuickThroughKey__" );
+			var key = structKeyExists( result, "isQuickEntity" ) ? result.retrieveAttribute( "__QuickThroughKey__" ) : result[
+				"__QuickThroughKey__"
+			];
 			if ( !structKeyExists( arguments.dict, key ) ) {
 				arguments.dict[ key ] = [];
 			}

--- a/models/Relationships/HasOneThrough.cfc
+++ b/models/Relationships/HasOneThrough.cfc
@@ -53,7 +53,12 @@ component extends="quick.models.Relationships.HasOneOrManyThrough" {
 	 */
 	public array function initRelation( required array entities, required string relation ) {
 		return arguments.entities.map( function( entity ) {
-			return arguments.entity.assignRelationship( relation, javacast( "null", "" ) );
+			if ( structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+				arguments.entity.assignRelationship( relation, javacast( "null", "" ) );
+			} else {
+				arguments.entity[ relation ] = {};
+			}
+			return arguments.entity;
 		} );
 	}
 

--- a/models/Relationships/IRelationship.cfc
+++ b/models/Relationships/IRelationship.cfc
@@ -15,7 +15,7 @@ interface displayname="IRelationship" {
 	 * @doc_generic  quick.models.BaseEntity
 	 * @return       [quick.models.BaseEntity]
 	 */
-	public array function getEager();
+	public array function getEager( boolean asQuery, boolean withAliases );
 
 	/**
 	 * Gets the first matching record for the relationship.

--- a/models/Relationships/PolymorphicHasMany.cfc
+++ b/models/Relationships/PolymorphicHasMany.cfc
@@ -41,7 +41,12 @@ component extends="quick.models.Relationships.PolymorphicHasOneOrMany" accessors
 	 */
 	public array function initRelation( required array entities, required string relation ) {
 		return arguments.entities.map( function( entity ) {
-			return arguments.entity.assignRelationship( relation, [] );
+			if ( structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+				arguments.entity.assignRelationship( relation, [] );
+			} else {
+				arguments.entity[ relation ] = [];
+			}
+			return arguments.entity;
 		} );
 	}
 

--- a/models/Relationships/PolymorphicHasOneOrMany.cfc
+++ b/models/Relationships/PolymorphicHasOneOrMany.cfc
@@ -82,8 +82,8 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 	 *
 	 * @return    quick.models.Relationships.PolymorphicHasOneOrMany
 	 */
-	public boolean function addEagerConstraints( required array entities ) {
-		if ( !super.addEagerConstraints( arguments.entities ) ) {
+	public boolean function addEagerConstraints( required array entities, required any baseEntity ) {
+		if ( !super.addEagerConstraints( arguments.entities, arguments.baseEntity ) ) {
 			return false;
 		}
 		variables.relationshipBuilder.where( variables.morphType, variables.morphMapping );

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -5,6 +5,7 @@ component {
     this.setClientCookies   = true;
     this.sessionTimeout     = createTimeSpan( 0, 0, 15, 0 );
     this.applicationTimeout = createTimeSpan( 0, 0, 15, 0 );
+    this.timezone = "UTC";
 
     // Turn on/off white space management
 	this.whiteSpaceManagement = "smart";

--- a/tests/resources/app/config/Coldbox.cfc
+++ b/tests/resources/app/config/Coldbox.cfc
@@ -48,7 +48,10 @@
 		moduleSettings = {
 			"quick" = {
 				"defaultGrammar" = "MySQLGrammar@qb"
-            }
+            },
+			"mementifier" = {
+				"convertToTimezone" = "UTC"
+			}
 		};
 
 		// custom settings

--- a/tests/specs/integration/BaseEntity/AsQuerySpec.cfc
+++ b/tests/specs/integration/BaseEntity/AsQuerySpec.cfc
@@ -1,0 +1,106 @@
+component extends="tests.resources.ModuleIntegrationSpec" {
+
+	function run() {
+		describe( "asQuery", function() {
+			it( "can execute a QuickBuilder query as a qb query", function() {
+				var results = getInstance( "User" )
+					.newQuery()
+					.asQuery()
+					.limit( 2 )
+					.get();
+				expect( results ).toBeArray();
+				expect( results ).toHaveLength( 2 );
+				expect( results[ 1 ] ).toBeStruct();
+				expect( results[ 1 ] ).toBe( {
+					"city"            : "Salt Lake City",
+					"countryId"       : "02B84D66-0AA0-F7FB-1F71AFC954843861",
+					"createdDate"     : "2017-07-28 02:06:36",
+					"email"           : "",
+					"externalID"      : "1234",
+					"favoritePost_id" : 1245,
+					"firstName"       : "Eric",
+					"id"              : 1,
+					"lastName"        : "Peterson",
+					"modifiedDate"    : "2017-07-28 02:06:36",
+					"password"        : "5F4DCC3B5AA765D61D8327DEB882CF99",
+					"state"           : "UT",
+					"streetOne"       : "123 Elm Street",
+					"streetTwo"       : "",
+					"teamId"          : 1,
+					"type"            : "admin",
+					"username"        : "elpete",
+					"zip"             : "84123"
+				} );
+				expect( results[ 2 ] ).toBeStruct();
+				expect( results[ 2 ] ).toBe( {
+					"city"            : "Salt Lake City",
+					"countryId"       : "02B84D66-0AA0-F7FB-1F71AFC954843861",
+					"createdDate"     : "2017-07-28 02:07:16",
+					"email"           : "",
+					"externalID"      : "6789",
+					"favoritePost_id" : "",
+					"firstName"       : "John",
+					"id"              : 2,
+					"lastName"        : "Doe",
+					"modifiedDate"    : "2017-07-28 02:07:16",
+					"password"        : "5F4DCC3B5AA765D61D8327DEB882CF99",
+					"state"           : "UT",
+					"streetOne"       : "123 Elm Street",
+					"streetTwo"       : "",
+					"teamId"          : 1,
+					"type"            : "limited",
+					"username"        : "johndoe",
+					"zip"             : "84123"
+				} );
+			} );
+
+			it( "can execute with subselects", function() {
+				var results = getInstance( "User" )
+					.newQuery()
+					.withLatestPostId()
+					.limit( 2 )
+					.asQuery()
+					.get();
+				expect( results ).toBeArray();
+				expect( results ).toHaveLength( 2 );
+				expect( results[ 1 ] ).toBeStruct();
+				expect( results[ 1 ] ).toHaveKey( "latestPostId" );
+				expect( results[ 1 ][ "latestPostId" ] ).toBe( 523526 );
+				expect( results[ 2 ] ).toBeStruct();
+				expect( results[ 2 ] ).toHaveKey( "latestPostId" );
+				expect( results[ 2 ][ "latestPostId" ] ).toBe( "" );
+			} );
+
+			it( "can do eager loading", function() {
+				var results = getInstance( "Post" )
+					.newQuery()
+					.with( [ "author" ] )
+					.asQuery()
+					.get();
+
+				expect( results ).toBeArray();
+				expect( results ).toHaveLength( 4 );
+
+				expect( results[ 1 ] ).toBeStruct();
+				expect( results[ 1 ] ).toHaveKey( "author" );
+				expect( results[ 1 ][ "author" ] ).toHaveKey( "id" );
+				expect( results[ 1 ][ "author" ][ "id" ] ).toBe( 4 );
+
+				expect( results[ 2 ] ).toBeStruct();
+				expect( results[ 2 ] ).toHaveKey( "author" );
+				expect( results[ 2 ][ "author" ] ).toHaveKey( "id" );
+				expect( results[ 2 ][ "author" ][ "id" ] ).toBe( 1 );
+
+				expect( results[ 3 ] ).toBeStruct();
+				expect( results[ 3 ] ).toHaveKey( "author" );
+				expect( results[ 3 ][ "author" ] ).toBeEmpty();
+
+				expect( results[ 4 ] ).toBeStruct();
+				expect( results[ 4 ] ).toHaveKey( "author" );
+				expect( results[ 4 ][ "author" ] ).toHaveKey( "id" );
+				expect( results[ 4 ][ "author" ][ "id" ] ).toBe( 1 );
+			} );
+		} );
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/Relationships/AsQueryEagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/AsQueryEagerLoadingSpec.cfc
@@ -1,0 +1,581 @@
+component extends="tests.resources.ModuleIntegrationSpec" {
+
+	function beforeAll() {
+		super.beforeAll();
+		controller
+			.getInterceptorService()
+			.registerInterceptor( interceptorObject = this, interceptorName = "AsQueryEagerLoadingSpec" );
+	}
+
+	function afterAll() {
+		controller.getInterceptorService().unregister( "AsQueryEagerLoadingSpec" );
+		super.afterAll();
+	}
+
+	function run() {
+		describe( "Eager Loading Spec", function() {
+			beforeEach( function() {
+				variables.queries = [];
+			} );
+
+			it( "can eager load a belongs to relationship", function() {
+				var posts = getInstance( "Post" )
+					.with( "author" )
+					.asQuery()
+					.get();
+				expect( posts ).toBeArray();
+				expect( posts ).toHaveLength( 4, "4 posts should have been loaded" );
+				expect( posts[ 1 ][ "author" ] ).toBeStruct().notToBeEmpty();
+				expect( posts[ 2 ][ "author" ] ).toBeStruct().notToBeEmpty();
+				expect( posts[ 3 ][ "author" ] ).toBeStruct().toBeEmpty();
+				expect( posts[ 4 ][ "author" ] ).toBeStruct().notToBeEmpty();
+				if ( arrayLen( variables.queries ) != 2 ) {
+					expect( variables.queries ).toHaveLength(
+						2,
+						"Only two queries should have been executed. #arrayLen( variables.queries )# were instead."
+					);
+				}
+			} );
+
+			it( "can eager load a belongs to relationship using a composite key", function() {
+				var compositeChildren = getInstance( "CompositeChild" )
+					.with( "parent" )
+					.asQuery()
+					.get();
+				expect( compositeChildren ).toBeArray();
+				expect( compositeChildren ).toHaveLength( 2, "2 entities should have been loaded" );
+				expect( compositeChildren[ 1 ][ "parent" ] ).toBeStruct().notToBeEmpty();
+				expect( compositeChildren[ 1 ][ "parent" ] ).toHaveKey( "a" );
+				expect( compositeChildren[ 1 ][ "parent" ] ).toHaveKey( "b" );
+				expect( compositeChildren[ 1 ][ "parent" ][ "a" ] ).toBe( 1 );
+				expect( compositeChildren[ 1 ][ "parent" ][ "b" ] ).toBe( 2 );
+				expect( compositeChildren[ 2 ][ "parent" ] ).toBeStruct().toBeEmpty();
+
+				if ( arrayLen( variables.queries ) != 2 ) {
+					expect( variables.queries ).toHaveLength(
+						2,
+						"Only two queries should have been executed. #arrayLen( variables.queries )# were instead."
+					);
+				}
+			} );
+
+			it( "does not eager load a belongs to empty record set", function() {
+				var posts = getInstance( "Post" )
+					.whereNull( "createdDate" )
+					.with( "author" )
+					.asQuery()
+					.get();
+				expect( posts ).toBeArray();
+				expect( posts ).toHaveLength( 0, "0 posts should have been loaded" );
+				if ( arrayLen( variables.queries ) != 1 ) {
+					expect( variables.queries ).toHaveLength(
+						1,
+						"Only one query should have been executed. #arrayLen( variables.queries )# were instead."
+					);
+				}
+			} );
+
+			it( "does not eager load a belongs to relationship if there are no foreign keys available", function() {
+				var usersWithoutFavoritePosts = getInstance( "User" )
+					.whereNull( "favoritePost_id" )
+					.with( "favoritePost" )
+					.asQuery()
+					.get();
+				expect( usersWithoutFavoritePosts ).toBeArray();
+				expect( usersWithoutFavoritePosts ).toHaveLength( 4, "4 users should have been loaded" );
+				if ( arrayLen( variables.queries ) != 1 ) {
+					expect( variables.queries ).toHaveLength(
+						1,
+						"Only one query should have been executed. #arrayLen( variables.queries )# were instead."
+					);
+				}
+			} );
+
+			it( "does not eager load a has many empty record set", function() {
+				var users = getInstance( "User" )
+					.whereNull( "createdDate" )
+					.with( "posts" )
+					.asQuery()
+					.get();
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 0, "0 users should have been loaded" );
+				if ( arrayLen( variables.queries ) != 1 ) {
+					expect( variables.queries ).toHaveLength(
+						1,
+						"Only one query should have been executed. #arrayLen( variables.queries )# were instead."
+					);
+				}
+			} );
+
+			it( "can eager load a has many relationship", function() {
+				var users = getInstance( "User" )
+					.with( "posts" )
+					.latest()
+					.asQuery()
+					.get();
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 5, "Five users should be returned" );
+
+				var michaelscott = users[ 1 ];
+				expect( michaelscott[ "username" ] ).toBe( "michaelscott" );
+				expect( michaelscott[ "posts" ] ).toBeArray();
+				expect( michaelscott[ "posts" ] ).toHaveLength( 0, "No posts should belong to michaelscott" );
+
+				var elpete2 = users[ 2 ];
+				expect( elpete2[ "username" ] ).toBe( "elpete2" );
+				expect( elpete2[ "posts" ] ).toBeArray();
+				expect( elpete2[ "posts" ] ).toHaveLength( 1, "One post should belong to elpete2" );
+
+				var janedoe = users[ 3 ];
+				expect( janedoe[ "username" ] ).toBe( "janedoe" );
+				expect( janedoe[ "posts" ] ).toBeArray();
+				expect( janedoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to janedoe" );
+
+				var johndoe = users[ 4 ];
+				expect( johndoe[ "username" ] ).toBe( "johndoe" );
+				expect( johndoe[ "posts" ] ).toBeArray();
+				expect( johndoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to johndoe" );
+
+				var elpete = users[ 5 ];
+				expect( elpete[ "username" ] ).toBe( "elpete" );
+				expect( elpete[ "posts" ] ).toBeArray();
+				expect( elpete[ "posts" ] ).toHaveLength( 2, "Two posts should belong to elpete" );
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "respects other filters on a relationship when eager loading", function() {
+				var users = getInstance( "User" )
+					.with( "publishedPosts" )
+					.latest()
+					.asQuery()
+					.get();
+
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 5, "Five users should be returned" );
+
+				var michaelscott = users[ 1 ];
+				expect( michaelscott[ "username" ] ).toBe( "michaelscott" );
+				expect( michaelscott[ "publishedPosts" ] ).toBeArray();
+				expect( michaelscott[ "publishedPosts" ] ).toHaveLength(
+					0,
+					"No posts should belong to michaelscott. Instead got #arrayLen( michaelscott[ "publishedPosts" ] )#."
+				);
+
+				var elpete2 = users[ 2 ];
+				expect( elpete2[ "username" ] ).toBe( "elpete2" );
+				expect( elpete2[ "publishedPosts" ] ).toBeArray();
+				expect( elpete2[ "publishedPosts" ] ).toHaveLength(
+					1,
+					"One post should belong to elpete2. Instead got #arrayLen( elpete2[ "publishedPosts" ] )#."
+				);
+
+				var janedoe = users[ 3 ];
+				expect( janedoe[ "username" ] ).toBe( "janedoe" );
+				expect( janedoe[ "publishedPosts" ] ).toBeArray();
+				expect( janedoe[ "publishedPosts" ] ).toHaveLength(
+					0,
+					"No posts should belong to janedoe. Instead got #arrayLen( janedoe[ "publishedPosts" ] )#."
+				);
+
+				var johndoe = users[ 4 ];
+				expect( johndoe[ "username" ] ).toBe( "johndoe" );
+				expect( johndoe[ "publishedPosts" ] ).toBeArray();
+				expect( johndoe[ "publishedPosts" ] ).toHaveLength(
+					0,
+					"No posts should belong to johndoe. Instead got #arrayLen( johndoe[ "publishedPosts" ] )#."
+				);
+
+				var elpete = users[ 5 ];
+				expect( elpete[ "username" ] ).toBe( "elpete" );
+				expect( elpete[ "publishedPosts" ] ).toBeArray();
+				expect( elpete[ "publishedPosts" ] ).toHaveLength(
+					1,
+					"One post should belong to elpete. Instead got #arrayLen( elpete[ "publishedPosts" ] )#."
+				);
+
+				expect( variables.queries ).toHaveLength(
+					2,
+					"Only two queries should have been executed. Instead got #variables.queries.len()#."
+				);
+			} );
+
+			it( "can eager load a hasOne relationship", function() {
+				var users = getInstance( "User" )
+					.with( "latestPost" )
+					.latest()
+					.asQuery()
+					.get();
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 5, "Five users should be returned" );
+
+				var michaelscott = users[ 1 ];
+				expect( michaelscott[ "username" ] ).toBe( "michaelscott" );
+				expect( michaelscott[ "latestPost" ] ).toBeStruct().toBeEmpty();
+
+				var elpete2 = users[ 2 ];
+				expect( elpete2[ "username" ] ).toBe( "elpete2" );
+				expect( elpete2[ "latestPost" ] ).toBeStruct().notToBeEmpty();
+
+				var janedoe = users[ 3 ];
+				expect( janedoe[ "username" ] ).toBe( "janedoe" );
+				expect( janedoe[ "latestPost" ] ).toBeStruct().toBeEmpty();
+
+				var johndoe = users[ 4 ];
+				expect( johndoe[ "username" ] ).toBe( "johndoe" );
+				expect( johndoe[ "latestPost" ] ).toBeStruct().toBeEmpty();
+
+				var elpete = users[ 5 ];
+				expect( elpete[ "username" ] ).toBe( "elpete" );
+				expect( elpete[ "latestPost" ] ).toBeStruct().notToBeEmpty();
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "can eager load a belongs to many relationship", function() {
+				var posts = getInstance( "Post" )
+					.with( "tags" )
+					.asQuery()
+					.get();
+				expect( posts ).toBeArray();
+				expect( posts ).toHaveLength( 4 );
+
+				expect( posts[ 1 ][ "tags" ] ).toBeArray();
+				expect( posts[ 1 ][ "tags" ] ).toHaveLength( 0 );
+
+				expect( posts[ 2 ][ "tags" ] ).toBeArray();
+				expect( posts[ 2 ][ "tags" ] ).toHaveLength( 2 );
+				expect( posts[ 2 ][ "tags" ][ 1 ][ "name" ] ).toBe( "programming" );
+				expect( posts[ 2 ][ "tags" ][ 2 ][ "name" ] ).toBe( "music" );
+
+				expect( posts[ 3 ][ "tags" ] ).toBeArray();
+				expect( posts[ 3 ][ "tags" ] ).toHaveLength( 0 );
+
+				expect( posts[ 4 ][ "tags" ] ).toBeArray();
+				expect( posts[ 4 ][ "tags" ] ).toHaveLength( 2 );
+				expect( posts[ 4 ][ "tags" ][ 1 ][ "name" ] ).toBe( "programming" );
+				expect( posts[ 4 ][ "tags" ][ 2 ][ "name" ] ).toBe( "music" );
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "can eager load a has many through relationship", function() {
+				var countries = getInstance( "Country" )
+					.with( "posts" )
+					.asQuery()
+					.get();
+				expect( countries ).toBeArray();
+				expect( countries ).toHaveLength( 2 );
+
+				expect( countries[ 1 ][ "posts" ] ).toBeArray();
+				expect( countries[ 1 ][ "posts" ] ).toHaveLength( 2 );
+				expect( countries[ 1 ][ "posts" ][ 1 ][ "body" ] ).toBe( "My awesome post body" );
+				expect( countries[ 1 ][ "posts" ][ 2 ][ "body" ] ).toBe( "My second awesome post body" );
+
+				expect( countries[ 2 ][ "posts" ] ).toBeArray();
+				expect( countries[ 2 ][ "posts" ] ).toHaveLength( 1 );
+				expect( countries[ 2 ][ "posts" ][ 1 ][ "body" ] ).toBe( "My post with a different author" );
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "can eager load a long has many through relationship", function() {
+				var countries = getInstance( "Country" )
+					.with( "comments" )
+					.asQuery()
+					.get();
+				expect( countries ).toBeArray();
+				expect( countries ).toHaveLength( 2 );
+
+				expect( countries[ 1 ][ "comments" ] ).toBeArray();
+				expect( countries[ 1 ][ "comments" ] ).toHaveLength( 1 );
+				expect( countries[ 1 ][ "comments" ][ 1 ][ "body" ] ).toBe( "I thought this post was great" );
+
+				expect( countries[ 2 ][ "comments" ] ).toBeArray();
+				expect( countries[ 2 ][ "comments" ] ).toHaveLength( 1 );
+				expect( countries[ 2 ][ "comments" ][ 1 ][ "body" ] ).toBe( "I thought this post was not so good" );
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "can eager load a recursive has many through relationship", function() {
+				var countries = getInstance( "Country" )
+					.with( "commentsUsingHasManyThrough" )
+					.asQuery()
+					.get();
+				expect( countries ).toBeArray();
+				expect( countries ).toHaveLength( 2 );
+
+				expect( countries[ 1 ][ "commentsUsingHasManyThrough" ] ).toBeArray();
+				expect( countries[ 1 ][ "commentsUsingHasManyThrough" ] ).toHaveLength( 1 );
+				expect( countries[ 1 ][ "commentsUsingHasManyThrough" ][ 1 ][ "body" ] ).toBe(
+					"I thought this post was great"
+				);
+
+				expect( countries[ 2 ][ "commentsUsingHasManyThrough" ] ).toBeArray();
+				expect( countries[ 2 ][ "commentsUsingHasManyThrough" ] ).toHaveLength( 1 );
+				expect( countries[ 2 ][ "commentsUsingHasManyThrough" ][ 1 ][ "body" ] ).toBe(
+					"I thought this post was not so good"
+				);
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "can eager load polymorphic belongs to relationships", function() {
+				var comments = getInstance( "Comment" )
+					.where( "designation", "public" )
+					.with( "commentable" )
+					.asQuery()
+					.get();
+
+				expect( comments ).toBeArray();
+				expect( comments ).toHaveLength( 3 );
+
+				expect( comments[ 1 ][ "id" ] ).toBe( 1 );
+				expect( comments[ 1 ][ "commentable" ] ).toHaveKey( "body", "Post entities should have a body key" );
+				expect( comments[ 1 ][ "commentable" ][ "post_pk" ] ).toBe( 1245 );
+
+				expect( comments[ 2 ][ "id" ] ).toBe( 2 );
+				expect( comments[ 2 ][ "commentable" ] ).toHaveKey( "body", "Post entities should have a body key" );
+				expect( comments[ 2 ][ "commentable" ][ "post_pk" ] ).toBe( 321 );
+
+				expect( comments[ 3 ][ "id" ] ).toBe( 3 );
+				expect( comments[ 3 ][ "commentable" ] ).toHaveKey( "url", "Video entities should have a url key" );
+				expect( comments[ 3 ][ "commentable" ][ "id" ] ).toBe( 1245 );
+
+				expect( variables.queries ).toHaveLength( 3, "Only three queries should have been executed." );
+			} );
+
+			it( "can eager load polymorphic has many relationships", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
+				variables.queries = [];
+
+				var posts = getInstance( "Post" )
+					.with( "comments" )
+					.asQuery()
+					.get();
+
+				expect( posts ).toBeArray();
+				expect( posts ).toHaveLength( 4 );
+
+				expect( posts[ 1 ][ "comments" ] ).toBeArray();
+				expect( posts[ 1 ][ "comments" ] ).toHaveLength( 1 );
+
+				expect( posts[ 2 ][ "comments" ] ).toBeArray();
+				expect( posts[ 2 ][ "comments" ] ).toHaveLength( 1 );
+
+				expect( posts[ 3 ][ "comments" ] ).toBeArray();
+				expect( posts[ 3 ][ "comments" ] ).toBeEmpty();
+
+				expect( posts[ 4 ][ "comments" ] ).toBeArray();
+				expect( posts[ 4 ][ "comments" ] ).toBeEmpty();
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "can eager load a nested relationship", function() {
+				// delete our internal comments to allow the test to pass:
+				getInstance( "InternalComment" )
+					.get()
+					.each( function( comment ) {
+						comment.delete();
+					} );
+				variables.queries = [];
+				var users         = getInstance( "User" )
+					.with( "posts.comments" )
+					.latest()
+					.asQuery()
+					.get();
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 5, "Five users should be returned" );
+
+				var michaelscott = users[ 1 ];
+				expect( michaelscott[ "username" ] ).toBe( "michaelscott" );
+				expect( michaelscott[ "posts" ] ).toBeArray();
+				expect( michaelscott[ "posts" ] ).toHaveLength( 0, "No posts should belong to michaelscott" );
+
+				var elpete2 = users[ 2 ];
+				expect( elpete2[ "username" ] ).toBe( "elpete2" );
+				expect( elpete2[ "posts" ] ).toBeArray();
+				expect( elpete2[ "posts" ] ).toHaveLength( 1, "One post should belong to elpete2" );
+
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ] ).toBeArray();
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ] ).toHaveLength( 1 );
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ][ 1 ][ "id" ] ).toBe( 2 );
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ][ 1 ][ "body" ] ).toBe(
+					"I thought this post was not so good"
+				);
+
+				var janedoe = users[ 3 ];
+				expect( janedoe[ "username" ] ).toBe( "janedoe" );
+				expect( janedoe[ "posts" ] ).toBeArray();
+				expect( janedoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to janedoe" );
+
+				var johndoe = users[ 4 ];
+				expect( johndoe[ "username" ] ).toBe( "johndoe" );
+				expect( johndoe[ "posts" ] ).toBeArray();
+				expect( johndoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to johndoe" );
+
+				var elpete = users[ 5 ];
+				expect( elpete[ "username" ] ).toBe( "elpete" );
+
+				expect( elpete[ "posts" ] ).toBeArray();
+				expect( elpete[ "posts" ] ).toHaveLength( 2, "Two posts should belong to elpete" );
+
+				expect( elpete[ "posts" ][ 1 ][ "post_pk" ] ).toBe( 523526 );
+				expect( elpete[ "posts" ][ 1 ][ "comments" ] ).toBeArray();
+				expect( elpete[ "posts" ][ 1 ][ "comments" ] ).toBeEmpty();
+
+				expect( elpete[ "posts" ][ 2 ][ "post_pk" ] ).toBe( 1245 );
+				expect( elpete[ "posts" ][ 2 ][ "comments" ] ).toBeArray();
+				expect( elpete[ "posts" ][ 2 ][ "comments" ] ).toHaveLength( 1 );
+				expect( elpete[ "posts" ][ 2 ][ "comments" ][ 1 ][ "id" ] ).toBe( 1 );
+				expect( elpete[ "posts" ][ 2 ][ "comments" ][ 1 ][ "body" ] ).toBe( "I thought this post was great" );
+
+				expect( variables.queries ).toHaveLength( 3, "Only three queries should have been executed." );
+			} );
+
+			it( "can constrain eager loading on a belongs to relationship", function() {
+				var users = getInstance( "User" )
+					.with( {
+						"posts" : function( query ) {
+							return query.where( "post_pk", "<", 7777 );
+						}
+					} )
+					.latest()
+					.asQuery()
+					.get();
+
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 5, "Five users should be returned" );
+
+				var michaelscott = users[ 1 ];
+				expect( michaelscott[ "username" ] ).toBe( "michaelscott" );
+				expect( michaelscott[ "posts" ] ).toBeArray();
+				expect( michaelscott[ "posts" ] ).toHaveLength( 0, "No posts should belong to michaelscott" );
+
+				var janedoe = users[ 3 ];
+				expect( janedoe[ "username" ] ).toBe( "janedoe" );
+				expect( janedoe[ "posts" ] ).toBeArray();
+				expect( janedoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to janedoe" );
+
+				var johndoe = users[ 4 ];
+				expect( johndoe[ "username" ] ).toBe( "johndoe" );
+				expect( johndoe[ "posts" ] ).toBeArray();
+				expect( johndoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to johndoe" );
+
+				var elpete = users[ 5 ];
+				expect( elpete[ "username" ] ).toBe( "elpete" );
+				expect( elpete[ "posts" ] ).toBeArray();
+				expect( elpete[ "posts" ] ).toHaveLength( 1, "One post should belong to elpete" );
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "can constrain an eager load on a nested relationship", function() {
+				var users = getInstance( "User" )
+					.with( {
+						"posts" : function( q1 ) {
+							return q1.with( {
+								"comments" : function( q2 ) {
+									return q2.where( "body", "like", "%not%" );
+								}
+							} );
+						}
+					} )
+					.latest()
+					.asQuery()
+					.get();
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 5, "Five users should be returned" );
+
+				var michaelscott = users[ 1 ];
+				expect( michaelscott[ "username" ] ).toBe( "michaelscott" );
+				expect( michaelscott[ "posts" ] ).toBeArray();
+				expect( michaelscott[ "posts" ] ).toHaveLength( 0, "No posts should belong to michaelscott" );
+
+				var elpete2 = users[ 2 ];
+				expect( elpete2[ "username" ] ).toBe( "elpete2" );
+				expect( elpete2[ "posts" ] ).toBeArray();
+				expect( elpete2[ "posts" ] ).toHaveLength( 1, "One post should belong to elpete2" );
+
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ] ).toBeArray();
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ] ).toHaveLength( 1 );
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ][ 1 ][ "id" ] ).toBe( 2 );
+				expect( elpete2[ "posts" ][ 1 ][ "comments" ][ 1 ][ "body" ] ).toBe(
+					"I thought this post was not so good"
+				);
+
+				var janedoe = users[ 3 ];
+				expect( janedoe[ "username" ] ).toBe( "janedoe" );
+				expect( janedoe[ "posts" ] ).toBeArray();
+				expect( janedoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to janedoe" );
+
+				var johndoe = users[ 4 ];
+				expect( johndoe[ "username" ] ).toBe( "johndoe" );
+				expect( johndoe[ "posts" ] ).toBeArray();
+				expect( johndoe[ "posts" ] ).toHaveLength( 0, "No posts should belong to johndoe" );
+
+				var elpete = users[ 5 ];
+				expect( elpete[ "username" ] ).toBe( "elpete" );
+				expect( elpete[ "posts" ] ).toBeArray();
+				expect( elpete[ "posts" ] ).toHaveLength( 2, "Two posts should belong to elpete" );
+
+				expect( elpete[ "posts" ][ 1 ][ "post_pk" ] ).toBe( 523526 );
+				expect( elpete[ "posts" ][ 1 ][ "comments" ] ).toBeArray();
+				expect( elpete[ "posts" ][ 1 ][ "comments" ] ).toBeEmpty();
+
+				expect( elpete[ "posts" ][ 2 ][ "post_pk" ] ).toBe( 1245 );
+				expect( elpete[ "posts" ][ 2 ][ "comments" ] ).toBeArray();
+				expect( elpete[ "posts" ][ 2 ][ "comments" ] ).toBeEmpty();
+
+				expect( variables.queries ).toHaveLength( 3, "Only three queries should have been executed." );
+			} );
+
+			it( "can eager load a find or first call", function() {
+				var post = getInstance( "Post" )
+					.with( "comments.author" )
+					.asQuery()
+					.findOrFail( 1245 );
+				expect( post ).toBeStruct().toHaveKey( "comments" );
+				var comments = post[ "comments" ];
+				expect( comments ).toHaveLength( 2 );
+				for ( var comment in comments ) {
+					expect( comment ).toHaveKey( "author" );
+					expect( comment[ "author" ] ).toBeStruct().notToBeEmpty();
+				}
+				if ( arrayLen( variables.queries ) != 3 ) {
+					expect( variables.queries ).toHaveLength(
+						3,
+						"Only three queries should have been executed. #arrayLen( variables.queries )# were instead."
+					);
+				}
+			} );
+
+			it( "can eager load in a relationship", function() {
+				expect( function() {
+					var result = getInstance( "RMME_A" )
+						.with( "B" )
+						.asQuery()
+						.get();
+				} ).notToThrow();
+			} );
+		} );
+	}
+
+	function preQBExecute(
+		event,
+		interceptData,
+		buffer,
+		rc,
+		prc
+	) {
+		arrayAppend( variables.queries, interceptData );
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/Relationships/RelationshipLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/RelationshipLoadingSpec.cfc
@@ -31,7 +31,6 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				elpete.loadRelationship( "posts" );
 				elpete.loadRelationship( "posts" );
 				expect( elpete.isRelationshipLoaded( "posts" ) ).toBeTrue();
-				debug( variables.queries );
 				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed" );
 			} );
 
@@ -41,7 +40,6 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				elpete.forceLoadRelationship( "posts" );
 				elpete.forceLoadRelationship( "posts" );
 				expect( elpete.isRelationshipLoaded( "posts" ) ).toBeTrue();
-				debug( variables.queries );
 				expect( variables.queries ).toHaveLength( 3, "Only three queries should have been executed" );
 			} );
 		} );


### PR DESCRIPTION
Using a new `asQuery` helper method, Quick can bypass creating entities at all. This includes eager loading of relationships into keys in the returned structs.