### PR TITLE
Add test for global scope not being invoked on relationship-as-query

### DIFF
--- a/tests/resources/app/models/PostWithGlobalScope.cfc
+++ b/tests/resources/app/models/PostWithGlobalScope.cfc
@@ -1,0 +1,10 @@
+component table="my_posts" extends="Post" accessors="true" {
+
+    function scopeWithAuthorLastName( qb ) {
+        qb.addSubselect( "authorLastName", "author.lastname" );
+    }       
+
+    function applyGlobalScopes( qb ) {
+        qb.withAuthorLastName();
+    }
+}

--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -152,6 +152,10 @@ component extends="quick.models.BaseEntity" accessors="true" {
 		return hasMany( "Post", "user_id" ).latest();
 	}
 
+	function postsWithGlobalScope() {
+		return hasMany( "PostWithGlobalScope", "user_id" );
+	}
+
 	function publishedPosts() {
 		return hasMany( "Post", "user_id" ).whereNotNull( "published_date" );
 	}

--- a/tests/specs/integration/BaseEntity/GlobalScopeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GlobalScopeSpec.cfc
@@ -37,24 +37,34 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 			it( "applies global scopes to relationships", function() {
 				var user = getInstance( "User" ).find( 1 );
-				var post = user.postsWithGlobalScope().first().getMemento();
+				var post = user
+					.postsWithGlobalScope()
+					.first()
+					.getMemento();
 				expect( post ).toHaveKey( "authorLastName" );
 				expect( len( post.authorLastName ) ).toBeGT( 0 );
-			});
+			} );
 
 			it( "can apply scopes to relationships if they are retrieved as queries", function() {
 				var user = getInstance( "User" ).find( 1 );
-				var post = user.postsWithGlobalScope().withAuthorLastName().retrieveQuery().first();
+				var post = user
+					.postsWithGlobalScope()
+					.withAuthorLastName()
+					.retrieveQuery()
+					.first();
 				expect( post ).toHaveKey( "authorLastName" );
 				expect( len( post.authorLastName ) ).toBeGT( 0 );
-			})
+			} )
 
 			it( "applies global scopes to relationships if they are retrieved as queries", function() {
 				var user = getInstance( "User" ).find( 1 );
-				var post = user.postsWithGlobalScope().retrieveQuery().first();
+				var post = user
+					.postsWithGlobalScope()
+					.retrieveQuery()
+					.first();
 				expect( post ).toHaveKey( "authorLastName" );
 				expect( len( post.authorLastName ) ).toBeGT( 0 );
-			});
+			} );
 
 
 			it( "applies global scopes when calling fresh", function() {

--- a/tests/specs/integration/BaseEntity/GlobalScopeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GlobalScopeSpec.cfc
@@ -35,6 +35,28 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( admins[ 2 ].id ).toBe( 4 );
 			} );
 
+			it( "applies global scopes to relationships", function() {
+				var user = getInstance( "User" ).find( 1 );
+				var post = user.postsWithGlobalScope().first().getMemento();
+				expect( post ).toHaveKey( "authorLastName" );
+				expect( len( post.authorLastName ) ).toBeGT( 0 );
+			});
+
+			it( "can apply scopes to relationships if they are retrieved as queries", function() {
+				var user = getInstance( "User" ).find( 1 );
+				var post = user.postsWithGlobalScope().withAuthorLastName().retrieveQuery().first();
+				expect( post ).toHaveKey( "authorLastName" );
+				expect( len( post.authorLastName ) ).toBeGT( 0 );
+			})
+
+			it( "applies global scopes to relationships if they are retrieved as queries", function() {
+				var user = getInstance( "User" ).find( 1 );
+				var post = user.postsWithGlobalScope().retrieveQuery().first();
+				expect( post ).toHaveKey( "authorLastName" );
+				expect( len( post.authorLastName ) ).toBeGT( 0 );
+			});
+
+
 			it( "applies global scopes when calling fresh", function() {
 				var user = getInstance( "UserWithGlobalScope" ).findOrFail( 1 );
 				expect( user.getUsername() ).toBe( "elpete" );


### PR DESCRIPTION
Global scopes are invoked on relationships. 

Global scopes are invoked on entities loaded with `.retrieveQuery()` 

Global scopes are not invoked on entity relationships loaded with `.retrieveQuery()` (`User.posts().retrieveQuery().get()`)

This PR adds a test demonstrating this to `GlobalScopeSpec.cfc`

Relates to https://github.com/coldbox-modules/quick/issues/221