### PR TITLE
feat(QuickBuilder): Allow for cloning of QuickBuilder instances

### DIFF
--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1091,7 +1091,7 @@ component accessors="true" transientCache="false" {
 	 * @returns  quick.models.BaseEntity
 	 */
 	public any function resetQuery() {
-		variables.qb = newQuery();
+		variables.qb = newQuickQB();
 		return this;
 	}
 
@@ -1116,6 +1116,15 @@ component accessors="true" transientCache="false" {
 	 * @return  quick.models.QuickBuilder
 	 */
 	public any function newQuery() {
+		return variables._wirebox.getInstance( "QuickBuilder@quick" ).setEntity( getEntity() );
+	}
+
+	/**
+	 * Configures a new query builder and returns it.
+	 *
+	 * @return  quick.models.QuickQB
+	 */
+	public any function newQuickQB() {
 		return variables._wirebox
 			.getInstance( "QuickQB@quick" )
 			.setQuickBuilder( this )
@@ -1212,6 +1221,21 @@ component accessors="true" transientCache="false" {
 		}
 		variables._asMemento = false;
 		return this;
+	}
+
+	public QuickBuilder function clone() {
+		var newBuilder = newQuery();
+		newBuilder.setQB( variables.qb.clone() );
+		newBuilder.set_applyingGlobalScopes( this.get_applyingGlobalScopes() );
+		newBuilder.set_globalScopesApplied( this.get_globalScopesApplied() );
+		newBuilder.set_globalScopeExcludeAll( this.get_globalScopeExcludeAll() );
+		newBuilder.set_globalScopeExclusions( this.get_globalScopeExclusions() );
+		newBuilder.set_eagerLoad( this.get_eagerLoad() );
+		newBuilder.set_asQuery( this.get_asQuery() );
+		newBuilder.set_withAliases( this.get_withAliases() );
+		newBuilder.set_asMemento( this.get_asMemento() );
+		newBuilder.set_asMementoSettings( this.get_asMementoSettings() );
+		return newBuilder;
 	}
 
 	/**

--- a/tests/specs/integration/BaseEntity/CloneSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CloneSpec.cfc
@@ -25,6 +25,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var clonedUser = user.clone( markLoaded = true );
 				expect( clonedUser.isLoaded() ).toBeTrue( "The cloned user instance should be marked as loaded, but was not." );
 			} );
+
+			it( "can clone a QuickBuilder instance", function() {
+				var userBuilder  = getInstance( "User" ).orderBy( "id" );
+				var userBuilder2 = userBuilder.clone();
+				userBuilder2.clearOrders();
+				expect( userBuilder.getOrders() ).toBe( [
+					{
+						"column"    : "users.id",
+						"direction" : "asc"
+					}
+				] );
+				expect( userBuilder2.getOrders() ).toBe( [] );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Previously, this forwarded to qb but saved the cloned instance in the QuickBuilder, so nothing really changed.

BREAKING CHANGE: `newQuery` now returns a QuickBuilder instance instead of a QuickQB instance. To retrieve a QuickQB instance, use `newQuickQB`.