### PR TITLE
Fixed issue where virtualAttributes were not being applied to discriminated child entities when loading through the parent

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1152,7 +1152,11 @@ component accessors="true" {
 		fireEvent( "postSave", { entity : this } );
 
 		// re-cast
-		populateAttributes( variables._castCache );
+		for ( var key in variables._castCache) {
+			var castedValue = castValueForGetter( key, variables._castCache[ key ], true );
+			variables._data[ retrieveColumnForAlias( key ) ] = castedValue;
+			variables[ retrieveAliasForColumn( key ) ] = castedValue;
+		}
 
 		return this;
 	}
@@ -3121,10 +3125,10 @@ component accessors="true" {
 	 *
 	 * @return  any
 	 */
-	private any function castValueForGetter( required string key, any value ) {
+	private any function castValueForGetter( required string key, any value, boolean forceCast = false ) {
 		arguments.key = retrieveAliasForColumn( arguments.key );
 
-		if ( structKeyExists( variables._castCache, arguments.key ) ) {
+		if ( structKeyExists( variables._castCache, arguments.key )  AND !arguments.forceCast ) {
 			return variables._castCache[ arguments.key ];
 		}
 

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -173,6 +173,13 @@ component accessors="true" {
 	 */
 	property name="_withoutFiringEvents" persistent="false";
 
+
+	/**
+	 * An array of virtual attribute key names that have been add to this entity
+	 */
+	property name="_virtualAttributes" persistent="false"; 
+
+
 	/**
 	 * A boolean flag indicating that the entity has been loaded from the database.
 	 */
@@ -242,6 +249,7 @@ component accessors="true" {
 		param variables._queryOptions             = {};
 		param variables._attributes               = {};
 		param variables._columns                  = {};
+		param variables._virtualAttributes        = [];
 		variables._saving                         = false;
 		return this;
 	}
@@ -2617,6 +2625,7 @@ component accessors="true" {
 			variables._columns[ attr.column ]            = attr;
 			variables._meta.attributes[ arguments.name ] = variables._attributes[ arguments.name ];
 			variables._meta.originalMetadata.properties.append( variables._attributes[ arguments.name ] );
+			variables._virtualAttributes.append( arguments.name );
 		}
 		return this;
 	}

--- a/models/Casts/JsonCast.cfc
+++ b/models/Casts/JsonCast.cfc
@@ -15,8 +15,8 @@ component singleton {
 		any value
 	) {
 
-		if( isStruct( arguments.value ) ){
-			return arguments.value
+		if( !isJSON(arguments.value) ){
+			return arguments.value;
 		}
 
 		if ( isNull( arguments.value ) ) {

--- a/models/Casts/JsonCast.cfc
+++ b/models/Casts/JsonCast.cfc
@@ -15,19 +15,16 @@ component singleton {
 		any value
 	) {
 
-		if( !isJSON(arguments.value) ){
-			return arguments.value;
-		}
-
 		if ( isNull( arguments.value ) ) {
 			return javacast( "null", "" );
 		}
 
-		if ( arguments.value == "" ) {
-			return "";
+		if( isJSON( arguments.value ) ){
+			return deserializeJSON( arguments.value );
 		}
 
-		return deserializeJSON( arguments.value );
+		return arguments.value;
+
 	}
 
 	/**

--- a/models/Casts/JsonCast.cfc
+++ b/models/Casts/JsonCast.cfc
@@ -14,6 +14,11 @@ component singleton {
 		required string key,
 		any value
 	) {
+
+		if( isStruct( arguments.value ) ){
+			return arguments.value
+		}
+
 		if ( isNull( arguments.value ) ) {
 			return javacast( "null", "" );
 		}

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1233,13 +1233,11 @@ component accessors="true" transientCache="false" {
 				childClass.appendVirtualAttribute( item );
 			} );
 
-			getEntity()
-				.keyNames()
-				.each( function( key, i ) {
-					data[ childClass.keyNames()[ i ] ] = data[ key ];
-				} );
+			return childClass				
+				.assignAttributesData( arguments.data )
+				.assignOriginalAttributes( arguments.data )
+				.markLoaded();
 
-			return childClass.hydrate( arguments.data, true );
 		} else {
 			return getEntity()
 				.newEntity()

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1228,6 +1228,11 @@ component accessors="true" transientCache="false" {
 				].mapping
 			);
 
+			//add any virtual attributes present in the parent entity to child entity
+			getEntity().get_virtualAttributes().each( function( item ) {
+				childClass.appendVirtualAttribute( item );
+			} );
+
 			getEntity()
 				.keyNames()
 				.each( function( key, i ) {

--- a/tests/resources/app/models/Comment.cfc
+++ b/tests/resources/app/models/Comment.cfc
@@ -11,10 +11,12 @@ component
     property name="userId" column="user_id";
     property name="createdDate" column="created_date";
     property name="modifiedDate" column="modified_date";
+    property name="sentimentAnalysis" casts="JsonCast@quick";
 
     variables._discriminators = [
         "InternalComment"
     ];
+
 
     function commentable() {
         return polymorphicBelongsTo( "commentable" );

--- a/tests/resources/app/models/Comment.cfc
+++ b/tests/resources/app/models/Comment.cfc
@@ -28,4 +28,10 @@ component
         return hasManyThrough( [ "commentable", "tags" ] );
     }
 
+    // chose this sql function as it present in both mysql and sql server
+    function scopeAddUpperBody(qb){
+        qb.selectRaw( "UPPER(body) as upperBody" );
+        appendVirtualAttribute( "upperBody" );        
+    }
+
 }

--- a/tests/resources/database/migrations/2023_10_25_102757_add_comment_column.cfc
+++ b/tests/resources/database/migrations/2023_10_25_102757_add_comment_column.cfc
@@ -1,0 +1,23 @@
+component {
+
+    function up( schema, query ) {
+
+        var defaultJson = '{ "analyzed": true, "magnitude": 0.8, "score": 0.6  }';
+
+        schema.alter( "comments", function( table ) {
+            table.addColumn( table.string( "sentimentAnalysis" ).nullable() );
+        } );
+
+
+        query.from( "comments" )
+            .update( {  "sentimentAnalysis" = defaultJson } );
+
+    }
+
+    function down( schema, query ) {
+        schema.alter( "comments", function( table ) {
+            table.dropColumn( "sentimentAnalysis" );
+        } );
+    }
+
+}

--- a/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
@@ -98,6 +98,21 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 			} );
 
+			it( "will recast after saving entity", function() {
+				var pn = getInstance( "PhoneNumber" ).find(1);
+				pn.setNumber( "111-111-1111" );
+				pn.setActive( "0" );
+
+				expect( pn.getActive() ).toBe( "0" );
+				expect( pn.getActive() ).toBeNumeric();
+ 
+				pn.save();
+
+				expect( pn.getActive() ).toBe( false ); 
+				expect( pn.getActive() ).toBeBoolean();
+
+			} );
+
 		} );
 	}
 

--- a/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
@@ -84,6 +84,20 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					pn.update( { "active" : false } );
 				} ).notToThrow( message = "PhoneNumber should be able to be saved with a `null` [confirmed] value" );
 			} );
+
+			it( "can maintain casts when loading a discriminated child through the parent", () => {
+				var comment = getInstance( "Comment" )
+					.where('designation', 'internal')
+					.first();
+
+				expect( comment.getSentimentAnalysis() ).notToBeNull();
+				expect( comment.getSentimentAnalysis() ).toBeStruct();
+				expect( comment.getSentimentAnalysis() ).toHaveKey( "analyzed" );
+				expect( comment.getSentimentAnalysis() ).toHaveKey( "magnitude" );
+				expect( comment.getSentimentAnalysis() ).toHaveKey( "score" );
+
+			} );
+
 		} );
 	}
 

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -330,6 +330,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					expect( comment.isNullAttribute( "reason" ) ).toBeFalse( "The reason field should not be null." );
 				} );
 			} );
+
+
+			it( "Will maintain virtual attributes in the child class when fetching results from the parent class", function() {
+				var comment = getInstance( "Comment" )
+					.addUpperBody()
+					.where( "designation", "internal" )
+					.get()[1]
+
+				expect( comment.hasAttribute( "upperBody" ) ).toBeTrue(
+					"Child class should have a virtual attribute 'upperBody'."
+				);
+			} );
+
 		} );
 
 		describe( "Single Table Inheritence Class Spec", function() {


### PR DESCRIPTION
If you add a virtual attribute to a parent entity and load a discriminated child entity through that parent entity. The virtual attributes will not be applied to the child entity as quick will load a new instance of the child class and then use `hydrate()` to populate the entity. I fixed this by checking if the parent entity has any virtual attributes and then manually calling `appendVirtualAttribute`  on the child class.

Additionally, thinking in terms of performance I cached the key name of all virtual entities in a new property called `_virtualAttributes`. This would eliminate the overhead (albeit a tiny one)  of looping through all the attributes in the parent entity to check if it is a virtual attribute.