### PR TITLE
Update HasOneOrMany Relationship Class to Allow Returning a New Entity

### DIFF
--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -317,9 +317,20 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	 * @return      quick.models.BaseEntity
 	 */
 	public any function create( struct attributes = {} ) {
-		var newInstance = variables.related.newEntity().fill( arguments.attributes );
+		return newEntity()
+			.fill( arguments.attributes )
+			.save();
+	}
+
+	/**
+	 * Returns a new instance of the entity, pre-associated to the parent entity. Does not persist it.
+	 *
+	 * @return      quick.models.BaseEntity
+	 */
+	public any function newEntity() {
+		var newInstance = variables.related.newEntity();
 		setForeignAttributesForCreate( newInstance );
-		return newInstance.save();
+		return newInstance;
 	}
 
 	/**


### PR DESCRIPTION
Being able to create a new `HasOneOrMany` relationship entity is great, but sometimes you need access to the new entity before persistence.  Adding a `newEntity()` method gives additional flexibility and also plays nicely with other relationship types.

Additionally, being able to call something like `prc.post.postCategories().newEntity()` is much cleaner than using the current workaround, which is `prc.post.postCategories().getRelated().newEntity()`