### PR TITLE
Fixed issue with NULL values being inserted into identity columns for MSSQL

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -174,7 +174,7 @@ component accessors="true" {
 	/**
 	 * An array of virtual attribute key names that have been add to this entity
 	 */
-	property name="_virtualAttributes" persistent="false"; 
+	property name="_virtualAttributes" persistent="false";
 
 
 	/**
@@ -1166,10 +1166,14 @@ component accessors="true" {
 		fireEvent( "postSave", { entity : this } );
 
 		// re-cast
-		for ( var key in variables._castCache) {
-			var castedValue = castValueForGetter( key, variables._castCache[ key ], true );
+		for ( var key in variables._castCache ) {
+			var castedValue = castValueForGetter(
+				key,
+				variables._castCache[ key ],
+				true
+			);
 			variables._data[ retrieveColumnForAlias( key ) ] = castedValue;
-			variables[ retrieveAliasForColumn( key ) ] = castedValue;
+			variables[ retrieveAliasForColumn( key ) ]       = castedValue;
 		}
 
 		return this;
@@ -3264,10 +3268,14 @@ component accessors="true" {
 	 *
 	 * @return  any
 	 */
-	private any function castValueForGetter( required string key, any value, boolean forceCast = false ) {
+	private any function castValueForGetter(
+		required string key,
+		any value,
+		boolean forceCast = false
+	) {
 		arguments.key = retrieveAliasForColumn( arguments.key );
 
-		if ( structKeyExists( variables._castCache, arguments.key )  AND !arguments.forceCast ) {
+		if ( structKeyExists( variables._castCache, arguments.key ) AND !arguments.forceCast ) {
 			return variables._castCache[ arguments.key ];
 		}
 

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1094,7 +1094,7 @@ component accessors="true" {
 				var parent = variables._wirebox.getInstance( parentDefinition.meta.fullName );
 			}
 
-			parent.fill( getMemento(), true ).save();
+			parent.fill( retrieveAttributesData(), true ).save();
 
 			assignAttributesData( {
 				"#parentDefinition.key#"        : parent.keyValues()[ 1 ],

--- a/models/Casts/JsonCast.cfc
+++ b/models/Casts/JsonCast.cfc
@@ -14,17 +14,15 @@ component singleton {
 		required string key,
 		any value
 	) {
-
 		if ( isNull( arguments.value ) ) {
 			return javacast( "null", "" );
 		}
 
-		if( isJSON( arguments.value ) ){
+		if ( isJSON( arguments.value ) ) {
 			return deserializeJSON( arguments.value );
 		}
 
 		return arguments.value;
-
 	}
 
 	/**

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1311,10 +1311,12 @@ component accessors="true" transientCache="false" {
 				].mapping
 			);
 
-			//add any virtual attributes present in the parent entity to child entity
-			getEntity().get_virtualAttributes().each( function( item ) {
-				childClass.appendVirtualAttribute( item );
-			} );
+			// add any virtual attributes present in the parent entity to child entity
+			getEntity()
+				.get_virtualAttributes()
+				.each( function( item ) {
+					childClass.appendVirtualAttribute( item );
+				} );
 
 			return childClass
 				.assignAttributesData( arguments.data )

--- a/tests/resources/database/migrations/2020_08_11_102649_create_songs_table.cfc
+++ b/tests/resources/database/migrations/2020_08_11_102649_create_songs_table.cfc
@@ -5,8 +5,13 @@ component {
             t.increments( "id" );
             t.string( "title" ).nullable();
             t.string( "download_url" );
-            t.timestamp( "created_date" ).withCurrent();
-            t.timestamp( "modified_date" ).withCurrent();
+
+            t.raw( "`created_date` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)" );
+            t.raw( "`modified_date` TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)" );
+
+            //proposed qb pull request https://github.com/coldbox-modules/qb/pull/282:
+            //t.timestamp( "created_date", 6 ).withCurrent( 6 );
+            //t.timestamp( "modified_date", 6 ).withCurrent( 6 );
         } );
 
         qb.table( "songs" ).insert( [

--- a/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
@@ -112,33 +112,28 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 			} );
 
 			it( "can maintain casts when loading a discriminated child through the parent", () => {
-				var comment = getInstance( "Comment" )
-					.where('designation', 'internal')
-					.first();
+				var comment = getInstance( "Comment" ).where( "designation", "internal" ).first();
 
 				expect( comment.getSentimentAnalysis() ).notToBeNull();
 				expect( comment.getSentimentAnalysis() ).toBeStruct();
 				expect( comment.getSentimentAnalysis() ).toHaveKey( "analyzed" );
 				expect( comment.getSentimentAnalysis() ).toHaveKey( "magnitude" );
 				expect( comment.getSentimentAnalysis() ).toHaveKey( "score" );
-
 			} );
 
 			it( "will recast after saving entity", function() {
-				var pn = getInstance( "PhoneNumber" ).find(1);
+				var pn = getInstance( "PhoneNumber" ).find( 1 );
 				pn.setNumber( "111-111-1111" );
 				pn.setActive( "0" );
 
 				expect( pn.getActive() ).toBe( "0" );
 				expect( pn.getActive() ).toBeNumeric();
- 
+
 				pn.save();
 
-				expect( pn.getActive() ).toBe( false ); 
+				expect( pn.getActive() ).toBe( false );
 				expect( pn.getActive() ).toBeBoolean();
-
 			} );
-
 		} );
 	}
 

--- a/tests/specs/integration/BaseEntity/AttributeHashSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeHashSpec.cfc
@@ -9,18 +9,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 			} );
 
 			it( "can compute attributes hash correctly", function() {
+				var passwordHash = hash( "password" )
 				var user = getInstance( "User" ).populate(
 					{
 						"username"              : "JaneDoe",
 						"first_name"            : "Jane",
 						"last_name"             : "Doe",
-						"password"              : hash( "password" ),
+						"password"              : passwordHash,
 						"non-existant-property" : "any-value"
 					},
 					true
 				);
 
-				var expectedHash = hash( "first_name=Jane&last_name=Doe&password=5F4DCC3B5AA765D61D8327DEB882CF99&username=JaneDoe" );
+				var expectedHash = hash( "first_name=Jane&last_name=Doe&password=#passwordHash#&username=JaneDoe" );
 				var hash         = user.computeAttributesHash( user.retrieveAttributesData() );
 				expect( expectedHash ).toBe( hash, "The computeAttributesHash method does not return the correct hash" );
 			} );

--- a/tests/specs/integration/BaseEntity/AttributeHashSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeHashSpec.cfc
@@ -10,7 +10,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 			it( "can compute attributes hash correctly", function() {
 				var passwordHash = hash( "password" )
-				var user = getInstance( "User" ).populate(
+				var user         = getInstance( "User" ).populate(
 					{
 						"username"              : "JaneDoe",
 						"first_name"            : "Jane",

--- a/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ChildClassSpec.cfc
@@ -352,13 +352,12 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var comment = getInstance( "Comment" )
 					.addUpperBody()
 					.where( "designation", "internal" )
-					.get()[1]
+					.get()[ 1 ]
 
 				expect( comment.hasAttribute( "upperBody" ) ).toBeTrue(
 					"Child class should have a virtual attribute 'upperBody'."
 				);
 			} );
-
 		} );
 
 		describe( "Single Table Inheritence Class Spec", function() {


### PR DESCRIPTION
In relation to auto-incrementing fields MySQL and MSSQL have different behaviors when inserting a null value into the database. eg.
```
# id = auto-increment
INSERT INTO song (id,title) 
VALUES (NULL, 'some song name')
```
MySQL will accept the statement and generate a new key. MSSQL will throw an exception. 

When inserting subclassed entities quick will retrieve an instance of the parent class and populate (fill) it using `getMemento()`. This causes an issue as `getMemento()` will included empty attributes which will explicity set an `id` property with an empty string. This will subsequently flow into the `save()` call causing an exception. Using `retrieveAttributesData()` solved this issue. 