### PR TITLE
Update Splits to use regex to match other parts of quick codebase

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2096,7 +2096,7 @@ component accessors="true" {
 		} else if ( !isSimpleValue( arguments.relationName ) ) {
 			related = arguments.relationName;
 		} else {
-			var parts = arguments.relationName.split( "[Aa][Ss]" );
+			var parts = arguments.relationName.split( "\s(?:[Aa][Ss]\s)?" );
 			related   = variables._wirebox.getInstance( trim( parts[ 1 ] ) );
 			if ( arrayLen( parts ) > 1 ) {
 				related.withAlias( trim( parts[ 2 ] ) );
@@ -2118,7 +2118,7 @@ component accessors="true" {
 			} else if ( !isSimpleValue( throughEntityName ) ) {
 				throughEntity = throughEntityName;
 			} else {
-				var parts = throughEntityName.split( "[Aa][Ss]" );
+				var parts = throughEntityName.split( "\s(?:[Aa][Ss]\s)?" );
 				if ( variables._wirebox.containsInstance( trim( parts[ 1 ] ) ) ) {
 					throughEntity = variables._wirebox.getInstance( trim( parts[ 1 ] ) );
 					if ( arrayLen( parts ) > 1 ) {

--- a/models/Relationships/Builders/HasManyDeepBuilder.cfc
+++ b/models/Relationships/Builders/HasManyDeepBuilder.cfc
@@ -27,7 +27,7 @@ component accessors="true" {
 		if ( !isNull( arguments.callback ) ) {
 			variables.through.append( function() {
 				var entity = "";
-				var parts  = entityName.split( "[Aa][Ss]" );
+				var parts  = entityName.split( "\s(?:[Aa][Ss]\s)?" );
 				var entity = variables.wirebox.getInstance( trim( parts[ 1 ] ) );
 				if ( arrayLen( parts ) > 1 ) {
 					entity.withAlias( trim( parts[ 2 ] ) );
@@ -78,7 +78,7 @@ component accessors="true" {
 		if ( !isNull( arguments.callback ) ) {
 			related = function() {
 				var entity = "";
-				var parts  = relationName.split( "[Aa][Ss]" );
+				var parts  = relationName.split( "\s(?:[Aa][Ss]\s)?" );
 				var entity = variables.wirebox.getInstance( trim( parts[ 1 ] ) );
 				if ( arrayLen( parts ) > 1 ) {
 					entity.withAlias( trim( parts[ 2 ] ) );

--- a/models/Relationships/HasManyDeep.cfc
+++ b/models/Relationships/HasManyDeep.cfc
@@ -97,7 +97,7 @@ component
 		var segments = arguments.builder
 			.getQB()
 			.getTableName()
-			.split( "[Aa][Ss]" );
+			.split( "\s(?:[Aa][Ss]\s)?" );
 		var alias = segments[ 2 ] ?: "";
 
 		var chainLength = variables.throughParents.len();
@@ -213,7 +213,7 @@ component
 		var segments = arguments.builder
 			.getQB()
 			.getTableName()
-			.split( "[Aa][Ss]" );
+			.split( "\s(?:[Aa][Ss]\s)?" );
 		var alias = segments[ 2 ] ?: "";
 
 		var foreignKeys = [];
@@ -239,7 +239,7 @@ component
 		var segments = arguments.builder
 			.getQB()
 			.getTableName()
-			.split( "[Aa][Ss]" );
+			.split( "\s(?:[Aa][Ss]\s)?" );
 		var alias = segments[ 2 ] ?: "";
 
 		var localKeys = [];


### PR DESCRIPTION
This stops tables like "class_class" from being used at "s_cl" as the 2nd item in the split.