### PR TITLE
Fix eager-load key type coercion

### DIFF
--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -370,7 +370,8 @@ component accessors="true" implements="IRelationship" {
 		required array keys,
 		required any baseEntity
 	) {
-		var uniqueKeys = arguments.entities.reduce( function( acc, entity ) {
+		var seenKeys = createObject( "java", "java.util.LinkedHashSet" ).init();
+		return arguments.entities.reduce( function( acc, entity ) {
 			var keyValues = [];
 			for ( var key in keys ) {
 				var value = structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( key ) : entity[ key ];
@@ -380,12 +381,9 @@ component accessors="true" implements="IRelationship" {
 				keyValues.append( value );
 			}
 
-			acc[ serializeJSON( keyValues ) ] = keyValues;
-			return acc;
-		}, {} );
-
-		return uniqueKeys.reduce( function( acc, _, keyValues ) {
-			acc.append( keyValues );
+			if ( seenKeys.add( serializeJSON( keyValues ) ) ) {
+				acc.append( keyValues );
+			}
 			return acc;
 		}, [] );
 	}

--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -370,22 +370,24 @@ component accessors="true" implements="IRelationship" {
 		required array keys,
 		required any baseEntity
 	) {
-		return unique(
-			arguments.entities.reduce( function( acc, entity ) {
-				var keyValues = [];
-				for ( var key in keys ) {
-					var value = structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( key ) : entity[ key ];
-					if ( entityIsNullValue( baseEntity, key, value ) ) {
-						return acc;
-					}
-					keyValues.append( value );
+		var uniqueKeys = arguments.entities.reduce( function( acc, entity ) {
+			var keyValues = [];
+			for ( var key in keys ) {
+				var value = structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( key ) : entity[ key ];
+				if ( entityIsNullValue( baseEntity, key, value ) ) {
+					return acc;
 				}
-				acc.append( keyValues.toList() );
-				return acc;
-			}, [] )
-		).map( function( key ) {
-			return key.listToArray();
-		} );
+				keyValues.append( value );
+			}
+
+			acc[ serializeJSON( keyValues ) ] = keyValues;
+			return acc;
+		}, {} );
+
+		return uniqueKeys.reduce( function( acc, _, keyValues ) {
+			acc.append( keyValues );
+			return acc;
+		}, [] );
 	}
 
 	/**

--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -381,7 +381,9 @@ component accessors="true" implements="IRelationship" {
 				keyValues.append( value );
 			}
 
-			if ( seenKeys.add( serializeJSON( keyValues ) ) ) {
+			var serializedKey = serializeJSON( keyValues );
+			if ( !seenKeys.contains( serializedKey ) ) {
+				seenKeys.add( serializedKey );
 				acc.append( keyValues );
 			}
 			return acc;

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -164,44 +164,43 @@ component
 	 * @return       [any]
 	 */
 	public array function getEagerEntityKeys( required array entities, required any baseEntity ) {
-		var uniqueKeys = arguments.entities
-			.reduce( function( keys, entity ) {
-				var values = variables.foreignKeys
-					.map( function( foreignKey ) {
-						return {
-							"foreignKey" : foreignKey,
-							"value"      : entityRetrieveAttribute( entity, foreignKey, baseEntity )
-						};
-					} )
-					.filter( function( map ) {
-						if ( !structKeyExists( map, "value" ) ) {
-							return false;
-						}
+		var uniqueKeys = arguments.entities.reduce( function( keys, entity ) {
+			var values = variables.foreignKeys
+				.map( function( foreignKey ) {
+					return {
+						"foreignKey" : foreignKey,
+						"value"      : entityRetrieveAttribute( entity, foreignKey, baseEntity )
+					};
+				} )
+				.filter( function( map ) {
+					if ( !structKeyExists( map, "value" ) ) {
+						return false;
+					}
 
-						if ( isNull( map.value ) ) {
-							return false;
-						}
+					if ( isNull( map.value ) ) {
+						return false;
+					}
 
-						if ( !entityHasAttribute( entity, map.foreignKey, baseEntity ) ) {
-							return false;
-						}
+					if ( !entityHasAttribute( entity, map.foreignKey, baseEntity ) ) {
+						return false;
+					}
 
-						if ( baseEntity.isNullValue( map.foreignKey, map.value ) ) {
-							return false;
-						}
+					if ( baseEntity.isNullValue( map.foreignKey, map.value ) ) {
+						return false;
+					}
 
-						return true;
-					} )
-					.map( function( map ) {
-						return map.value;
-					} );
+					return true;
+				} )
+				.map( function( map ) {
+					return map.value;
+				} );
 
-				if ( values.len() == variables.foreignKeys.len() ) {
-					arguments.keys[ serializeJSON( values ) ] = values;
-				}
+			if ( values.len() == variables.foreignKeys.len() ) {
+				arguments.keys[ serializeJSON( values ) ] = values;
+			}
 
-				return arguments.keys;
-			}, {} );
+			return arguments.keys;
+		}, {} );
 
 		return uniqueKeys.reduce( function( acc, _, values ) {
 			acc.append( values );

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -164,7 +164,8 @@ component
 	 * @return       [any]
 	 */
 	public array function getEagerEntityKeys( required array entities, required any baseEntity ) {
-		var uniqueKeys = arguments.entities.reduce( function( keys, entity ) {
+		var seenKeys = createObject( "java", "java.util.LinkedHashSet" ).init();
+		return arguments.entities.reduce( function( keys, entity ) {
 			var values = variables.foreignKeys
 				.map( function( foreignKey ) {
 					return {
@@ -196,15 +197,12 @@ component
 				} );
 
 			if ( values.len() == variables.foreignKeys.len() ) {
-				arguments.keys[ serializeJSON( values ) ] = values;
+				if ( seenKeys.add( serializeJSON( values ) ) ) {
+					arguments.keys.append( values );
+				}
 			}
 
 			return arguments.keys;
-		}, {} );
-
-		return uniqueKeys.reduce( function( acc, _, values ) {
-			acc.append( values );
-			return acc;
 		}, [] );
 	}
 

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -164,7 +164,7 @@ component
 	 * @return       [any]
 	 */
 	public array function getEagerEntityKeys( required array entities, required any baseEntity ) {
-		return arguments.entities
+		var uniqueKeys = arguments.entities
 			.reduce( function( keys, entity ) {
 				var values = variables.foreignKeys
 					.map( function( foreignKey ) {
@@ -197,15 +197,16 @@ component
 					} );
 
 				if ( values.len() == variables.foreignKeys.len() ) {
-					arguments.keys[ values.toList() ] = {};
+					arguments.keys[ serializeJSON( values ) ] = values;
 				}
 
 				return arguments.keys;
-			}, {} )
-			.keyArray()
-			.map( function( key ) {
-				return key.listToArray();
-			} );
+			}, {} );
+
+		return uniqueKeys.reduce( function( acc, _, values ) {
+			acc.append( values );
+			return acc;
+		}, [] );
 	}
 
 	/**

--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -197,7 +197,9 @@ component
 				} );
 
 			if ( values.len() == variables.foreignKeys.len() ) {
-				if ( seenKeys.add( serializeJSON( values ) ) ) {
+				var serializedKey = serializeJSON( values );
+				if ( !seenKeys.contains( serializedKey ) ) {
+					seenKeys.add( serializedKey );
 					arguments.keys.append( values );
 				}
 			}

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -34,6 +34,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				}
 			} );
 
+			it( "preserves numeric binding types when eager loading a belongs to relationship", function() {
+				getInstance( "Post" ).with( "author" ).get();
+
+				expect( variables.queries ).toHaveLength( 2 );
+				var bindingTypes = extractBindingTypes( variables.queries[ 2 ] );
+
+				expect( bindingTypes ).notToBeEmpty();
+				for ( var bindingType in bindingTypes ) {
+					expect( bindingType ).notToInclude( "varchar" );
+					expect( bindingType ).toInclude( "integer" );
+				}
+			} );
+
 			it( "can eager load a belongs to relationship using a composite key", function() {
 				var compositeChildren = getInstance( "CompositeChild" ).with( "parent" ).get();
 				expect( compositeChildren ).toBeArray();
@@ -241,6 +254,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( posts[ 4 ].getTags()[ 3 ].getName() ).toBe( "gaming" );
 
 				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
+			it( "preserves numeric binding types when eager loading a belongs to many relationship", function() {
+				getInstance( "Post" ).with( "tags" ).get();
+
+				expect( variables.queries ).toHaveLength( 2 );
+				var bindingTypes = extractBindingTypes( variables.queries[ 2 ] );
+
+				expect( bindingTypes ).notToBeEmpty();
+				for ( var bindingType in bindingTypes ) {
+					expect( bindingType ).notToInclude( "varchar" );
+					expect( bindingType ).toInclude( "integer" );
+				}
 			} );
 
 			it( "can eager load a has many through relationship", function() {
@@ -767,6 +793,16 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 		prc
 	) {
 		arrayAppend( variables.queries, interceptData );
+	}
+
+	private array function extractBindingTypes( required struct queryLogEntry ) {
+		return arguments.queryLogEntry.bindings
+			.filter( function( binding ) {
+				return isStruct( binding ) && ( binding.keyExists( "cfsqltype" ) || binding.keyExists( "sqltype" ) );
+			} )
+			.map( function( binding ) {
+				return lCase( binding.cfsqltype ?: binding.sqltype );
+			} );
 	}
 
 }

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -51,7 +51,10 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var post         = getInstance( "Post" ).firstOrFail();
 				var relationship = post.author();
 				var keys         = relationship.getEagerEntityKeys(
-					[ { "user_id" : "ABC" }, { "user_id" : "abc" } ],
+					[
+						{ "user_id" : "ABC" },
+						{ "user_id" : "abc" }
+					],
 					post
 				);
 
@@ -284,7 +287,10 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var user         = getInstance( "User" ).findOrFail( 1 );
 				var relationship = user.externalThings();
 				var keys         = relationship.getKeys(
-					[ { "externalID" : "ABC" }, { "externalID" : "abc" } ],
+					[
+						{ "externalID" : "ABC" },
+						{ "externalID" : "abc" }
+					],
 					[ "externalID" ],
 					user
 				);
@@ -824,7 +830,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				return isStruct( binding ) && ( binding.keyExists( "cfsqltype" ) || binding.keyExists( "sqltype" ) );
 			} )
 			.map( function( binding ) {
-				return lCase( binding.cfsqltype ?: binding.sqltype );
+				return lCase( binding.keyExists( "cfsqltype" ) ? binding[ "cfsqltype" ] : binding[ "sqltype" ] );
 			} );
 	}
 

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -47,6 +47,17 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				}
 			} );
 
+			it( "keeps belongs to eager keys that differ only by case", function() {
+				var post         = getInstance( "Post" ).firstOrFail();
+				var relationship = post.author();
+				var keys         = relationship.getEagerEntityKeys(
+					[ { "user_id" : "ABC" }, { "user_id" : "abc" } ],
+					post
+				);
+
+				expect( keys ).toHaveLength( 2 );
+			} );
+
 			it( "can eager load a belongs to relationship using a composite key", function() {
 				var compositeChildren = getInstance( "CompositeChild" ).with( "parent" ).get();
 				expect( compositeChildren ).toBeArray();
@@ -267,6 +278,18 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					expect( bindingType ).notToInclude( "varchar" );
 					expect( bindingType ).toInclude( "integer" );
 				}
+			} );
+
+			it( "keeps relationship eager keys that differ only by case", function() {
+				var user         = getInstance( "User" ).findOrFail( 1 );
+				var relationship = user.externalThings();
+				var keys         = relationship.getKeys(
+					[ { "externalID" : "ABC" }, { "externalID" : "abc" } ],
+					[ "externalID" ],
+					user
+				);
+
+				expect( keys ).toHaveLength( 2 );
 			} );
 
 			it( "can eager load a has many through relationship", function() {


### PR DESCRIPTION
## Summary

This fixes eager-loading paths that coerced numeric key values to strings before qb built relationship-query bindings.

The original implementation used `toList()` / `listToArray()` both to deduplicate composite eager-load keys and to transport the actual key values. That round-trip converted numeric IDs such as `1` into strings such as `"1"`, causing qb to bind them as `varchar` rather than `integer`.

## Changes

- Preserve original eager-load key arrays in `BaseRelationship.getKeys()` and `BelongsTo.getEagerEntityKeys()`.
- Use serialized tokens only for deduplication; values are still raw attribute values at this point, before qb expands them into full binding structs.
- Deduplicate with a Java `LinkedHashSet`, preserving insertion order and treating string keys that differ only by case as distinct.
- Use explicit safe struct-key selection in the binding-type test helper for Adobe CF compatibility.
- Rebase the PR onto current `next`.

## Test-first regression

Two relationship-level regressions exercise the public eager-key APIs for `BelongsTo` and the shared base relationship path. With the prior CFML-struct deduplication, both tests failed because `ABC` and `abc` collapsed into one key. After switching to case-sensitive tokens, both pass.

The existing public eager-loading regressions also assert that `belongsTo` and `belongsToMany` numeric bindings remain integer bindings.

## Validation

- Red phase: EagerLoadingSpec had 31 passed and 2 failed.
- Green phase: EagerLoadingSpec has 33 passed, 0 failed, 0 errors.
- Full Lucee 6 suite: 548 passed, 0 failed, 0 errors, 3 skipped.
- Full GitHub Actions matrix: 26 of 26 jobs passed, including Lucee, Adobe CF, BoxLang, BoxLang CFML, ColdBox 7/8, and full-null combinations.
- `box run-script format`
- `git diff --check`
