### PR TITLE
fix(BaseEntity): handle null values in fill

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -677,7 +677,11 @@ component accessors="true" {
 				continue;
 			}
 			var value = arguments.attributes[ key ];
-			var rs    = tryRelationshipSetter( "set#key#", { "1" : value } );
+			if ( hasAttribute( key ) && isNullValue( key, value ) ) {
+				clearAttribute( key, true );
+				continue;
+			}
+			var rs = tryRelationshipSetter( "set#key#", { "1" : value } );
 			if ( !isNull( rs ) ) {
 				continue;
 			}

--- a/tests/resources/app/models/UserFill.cfc
+++ b/tests/resources/app/models/UserFill.cfc
@@ -9,7 +9,7 @@ component extends="quick.models.BaseEntity" accessors="true" {
     property name="lastName";
     property name="aboutMe";
     property name="createdDate" readonly="true";
-    property name="updatedDate";
+	property name="updatedDate" type="date";
 	property name="lastLogin";
 	property name="avatarID";
 	property name="headerID";

--- a/tests/specs/integration/BaseEntity/FillSpec.cfc
+++ b/tests/specs/integration/BaseEntity/FillSpec.cfc
@@ -51,6 +51,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.retrieveAttribute( "lastName" ) ).toBe( "Vila" );
 				expect( user.retrieveAttribute( "email" ) ).toBe( "bob@vila.com" );
 			} );
+
+			it( "converts configured null values before invoking typed setters", function() {
+				var user = getInstance( "UserFill" );
+
+				expect( function() {
+					user.fill( { "updatedDate" : "" } );
+				} ).notToThrow();
+				expect( user.isNullAttribute( "updatedDate" ) ).toBeTrue();
+			} );
 		} );
 	}
 


### PR DESCRIPTION
## Summary

- convert configured null sentinels to native nulls during `fill()`
- avoid passing empty-string null values to typed generated setters
- add regression coverage for a nullable date attribute

Fixes #277

## Testing

- forced a fresh `qb@be` install, resolving to 14.0.0-beta.3
- verified the installed package contains `getQueryExecutor()` and the corrected predicate calls
- PR branch, Lucee 5 focused FillSpec: 4 passed, 0 failed/errors
- PR branch, Lucee 6 focused FillSpec: 4 passed, 0 failed/errors
- current local Quick qb 14 compatibility baseline, Lucee 6 full suite: 488 passed, 0 failed, 0 errors, 4 skipped
- `box run-script format:check`
- `git diff --check`

The beta.2 `getCollaborator` failures are resolved in beta.3. Running the full suite on the PR branch without the pending Quick qb 14 compatibility changes leaves the separate parameter-limit and builder-state regressions; those are green when tested with the current local compatibility baseline.