### PR TITLE
feat(Casts): delegate null handling to custom casts

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -616,12 +616,14 @@ component accessors="true" {
 			if ( !hasAttribute( key ) ) {
 				continue;
 			}
-			variables._data[ retrieveColumnForAlias( key ) ] = (
+			var value = castValueForGetter(
+				key,
 				!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )
-			) ? javacast( "null", "" ) : castValueForGetter( key, arguments.attributes[ key ] );
-			variables[ retrieveAliasForColumn( key ) ] = (
-				!arguments.attributes.keyExists( key ) || isNull( arguments.attributes[ key ] )
-			) ? javacast( "null", "" ) : castValueForGetter( key, arguments.attributes[ key ] );
+				 ? javacast( "null", "" )
+				 : arguments.attributes[ key ]
+			);
+			variables._data[ retrieveColumnForAlias( key ) ] = isNull( value ) ? javacast( "null", "" ) : value;
+			variables[ retrieveAliasForColumn( key ) ]       = isNull( value ) ? javacast( "null", "" ) : value;
 		}
 	}
 
@@ -3456,24 +3458,26 @@ component accessors="true" {
 		}
 
 		if ( !structKeyExists( variables._casts, arguments.key ) ) {
-			return arguments.value;
-		}
-
-		if ( !isVirtualAttribute( arguments.key ) && isNullValue( arguments.key, arguments.value ) ) {
-			return arguments.value;
+			return isNull( arguments.value ) ? javacast( "null", "" ) : arguments.value;
 		}
 
 		var castMapping = variables._casts[ arguments.key ];
 		if ( !variables._casterCache.keyExists( arguments.key ) ) {
 			variables._casterCache[ arguments.key ] = variables._wirebox.getInstance( dsl = castMapping );
 		}
-		var caster                            = variables._casterCache[ arguments.key ];
-		variables._castCache[ arguments.key ] = caster.get(
+		var caster      = variables._casterCache[ arguments.key ];
+		var castedValue = caster.get(
 			entity = this,
 			key    = arguments.key,
 			value  = isNull( arguments.value ) ? javacast( "null", "" ) : arguments.value
 		);
-		return variables._castCache[ arguments.key ];
+		if ( isNull( castedValue ) ) {
+			structDelete( variables._castCache, arguments.key );
+			return javacast( "null", "" );
+		}
+
+		variables._castCache[ arguments.key ] = castedValue;
+		return castedValue;
 	}
 
 	/**
@@ -3524,6 +3528,14 @@ component accessors="true" {
 			}
 			var caster = variables._casterCache[ key ];
 			var attrs  = caster.set( this, key, castedValue );
+			if ( isNull( attrs ) ) {
+				assignAttribute(
+					name  = key,
+					value = javacast( "null", "" ),
+					cast  = false
+				);
+				continue;
+			}
 			if ( !isStruct( attrs ) ) {
 				attrs = { "#key#" : attrs };
 			}

--- a/models/Casts/BooleanCast.cfc
+++ b/models/Casts/BooleanCast.cfc
@@ -15,7 +15,7 @@ component singleton {
 		any value
 	) {
 		if ( isNull( arguments.value ) ) {
-			return "";
+			return javacast( "null", "" );
 		}
 
 		return arguments.entity.isNullValue( arguments.key, arguments.value ) ? arguments.value : !!arguments.value;

--- a/models/Casts/BooleanCast.cfc
+++ b/models/Casts/BooleanCast.cfc
@@ -14,7 +14,11 @@ component singleton {
 		required string key,
 		any value
 	) {
-		return isNull( arguments.value ) ? false : !!arguments.value;
+		if ( isNull( arguments.value ) ) {
+			return "";
+		}
+
+		return arguments.entity.isNullValue( arguments.key, arguments.value ) ? arguments.value : !!arguments.value;
 	}
 
 	/**
@@ -32,6 +36,10 @@ component singleton {
 		required string key,
 		any value
 	) {
+		if ( isNull( arguments.value ) || arguments.entity.isNullValue( arguments.key, arguments.value ) ) {
+			return javacast( "null", "" );
+		}
+
 		return arguments.value ? 1 : 0;
 	}
 

--- a/tests/resources/app/models/CustomCastPhoneNumber.cfc
+++ b/tests/resources/app/models/CustomCastPhoneNumber.cfc
@@ -1,0 +1,10 @@
+component
+	extends  ="quick.models.BaseEntity"
+	table    ="phone_numbers"
+	accessors="true"
+{
+
+	property name="id";
+	property name="confirmed" casts="NullValueCast";
+
+}

--- a/tests/resources/app/models/NullValueCast.cfc
+++ b/tests/resources/app/models/NullValueCast.cfc
@@ -1,0 +1,21 @@
+component singleton {
+
+	public any function get(
+		required any entity,
+		required string key,
+		any value
+	) {
+		return isNull( arguments.value ) || arguments.entity.isNullValue( arguments.key, arguments.value )
+		 ? "casted-null"
+		 : arguments.value;
+	}
+
+	public any function set(
+		required any entity,
+		required string key,
+		any value
+	) {
+		return isNull( arguments.value ) ? javacast( "null", "" ) : arguments.value;
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
@@ -97,13 +97,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( theme.getConfig().primaryColor ).toBe( "orange" );
 			} );
 
-			it( "can still allow nulls when using casts", () => {
+			it( "preserves null values when using BooleanCast", () => {
 				var pn = getInstance( "PhoneNumber" ).find( 3 );
 				expect( pn.isNullAttribute( "confirmed" ) ).toBeTrue( "[confirmed] should be considered null" );
 				expect( pn.getConfirmed() ).toBe( "" );
 				// expect( function() {
 				pn.update( { "active" : false } );
 				// } ).notToThrow( message = "PhoneNumber should be able to be saved with a `null` [confirmed] value" );
+			} );
+
+			it( "allows custom casts to handle null database values", () => {
+				var pn = getInstance( "CustomCastPhoneNumber" ).find( 3 );
+
+				expect( pn.getConfirmed() ).toBe( "casted-null" );
 			} );
 
 			it( "correctly casts child entities", () => {

--- a/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
@@ -99,6 +99,13 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 			it( "preserves null values when using BooleanCast", () => {
 				var pn = getInstance( "PhoneNumber" ).find( 3 );
+				expect(
+					getInstance( "BooleanCast@quick" ).get(
+						entity = pn,
+						key    = "confirmed",
+						value  = javacast( "null", "" )
+					)
+				).toBeNull( "BooleanCast should return native null unchanged" );
 				expect( pn.isNullAttribute( "confirmed" ) ).toBeTrue( "[confirmed] should be considered null" );
 				expect( pn.getConfirmed() ).toBe( "" );
 				// expect( function() {

--- a/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
@@ -99,18 +99,13 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 			it( "preserves null values when using BooleanCast", () => {
 				var pn = getInstance( "PhoneNumber" ).find( 3 );
-				expect(
-					getInstance( "BooleanCast@quick" ).get(
-						entity = pn,
-						key    = "confirmed",
-						value  = javacast( "null", "" )
-					)
-				).toBeNull( "BooleanCast should return native null unchanged" );
 				expect( pn.isNullAttribute( "confirmed" ) ).toBeTrue( "[confirmed] should be considered null" );
 				expect( pn.getConfirmed() ).toBe( "" );
-				// expect( function() {
-				pn.update( { "active" : false } );
-				// } ).notToThrow( message = "PhoneNumber should be able to be saved with a `null` [confirmed] value" );
+
+				pn.update( { "active" : false } ).refresh();
+
+				expect( pn.isNullAttribute( "confirmed" ) ).toBeTrue( "[confirmed] should remain null after saving" );
+				expect( pn.getConfirmed() ).toBe( "" );
 			} );
 
 			it( "allows custom casts to handle null database values", () => {


### PR DESCRIPTION
## Summary

- invoke configured custom casts for database null values by default
- preserve native nulls and configured null sentinels in `BooleanCast`
- safely support cast getters and setters that return native null
- add regression coverage with a custom null-aware cast

Fixes #275.

This incorporates the core direction discussed in #276 while adding BooleanCast compatibility and tests.

## Test-first reproduction

Before the implementation, `allows custom casts to handle null database values` failed because the custom cast received no opportunity to transform the null value (expected `casted-null`, received an empty string). The test passes after the change.

The BooleanCast regression is covered through the normal Quick entity flow: load the nullable column with `find()`, read it through the entity null/accessor APIs, update an unrelated attribute, refresh, and verify the Boolean attribute remains null.

## Verification

- `qb@be` resolved locally to `14.0.0-beta.3`
- AttributeCastsSpec: 14 passed, 1 known unrelated qb 14 compatibility failure
- NullValuesSpec: 5 passed, 0 failed
- GitHub Actions: all 12 engine/ColdBox combinations passed, including Lucee 5/6, Adobe 2021/2023/2025, and BoxLang CFML
- GitHub Actions formatting and security checks passed
- `box run-script format:check`
- `git diff --check`