### PR TITLE
fix(Events): cast attributes assigned in preSave

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1143,7 +1143,6 @@ component accessors="true" {
 		}
 		guardNoAttributes();
 		guardReadOnly();
-		mergeAttributesFromCastCache();
 		fireEvent(
 			"preSave",
 			{
@@ -1151,6 +1150,7 @@ component accessors="true" {
 				options : arguments.options
 			}
 		);
+		mergeAttributesFromCastCache();
 		variables._saving = true;
 		var builder       = newQuery();
 		if ( variables._loaded ) {

--- a/tests/resources/app/models/PreSaveCastPhoneNumber.cfc
+++ b/tests/resources/app/models/PreSaveCastPhoneNumber.cfc
@@ -1,0 +1,16 @@
+component
+	extends  ="quick.models.BaseEntity"
+	table    ="phone_numbers"
+	accessors="true"
+{
+
+	property name="id";
+	property name="number"    casts="YesNoCast";
+	property name="active"    casts="BooleanCast@quick";
+	property name="confirmed" casts="BooleanCast@quick";
+
+	function preSave() {
+		assignAttribute( "number", getActive() );
+	}
+
+}

--- a/tests/resources/app/models/YesNoCast.cfc
+++ b/tests/resources/app/models/YesNoCast.cfc
@@ -1,0 +1,19 @@
+component singleton {
+
+	public any function get(
+		required any entity,
+		required string key,
+		any value
+	) {
+		return arguments.value == "Y";
+	}
+
+	public any function set(
+		required any entity,
+		required string key,
+		any value
+	) {
+		return arguments.value ? "Y" : "N";
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/Events/PreSaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PreSaveSpec.cfc
@@ -75,6 +75,12 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				);
 				structDelete( request, "preSaveCalled" );
 			} );
+
+			it( "casts attributes assigned by a preSave method", function() {
+				var phoneNumber = getInstance( "PreSaveCastPhoneNumber" ).create( { "active" : true, "confirmed" : false } );
+
+				expect( phoneNumber.fresh().getNumber() ).toBeTrue();
+			} );
 		} );
 	}
 


### PR DESCRIPTION
## Summary

- run `preSave` before merging entity-facing values through configured casts
- ensure attributes assigned by component or interceptor `preSave` hooks are converted before insert/update events and SQL generation
- add a public-API regression using `create()`, `fresh()`, and an entity getter

Fixes #273.

## Test-first reproduction

The regression creates an entity whose `preSave` hook copies a Boolean value into a Y/N-cast attribute, then reloads it with `fresh()` and reads it through the entity getter. Before the fix the test failed (`false` instead of `true`) because the hook assignment was persisted as `"1"`; after the save-order change it passes as the cast persists `"Y"`.

## Verification

- `qb@be` resolved to `14.0.0-beta.3`
- PreSaveSpec: 5 passed, 0 failed
- all BaseEntity event specs: 29 passed, 0 failed
- full local Lucee 6 suite: 449 passed, 3 failed, 39 errors, 3 skipped; this matches the known qb 14 compatibility baseline plus the new passing regression
- GitHub Actions: all 12 engine/ColdBox combinations passed, including Lucee 5/6, Adobe 2021/2023/2025, and BoxLang CFML
- GitHub Actions formatting and security checks passed
- `box run-script format:check`
- `git diff --check`