### PR TITLE
fix: prioritize attribute aliases over conflicting column names

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -786,6 +786,9 @@ component accessors="true" {
 	 * @return  string
 	 */
 	public string function retrieveAliasForColumn( required string column ) {
+		if ( variables._attributes.keyExists( arguments.column ) ) {
+			return variables._attributes[ arguments.column ].name;
+		}
 		return variables._columns.keyExists( arguments.column ) ? variables._columns[ arguments.column ].name : arguments.column;
 	}
 

--- a/tests/resources/app/models/ColumnAliasCollision.cfc
+++ b/tests/resources/app/models/ColumnAliasCollision.cfc
@@ -1,0 +1,13 @@
+component extends="quick.models.BaseEntity" accessors="true" {
+
+	property
+		name  ="activoSN"
+		column="Activo"
+		type  ="boolean";
+	property
+		name  ="activo"
+		column="Active"
+		type  ="boolean"
+		setter="false";
+
+}

--- a/tests/specs/integration/BaseEntity/AttributeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeSpec.cfc
@@ -30,6 +30,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getUsername() ).toBe( "new_username" );
 			} );
 
+			it( "prioritizes attribute aliases over conflicting column names in magic accessors", function() {
+				var entity = getInstance( "ColumnAliasCollision" );
+				entity.setActivoSN( false );
+				entity.setActivo( true );
+
+				expect( entity.getActivo() ).toBeTrue();
+				expect( entity.getActivoSN() ).toBeFalse();
+			} );
+
 			it( "can set a value to null using the `setColumnName` magic methods", function() {
 				var user = getInstance( "User" ).find( 1 );
 				expect( user.getUsername() ).toBe( "elpete" );


### PR DESCRIPTION
## Summary

- prioritize declared attribute aliases before column-name translation
- preserve magic access through a column name when no alias conflicts
- add a public-API regression covering conflicting `Activo` / `activo` accessors

## Testing

- confirmed the regression fails before the implementation change on Lucee 6
- `AttributeSpec`: 16 passed on Lucee 6.2.8.20
- `AttributeSpec`: 16 passed on Adobe ColdFusion 2021.0.23
- full Lucee 6 suite with latest `qb@be`: 450 passed, 3 failed, 39 errors, 3 skipped (matches the known qb 14 compatibility baseline plus the new passing spec)
- `box run-script format:check`
- `git diff --check`

Fixes #272