### PR TITLE
fix: exclude read-only attributes from generated SQL

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3581,6 +3581,7 @@ component accessors="true" {
 		var alias = retrieveAliasForColumn( arguments.name );
 		return variables._attributes.keyExists( alias ) &&
 		variables._attributes[ alias ].update &&
+		!variables._attributes[ alias ].readOnly &&
 		!variables._attributes[ alias ].isParentColumn;
 	}
 
@@ -3595,6 +3596,7 @@ component accessors="true" {
 		var alias = retrieveAliasForColumn( arguments.name );
 		return variables._attributes.keyExists( alias ) &&
 		variables._attributes[ alias ].insert &&
+		!variables._attributes[ alias ].readOnly &&
 		!variables._attributes[ alias ].isParentColumn;
 	}
 

--- a/tests/specs/integration/BaseEntity/ReadOnlyPropertySpec.cfc
+++ b/tests/specs/integration/BaseEntity/ReadOnlyPropertySpec.cfc
@@ -1,5 +1,17 @@
 component extends="tests.resources.ModuleIntegrationSpec" {
 
+	function beforeAll() {
+		super.beforeAll();
+		controller
+			.getInterceptorService()
+			.registerInterceptor( interceptorObject = this, interceptorName = "ReadOnlyPropertySpec" );
+	}
+
+	function afterAll() {
+		controller.getInterceptorService().unregister( "ReadOnlyPropertySpec" );
+		super.afterAll();
+	}
+
 	function run() {
 		describe( "Read-only properties", function() {
 			it( "prevents read-only properties from being saved", function() {
@@ -49,7 +61,39 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					getInstance( "Link" ).updateAll( { createdDate : now() } );
 				} ).toThrow( type = "QuickReadOnlyException" );
 			} );
+
+			it( "excludes read-only properties from generated update statements", function() {
+				var link = getInstance( "Link" ).findOrFail( 1 );
+				structDelete( request, "readOnlyPropertySpecPreQBExecute" );
+
+				link.setUrl( "https://example.com/updated" ).save();
+
+				expect( request.readOnlyPropertySpecPreQBExecute ).toHaveLength( 1 );
+				expect( request.readOnlyPropertySpecPreQBExecute[ 1 ].sql ).notToInclude( "created_date" );
+			} );
+
+			it( "excludes read-only properties from generated insert statements", function() {
+				var link = getInstance( "Link" );
+				link.setUrl( "https://example.com/new" ).forceAssignAttribute( "createdDate", now() );
+				structDelete( request, "readOnlyPropertySpecPreQBExecute" );
+
+				link.save();
+
+				expect( request.readOnlyPropertySpecPreQBExecute ).toHaveLength( 1 );
+				expect( request.readOnlyPropertySpecPreQBExecute[ 1 ].sql ).notToInclude( "created_date" );
+			} );
 		} );
+	}
+
+	function preQBExecute(
+		event,
+		interceptData,
+		buffer,
+		rc,
+		prc
+	) {
+		param request.readOnlyPropertySpecPreQBExecute = [];
+		request.readOnlyPropertySpecPreQBExecute.append( duplicate( arguments.interceptData ) );
 	}
 
 }


### PR DESCRIPTION
## Summary

- exclude `readonly="true"` attributes from generated `UPDATE` statements
- exclude read-only attributes from generated `INSERT` statements, even when populated internally
- preserve hydration and read access for read-only attributes
- add public-API persistence regressions that inspect Quick’s generated SQL

## Testing

- confirmed both regressions fail before the implementation change on Lucee 6
- `ReadOnlyPropertySpec`: 8 passed
- `SaveSpec`: 18 passed
- full Lucee 6 suite with latest `qb@be`: 452 passed, 3 failed, 39 errors, 3 skipped (matches the known qb 14 compatibility baseline plus the two new passing specs)
- `box run-script format:check`
- `git diff --check`

Fixes #271