### PR TITLE
fix: restore qb 14 compatibility

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -59,6 +59,16 @@ component {
 			.initArg( name = "preventDuplicateJoins", value = settings.preventDuplicateJoins )
 			.initArg( name = "defaultOptions", value = settings.defaultQueryOptions )
 			.initArg( name = "utils", dsl = "QueryUtils@qb" )
+			.initArg( name = "returnFormatterRegistry", ref = "ReturnFormatterRegistry@qb" )
+			.initArg(
+				name = "validateDuplicateSelectColumns",
+				dsl  = "coldbox:moduleSettings:qb:validateDuplicateSelectColumns"
+			)
+			.initArg(
+				name = "validateQueryExecuteReturnType",
+				dsl  = "coldbox:moduleSettings:qb:validateQueryExecuteReturnType"
+			)
+			.initArg( name = "collectQueryLog", dsl = "coldbox:moduleSettings:qb:collectQueryLog" )
 			.initArg( name = "sqlCommenter", ref = "ColdBoxSQLCommenter@qb" )
 			.initArg( name = "returnFormat", value = "array" );
 

--- a/box.json
+++ b/box.json
@@ -29,7 +29,7 @@
     },
     "type":"modules",
     "dependencies":{
-        "qb":"^13.0.12",
+        "qb":"14.0.0-beta.3",
         "str":"^4.0.0",
         "mementifier":"^3.0.0"
     },

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -562,9 +562,10 @@ component accessors="true" transientCache="false" {
 		// This is a workaround for grammars with a parameter limit.  If the grammar
 		// has a `parameterLimit` public property, it is used to slice up the array
 		// and work it in chunks.
-		if ( structKeyExists( getEntity().newQuery().getGrammar(), "parameterLimit" ) ) {
-			var parameterLimit = getEntity().newQuery().getGrammar().parameterLimit;
-			if ( arguments.entities.len() > parameterLimit ) {
+		var grammar = getEntity().newQuery().getGrammar();
+		if ( structKeyExists( grammar, "parameterLimit" ) ) {
+			var parameterLimit = grammar.parameterLimit;
+			if ( parameterLimit > 0 && arguments.entities.len() > parameterLimit ) {
 				for ( var i = 1; i < arguments.entities.len(); i += parameterLimit ) {
 					var length = min( arguments.entities.len() - i + 1, parameterLimit );
 					var slice  = arraySlice( arguments.entities, i, length );

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -27,12 +27,29 @@ component
 	 *
 	 * @return      quick.models.QuickQB
 	 */
-	private QuickQB function whereBasic(
-		required any column,
-		required any operator,
+	public QuickQB function where(
+		any column,
+		any operator,
 		any value,
 		string combinator = "and"
 	) {
+		if ( isClosure( arguments.column ) || isCustomFunction( arguments.column ) ) {
+			return whereNested( arguments.column, arguments.combinator );
+		}
+
+		if ( isNull( arguments.value ) && getQueryValidator().isInvalidOperator( arguments.operator ) ) {
+			arguments.value    = arguments.operator;
+			arguments.operator = "=";
+		}
+
+		if (
+			!isNull( arguments.value ) &&
+			isStruct( arguments.value ) &&
+			structKeyExists( arguments.value, "isQuickBuilder" )
+		) {
+			arguments.value = arguments.value.getQB();
+		}
+
 		if ( isSimpleValue( arguments.column ) && getEntity().hasAttribute( arguments.column ) ) {
 			arguments.value = generateQueryParamStruct(
 				column           = arguments.column,
@@ -41,7 +58,7 @@ component
 				shouldCastValues = true // we are in a where clause, so the casted values will not be persisted to the entity at this time.
 			);
 		}
-		super.whereBasic( argumentCollection = arguments );
+		super.where( argumentCollection = arguments );
 		return this;
 	}
 
@@ -55,17 +72,17 @@ component
 	 *
 	 * @return qb.models.Query.QueryBuilder
 	 */
-	private QuickQB function whereInSub(
+	public QuickQB function whereIn(
 		column,
-		query,
+		values,
 		combinator = "and",
 		negate     = false
 	) {
-		if ( isStruct( arguments.query ) && structKeyExists( arguments.query, "isQuickBuilder" ) ) {
-			arguments.query = arguments.query.getQB();
+		if ( isStruct( arguments.values ) && structKeyExists( arguments.values, "isQuickBuilder" ) ) {
+			arguments.values = arguments.values.getQB();
 		}
 
-		return super.whereInSub( argumentCollection = arguments );
+		return super.whereIn( argumentCollection = arguments );
 	}
 
 	/**
@@ -947,13 +964,17 @@ component
 	 */
 	public QueryBuilder function newQuery() {
 		var newBuilder = new quick.models.QuickQB(
-			grammar             = getGrammar(),
-			utils               = getUtils(),
-			returnFormat        = getReturnFormat(),
-			paginationCollector = isNull( variables.paginationCollector ) ? javacast( "null", "" ) : variables.paginationCollector,
-			columnFormatter     = isNull( getColumnFormatter() ) ? javacast( "null", "" ) : getColumnFormatter(),
-			parentQuery         = isNull( getParentQuery() ) ? javacast( "null", "" ) : getParentQuery().clone(),
-			defaultOptions      = getDefaultOptions()
+			grammar                        = getGrammar(),
+			utils                          = getUtils(),
+			returnFormat                   = getReturnFormat(),
+			returnFormatterRegistry        = getReturnFormatterRegistry(),
+			paginationCollector            = isNull( variables.paginationCollector ) ? javacast( "null", "" ) : variables.paginationCollector,
+			columnFormatter                = isNull( getColumnFormatter() ) ? javacast( "null", "" ) : getColumnFormatter(),
+			parentQuery                    = isNull( getParentQuery() ) ? javacast( "null", "" ) : getParentQuery().clone(),
+			defaultOptions                 = getDefaultOptions(),
+			validateDuplicateSelectColumns = getValidateDuplicateSelectColumns(),
+			validateQueryExecuteReturnType = getValidateQueryExecuteReturnType(),
+			collectQueryLog                = getCollectQueryLog()
 		);
 		newBuilder.setQuickBuilder( getQuickBuilder() );
 		newBuilder.setEntity( getEntity() );

--- a/tests/resources/ModuleIntegrationSpec.cfc
+++ b/tests/resources/ModuleIntegrationSpec.cfc
@@ -5,6 +5,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/app" {
 	function beforeAll() {
 		super.beforeAll();
 
+		getController().getModuleService().registerAndActivateModule( "qb", "root.modules" );
 		getController().getModuleService().registerAndActivateModule( "quick", "testingModuleRoot" );
 
 		param url.reloadDatabase     = false;


### PR DESCRIPTION
## Summary
- upgrade Quick to the latest `qb@be` release (`14.0.0-beta.3`)
- adapt QuickQB to qb 14 public predicate APIs while preserving Quick casts and builder unwrapping
- propagate qb 14 formatter and validation state into cloned builders
- treat `parameterLimit = 0` as unlimited during eager loading
- ensure the test harness loads the declared root qb before cfmigrations’ nested qb 13

This is prerequisite compatibility work discovered while validating #266 against the required latest `qb@be`. It does not close #266.

## Validation
- focused regressions: 65 passed, 0 failed, 0 errors
- full Lucee 6 suite: 491 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `box run-script format:check`
- `git diff --check`