### PR TITLE
test: cover QuickService get options

### DIFF
--- a/tests/specs/integration/BaseServiceSpec.cfc
+++ b/tests/specs/integration/BaseServiceSpec.cfc
@@ -1,5 +1,17 @@
 component extends="tests.resources.ModuleIntegrationSpec" {
 
+	function beforeAll() {
+		super.beforeAll();
+		controller
+			.getInterceptorService()
+			.registerInterceptor( interceptorObject = this, interceptorName = "BaseServiceSpec" );
+	}
+
+	function afterAll() {
+		controller.getInterceptorService().unregister( "BaseServiceSpec" );
+		super.afterAll();
+	}
+
 	function run() {
 		describe( "BaseService Spec", function() {
 			describe( "instantiation", function() {
@@ -44,8 +56,31 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					expect( users ).toBeArray();
 					expect( users ).toHaveLength( 2 );
 				} );
+
+				it( "passes get options through a quickService query", function() {
+					structDelete( request, "baseServiceSpecPreQBExecute" );
+
+					var users = variables.service
+						.whereNotNull( "created_date" )
+						.get( options = { datasource : "quick" } );
+
+					expect( users ).toBeArray();
+					expect( request.baseServiceSpecPreQBExecute ).toHaveLength( 1 );
+					expect( request.baseServiceSpecPreQBExecute[ 1 ].options.datasource ).toBe( "quick" );
+				} );
 			} );
 		} );
+	}
+
+	function preQBExecute(
+		event,
+		interceptData,
+		buffer,
+		rc,
+		prc
+	) {
+		param request.baseServiceSpecPreQBExecute = [];
+		request.baseServiceSpecPreQBExecute.append( duplicate( arguments.interceptData ) );
 	}
 
 }


### PR DESCRIPTION
## Summary
- add public-API integration coverage for passing query options through a `quickService` chain
- assert the datasource option reaches qb execution through the normal `.get()` flow

Refs #266.

## Reproduction
Current `next` already contains the production fix from `0e0fc11` (`fix(QuickBuilder): Allow passing options for retrieval methods`), so the reported failure does not reproduce unchanged. Temporarily restoring the pre-fix `QuickBuilder.get()` behavior made this regression fail because `options.datasource` was absent; restoring current code made it pass.

## Validation
- `BaseServiceSpec`: 7 passed, 0 failed, 0 errors
- full Lucee 6 suite: 495 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `box run-script format:check`
- `git diff --check`