### PR TITLE
test: verify hasManyThrough subselect aliases

### DIFF
--- a/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
@@ -131,9 +131,11 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 			} );
 
 			it( "can add a subquery to an entity using a hasManyThrough relationship with table aliases", function() {
-				// expect( () => {
 				var rmmeAs = getInstance( "RMME_A" ).asMemento( includes = [ "C" ] ).get();
-				// } ).notToThrow();
+
+				expect( rmmeAs ).toHaveLength( 1 );
+				expect( rmmeAs[ 1 ].C ).toHaveLength( 1 );
+				expect( rmmeAs[ 1 ].C[ 1 ].inlined_dValue ).toBe( 42 );
 			} );
 		} );
 	}


### PR DESCRIPTION
## Issue review

Refs #264.

This bug is a strong fit for Quick because relationship scopes must respect aliases generated by `hasManyThrough`; leaking the raw table name produces invalid SQL on engines that enforce alias references. The production behavior is already fixed on `next` by `95ce7e6` (`fix(HasManyThrough): Use qb 13 to fix missing alias rewriting`).

The existing regression only verified that execution did not throw, so it could pass without proving the subselect was hydrated correctly. This PR strengthens the public-API coverage to assert the related memento contains `inlined_dValue = 42`.

### Reasons for
- protects valid aliased SQL across database grammars
- verifies the observable hydrated result, not just absence of an exception
- exercises the normal `asMemento(...).get()` flow

### Tradeoffs
- no production change is needed because current `next` already contains the fix
- the fixture is specialized to the reported relationship chain

**Recommendation: 10/10 — retain the fix and merge the stronger regression coverage.**

## Reproduction

The original failing regression was committed first as `25bca38`; the production fix followed in `95ce7e6`. Current `next` does not reproduce the failure unchanged.

## Validation
- `SubqueriesSpec`: 11 passed, 0 failed, 0 errors
- full Lucee 6 suite: 495 passed, 0 failed, 0 errors, 3 skipped
- formatting and whitespace checks pass
