### PR TITLE
Fix eager loading for belongsToThrough relationships

### DIFF
--- a/models/Relationships/BelongsToThrough.cfc
+++ b/models/Relationships/BelongsToThrough.cfc
@@ -108,7 +108,7 @@ component extends="quick.models.Relationships.BaseRelationship" {
 	public boolean function addEagerConstraints( required array entities, required any baseEntity ) {
 		var allKeys = getKeys(
 			entities,
-			variables.closestToParent.getLocalKeys(),
+			getLocalKeys(),
 			arguments.baseEntity
 		);
 
@@ -116,8 +116,8 @@ component extends="quick.models.Relationships.BaseRelationship" {
 			return false;
 		}
 
-		performJoin();
-		var foreignKeys             = variables.closestToParent.getForeignKeys();
+		performJoin( variables.relationshipBuilder );
+		var foreignKeys             = getForeignKeys();
 		var qualifiedForeignKeyList = foreignKeys
 			.reduce( function( acc, foreignKey, i ) {
 				if ( i != 1 ) {
@@ -128,7 +128,7 @@ component extends="quick.models.Relationships.BaseRelationship" {
 			}, [] )
 			.toList();
 
-		variables.related
+		variables.relationshipBuilder
 			.when(
 				( qualifiedForeignKeyList.listLen() > 1 ),
 				function( q1 ) {
@@ -151,7 +151,6 @@ component extends="quick.models.Relationships.BaseRelationship" {
 					} );
 				} );
 			} );
-
 		return true;
 	}
 
@@ -293,7 +292,7 @@ component extends="quick.models.Relationships.BaseRelationship" {
 	) {
 		var dictionary = buildDictionary( arguments.results );
 		arguments.entities.each( function( entity ) {
-			var key = variables.localKeys
+			var key = getLocalKeys()
 				.map( function( localKey ) {
 					return structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( localKey ) : entity[
 						localKey
@@ -360,7 +359,7 @@ component extends="quick.models.Relationships.BaseRelationship" {
 	}
 
 	public array function getLocalKeys() {
-		return variables.parent.keyNames();
+		return variables.closestToParent.getForeignKeys();
 	}
 
 }

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToThroughSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToThroughSpec.cfc
@@ -8,6 +8,14 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( post.getCountry() ).notToBeArray();
 				expect( post.getCountry().getId() ).toBe( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
 			} );
+
+			it( "can eager load the owning entity through other relationships", function() {
+				var post = getInstance( "Post" ).with( "country" ).findOrFail( 523526 );
+
+				expect( post.getCountry() ).notToBeNull();
+				expect( post.getCountry() ).notToBeArray();
+				expect( post.getCountry().getId() ).toBe( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #254
Closes #145

## Issue review

These are valid duplicate bug reports and a strong fit for Quick. `BelongsToThrough.match()` referenced `variables.localKeys`, which is never defined on the relationship, so eager loading could throw the reported matching exception. The eager-loading path also applied joins and constraints to the related entity instead of the relationship builder that actually executes, and it paired the parent and joined keys on the wrong sides.

Recommendation: **10/10 — implement.**

Reasons for:
- eager loading is a core relationship feature and should behave consistently across relationship types
- the current failure is deterministic through Quick’s public `with()`/`findOrFail()` flow
- the fix uses the relationship’s existing key accessors and builder rather than adding configuration or special cases

Tradeoffs:
- this changes the eager-loading SQL for `belongsToThrough`, but the previous SQL could not correctly hydrate and match the relationship
- composite-key behavior relies on the same key zipping already used by other relationship implementations

## Reproduction and fix

I added the regression through the public API first:

```cfml
getInstance( "Post" ).with( "country" ).findOrFail( 523526 )
```

Before the implementation change, the test errored with `ArrayZipLengthMismatch` while building the eager constraint. Replacing only the undefined key access then exposed the second failure: the relationship remained null because the eager query mutations were being made on a different builder than the one executed. This is the modern manifestation of #145's original `MATCHONE` failure: both reports exercise the same unsupported eager-loading match path.

The implementation now:
- derives parent-side match values from the closest relationship foreign keys
- derives query-side values from the closest relationship local keys
- applies joins, selects, and constraints to `relationshipBuilder`
- implements matching directly in `BelongsToThrough.match()` rather than calling a missing `matchOne`
- uses `getLocalKeys()` in `match()` instead of the undefined member

## Validation

- focused `BelongsToThroughSpec`: 2 passed, 0 failed, 0 errors
- adjacent relationship/subquery suites: 59 passed, 0 failed, 0 errors
- full Lucee 6 suite using qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
