### PR TITLE
Fix table qualification in whereIn subqueries

### DIFF
--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -862,6 +862,24 @@ component accessors="true" transientCache="false" {
 	}
 
 	/**
+	 * Qualifies a column using the current table for the provided query.
+	 *
+	 * @column The column to qualify.
+	 * @query  The query whose current table should be used.
+	 *
+	 * @return string
+	 */
+	public string function qualifyColumnForQuery( required string column, required any query ) {
+		var tableName = arguments.query.getTableName();
+		if ( arguments.query.getAlias() != "" ) {
+			tableName = arguments.query.getAlias();
+		}
+		return !isNull( tableName ) && isSimpleValue( tableName ) && tableName != ""
+		 ? qualifyColumn( arguments.column, tableName )
+		 : qualifyColumn( arguments.column );
+	}
+
+	/**
 	 * Returns the table name of the underlying entity
 	 */
 	public string function tableName() {

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -80,6 +80,15 @@ component
 	) {
 		if ( isStruct( arguments.values ) && structKeyExists( arguments.values, "isQuickBuilder" ) ) {
 			arguments.values = arguments.values.getQB();
+		} else if ( isClosure( arguments.values ) || isCustomFunction( arguments.values ) ) {
+			var callback     = arguments.values;
+			var quickBuilder = variables.quickBuilder;
+			arguments.values = function( query ) {
+				query.setColumnFormatter( function( column ) {
+					return quickBuilder.qualifyColumnForQuery( column, query );
+				} );
+				return callback( query );
+			};
 		}
 
 		return super.whereIn( argumentCollection = arguments );

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -38,6 +38,23 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						expect( users ).toHaveLength( 1 );
 					} );
 
+					it( "uses a whereIn subquery table inside whereHas", function() {
+						queryExecute(
+							"INSERT INTO family_parents ( parentID, familyID ) VALUES ( :parentID, :familyID )",
+							{ "parentID" : 1, "familyID" : 2 },
+							{ "datasource" : "quick" }
+						);
+
+						var query = getInstance( "Registration" ).whereHas( "child", function( q ) {
+							q.whereIn( "familyID", function( subquery ) {
+								subquery.from( "family_parents" ).select( "familyID" );
+							} );
+						} );
+
+						expect( query.toSQL() ).toInclude( "SELECT `family_parents`.`familyID` FROM `family_parents`" );
+						expect( query.get() ).toBeEmpty();
+					} );
+
 					it( "automatically groups where clauses with an OR combinator inside whereHas", function() {
 						var sql = getInstance( "User" )
 							.whereHas( "posts", function( q ) {

--- a/tests/specs/integration/BaseEntity/ScopeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ScopeSpec.cfc
@@ -62,6 +62,18 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( users[ 2 ].getUsername() ).toBe( "elpete2" );
 			} );
 
+			it( "uses the subquery table for columns that are also entity attributes", function() {
+				var sql = getInstance( "User" )
+					.whereNotIn( "country_id", function( q ) {
+						q.from( "countries" ).select( "id" );
+					} )
+					.toSQL();
+
+				expect( sql ).toInclude( "SELECT `countries`.`id` FROM `countries`" );
+				expect( sql ).toInclude( "`users`.`country_id` NOT IN" );
+				expect( sql ).notToInclude( "SELECT `users`.`id` FROM `countries`" );
+			} );
+
 			it( "wraps scopes in parenthesis automatically if the scope contains an or clause", function() {
 				var sql = getInstance( "User" ).canView().toSQL();
 				expect( sql ).toBe(


### PR DESCRIPTION
Closes #248
Closes #231

## Issue review

Issues #248 and #231 are the same reproducible table-qualification bug at different nesting depths. A closure-based `whereIn`/`whereNotIn` subquery inherits Quick's entity-aware column formatter. After the closure changes the subquery table with `from()`, attribute names shared with the parent entity were still qualified against the parent table.

Recommendation: **10/10 - implement.**

Reasons for:

- the generated SQL can silently return incorrect records, not merely throw an error;
- closure subqueries and relationship constraints are supported public qb/Quick APIs;
- the fix retains attribute-to-column mapping while using the subquery's actual table or alias;
- the same correction covers direct subqueries (#248) and subqueries nested inside `whereHas` (#231).

Tradeoffs:

- subquery columns are now explicitly qualified with their current table/alias, which can change exact SQL-string snapshots;
- the formatter adjustment is deliberately scoped to closure-based `whereIn`/`whereNotIn` subqueries rather than changing qualification globally.

## Reproduction and fix

The #248 regression uses a direct public `whereNotIn` query. Before the fix, current `next` with qb 14.0.0-beta.3 generated:

```sql
SELECT `users`.`id` FROM `countries`
```

The #231 regression recreates the reported nested public flow:

```cfml
getInstance( "Registration" ).whereHas( "child", function( q ) {
    q.whereIn( "familyID", function( subquery ) {
        subquery.from( "family_parents" ).select( "familyID" );
    } );
} );
```

Before the fix it generated:

```sql
SELECT `children`.`familyID` FROM `family_parents`
```

and could return a false-positive registration. The callback now installs a formatter tied to the subquery builder, producing `countries.id` and `family_parents.familyID` respectively. Table aliases are also honored.

## Validation

- #248 test-first reproduction: 9 passed, 1 failed, 0 errors before implementation.
- #231 test-first reproduction: 37 passed, 1 failed, 0 errors before implementation.
- focused relationship-query suite after fix: 38 passed, 0 failed, 0 errors.
- full Lucee 6 suite using qb 14.0.0-beta.3: 497 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`
