### PR TITLE
Add regression coverage for simple QuickQB update values

### DIFF
--- a/tests/specs/integration/BaseEntity/QuerySpec.cfc
+++ b/tests/specs/integration/BaseEntity/QuerySpec.cfc
@@ -41,6 +41,16 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( users[ 2 ].getId() ).toBe( 4 );
 				expect( users[ 2 ].getUsername() ).toBe( "elpete2" );
 			} );
+
+			it( "can pass simple values directly to QuickQB update", function() {
+				var sql = getInstance( "User" )
+					.newQuery()
+					.getQB()
+					.where( "id", 1 )
+					.update( values = { "username" : "someValue" }, toSql = true );
+
+				expect( sql ).toInclude( "UPDATE `users` SET `username` = ?" );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #246

## Issue review

This was a valid QuickQB bug: `update()` assumed every value could be inspected with `structKeyExists`, so a normal string value could throw an expression exception. It is a strong fit for Quick because QuickQB explicitly supports both ordinary update values and embedded QuickBuilder queries.

Recommendation: **10/10 — retain the fix and its regression coverage.**

Reasons for:
- strings and other simple values are the normal case for SQL updates
- the guard should only inspect structs when checking for the `isQuickBuilder` marker
- the behavior is part of Quick’s supported qb bridge

Tradeoffs:
- none beyond maintaining a focused integration test

## Attempted reproduction

I attempted the report on current `next` with qb 14.0.0-beta.3 through Quick’s public builder bridge:

```cfml
getInstance( "User" )
    .newQuery()
    .getQB()
    .where( "id", 1 )
    .update( values = { "username" : "someValue" }, toSql = true );
```

The exception no longer reproduces. The production fix already landed in commit `70b1710` (`fix(QueryUtils): Minor fix for isQuickBuilder checks on BoxLang`), which added the required `isStruct(...)` guard to `QuickQB.update()` and the related QuickBuilder conversion sites.

This PR adds the missing regression test so the simple-value path remains protected. No additional production change is necessary.

## Validation

- focused QuerySpec: 5 passed, 0 failed, 0 errors
- full Lucee 6 suite using qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed