### PR TITLE
Clarify that create returns a separate entity

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1317,6 +1317,16 @@ component accessors="true" {
 	/**
 	 * Creates a new entity with the given attributes and then saves the entity.
 	 *
+	 * This method always creates and returns a separate entity instance. It does
+	 * not fill, save, or otherwise mutate the entity on which it was called.
+	 * Assign the returned entity when it needs to be used after creation:
+	 *
+	 * ```
+	 * var user = getInstance( "User" ).newEntity();
+	 * user = user.create( { "firstName" : "Dave" } );
+	 * user.isLoaded(); // true
+	 * ```
+	 *
 	 * @attributes                   A struct of key / value pairs.
 	 * @ignoreNonExistentAttributes  If true, does not throw an exception if an
 	 *                               attribute does not exist.  Instead, it skips

--- a/tests/specs/integration/BaseEntity/CreateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CreateSpec.cfc
@@ -17,6 +17,21 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				).notToBeNull();
 			} );
 
+			it( "returns a separate loaded entity without mutating the original entity", function() {
+				var originalUser = getInstance( "User" ).newEntity();
+				var createdUser  = originalUser.create( {
+					"username"   : "Dave",
+					"first_name" : "Dave",
+					"last_name"  : "Create",
+					"password"   : hash( "password" )
+				} );
+
+				expect( originalUser.isLoaded() ).toBeFalse();
+				expect( originalUser.isNullAttribute( "username" ) ).toBeTrue();
+				expect( createdUser.isLoaded() ).toBeTrue();
+				expect( createdUser.getUsername() ).toBe( "Dave" );
+			} );
+
 			it( "can ignore non-existant properties", function() {
 				var user = getInstance( "User" ).create(
 					{


### PR DESCRIPTION
Addresses #245

## Issue review

This is a useful and accurate documentation improvement. `BaseEntity.create()` is a factory-style convenience method: it calls `newEntity()`, fills that new instance, saves it, and returns it. Calling `create()` does not mutate or load the receiver. That distinction is easy to miss and can leave application variables pointing at an unloaded entity.

Recommendation: **9/10 — document explicitly.**

Reasons for:
- misunderstanding the return value can produce subtle application bugs
- the implementation has always made the separate-instance behavior explicit, but the user-facing wording does not
- a short assignment example makes the safe usage obvious

Tradeoffs:
- the GitBook page itself is maintained in the separate `ortus-docs/quick-docs` repository on version branches; that repository has no `next` branch
- this PR therefore updates Quick’s source/API documentation and locks the behavior down in `next`, while the same wording should be carried to the versioned GitBook source when documentation is published

## Implementation

The `BaseEntity.create()` documentation now states that it always creates and returns a separate instance, does not mutate the receiver, and shows assigning the return value.

A public API integration test demonstrates the exact concern from the issue:
- the original entity remains unloaded and has no username
- the returned entity is loaded and has the created username

No runtime behavior was changed.

## Validation

- focused CreateSpec: 4 passed, 0 failed, 0 errors
- full Lucee 6 suite using qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed