### PR TITLE
Strengthen eager loaded relationship default coverage

### DIFF
--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -526,7 +526,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} ).notToThrow();
 			} );
 
-			it( "can provides default models if they are defined for the relationship", () => {
+			it( "can provide default models if they are defined for the relationship", () => {
 				var categories = getInstance( "Category" )
 					.with( "parent" )
 					.orderByAsc( "id" )
@@ -541,6 +541,17 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( categories[ 2 ].getParent() ).notToBeNull();
 				expect( categories[ 2 ].getParent().isLoaded() ).toBeTrue( "Category 2 should have a parent Category loaded from the database" );
 				expect( categories[ 2 ].getParent().getId() ).toBe( 1 );
+			} );
+
+			it( "caches a default model for an unmatched eager loaded relationship", () => {
+				var category = getInstance( "Category" ).with( "parent" ).findOrFail( 1 );
+
+				expect( category.isRelationshipLoaded( "parent" ) ).toBeTrue();
+				expect( function() {
+					return category.getParent().isLoaded();
+				} ).notToThrow();
+				expect( category.getParent() ).toBeInstanceOf( "Category" );
+				expect( category.getParent().isLoaded() ).toBeFalse();
 			} );
 
 			describe( "handling lazy loading", () => {


### PR DESCRIPTION
Closes #242

## Issue review

This was a valid eager-loading bug. When a `belongsTo(...).withDefault()` relationship had no foreign-key value, eager loading initialized the relationship as null instead of caching the configured default entity. Calling the magic relationship getter could then fail even though lazy relationship execution returned a default.

Recommendation: **10/10 — preserve the fix and exact regression path.**

Reasons for:
- eager and lazy loading should honor `withDefault()` consistently
- relationship getters are the normal public access path
- avoiding a relationship query when the foreign key is null is desirable, but the cached value must still be correct

Tradeoffs:
- unmatched eager relationships with `withDefault()` return an unloaded default entity rather than null; this was intentionally documented as a breaking correction when fixed

## Attempted reproduction

Current `next` with qb 14.0.0-beta.3 no longer reproduces the exception. Commit `b1212de` (`fix(Relationships): Return default entities for non-matched eager loaded entities`) added the production fix and the self-referencing Category fixture from this report.

This PR strengthens the coverage to match the exact public flow:

```cfml
var category = getInstance( "Category" )
    .with( "parent" )
    .findOrFail( 1 );
category.getParent().isLoaded();
```

It now explicitly verifies that:
- `parent` is marked as loaded in the relationship cache
- the getter does not throw
- the cached value is a Category
- the default Category itself is correctly unloaded

No additional production change is necessary.

## Validation

- focused EagerLoadingSpec: 28 passed, 0 failed, 0 errors
- full Lucee 6 suite using qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed