### PR TITLE
test: cover constrained hasManyThrough eager loading

### DIFF
--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -260,6 +260,17 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
 			} );
 
+			it( "preserves constraints from intermediate has many relationships", function() {
+				var country = getInstance( "Country" )
+					.with( "publishedPostTags" )
+					.findOrFail( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
+
+				expect( country.getPublishedPostTags() ).toHaveLength( 2 );
+				expect( country.getPublishedPostTags()[ 1 ].getName() ).toBe( "programming" );
+				expect( country.getPublishedPostTags()[ 2 ].getName() ).toBe( "music" );
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+			} );
+
 			it( "can eager load a long has many through relationship", function() {
 				var countries = getInstance( "Country" ).with( "comments" ).get();
 				expect( countries ).toBeArray();


### PR DESCRIPTION
## Issue review

Issue #241 reports that constraints defined on an intermediate `hasMany` relationship are lost when that relationship participates in a `hasManyThrough`, especially during eager loading.

This behavior is essential for relationship composition. I rate the request **10/10** for Quick: callers should be able to trust that a constrained relationship keeps its semantics when reused. The main tradeoff is that through-relation query construction is complex, so exact integration coverage is important.

## Reproduction result

I attempted the reported scenario on current `next` with `qb 14.0.0-beta.3`, using the public entity API: `Country.with( "publishedPostTags" ).findOrFail(...)`, where `publishedPostTags` traverses the constrained `User.publishedPosts` relationship.

The bug no longer reproduces. The production behavior appears to have been fixed by commits `95a53d3` and `3f3de36`, which preserve final and intermediate relationship constraints in `HasManyThrough`.

## Change

- Adds exact eager-loading regression coverage through the public Quick API.
- Verifies that only tags belonging to published posts are returned.
- Verifies eager loading remains limited to two queries.

## Validation

- Focused eager-loading suite: 28 passed, 0 failed, 0 errors.
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Closes #241
