### PR TITLE
test: cover original data in entity preUpdate events

### DIFF
--- a/tests/resources/app/models/Song.cfc
+++ b/tests/resources/app/models/Song.cfc
@@ -35,7 +35,9 @@ component extends="quick.models.BaseEntity" accessors="true" {
     function preUpdate( eventData ) {
         param request.preUpdateCalled = [];
         arrayAppend( request.preUpdateCalled, {
-            "entity": eventData.entity.getMemento()
+            "entity": eventData.entity.getMemento(),
+            "originalAttributes": eventData.originalAttributes,
+            "newAttributes": eventData.newAttributes
         } );
     }
 

--- a/tests/specs/integration/BaseEntity/Events/PreUpdateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PreUpdateSpec.cfc
@@ -52,6 +52,12 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( request.preUpdateCalled[ 1 ].entity.downloadUrl ).toBe(
 					"https://open.spotify.com/track/0GHGd3jYqChGNxzjqgRZSv"
 				);
+				expect( request.preUpdateCalled[ 1 ].originalAttributes.download_url ).toBe(
+					"https://open.spotify.com/track/4Nd5HJn4EExnLmHtClk4QV"
+				);
+				expect( request.preUpdateCalled[ 1 ].newAttributes.download_url ).toBe(
+					"https://open.spotify.com/track/0GHGd3jYqChGNxzjqgRZSv"
+				);
 				structDelete( request, "preUpdateCalled" );
 			} );
 		} );


### PR DESCRIPTION
## Issue review

Issue #239 requests access to an entity's previous data during `preUpdate` so consumers can build reliable audit records.

I rate this **10/10** for Quick. Audit hooks need an immutable before/after view, and the `preUpdate` lifecycle point is the natural place to expose it. The only meaningful concern is event-payload compatibility, which is additive here.

## Analysis and implementation status

Current `next` with `qb 14.0.0-beta.3` already implements the feature. Commit `4dd8496` added `originalAttributes` and `newAttributes` to the `preUpdate` event payload.

Existing coverage verified those fields through the global `quickPreUpdate` interceptor, but did not verify the entity's own `preUpdate( eventData )` callback. This PR extends the integration fixture and assertions so both public event-consumption paths are covered.

## Test-first result

The new component-callback assertions initially errored because the test entity retained only `eventData.entity`. Updating the fixture to retain the actual `originalAttributes` and `newAttributes` payload made the test pass without any production-code change.

## Validation

- Focused pre-update suite: 2 passed, 0 failed, 0 errors.
- Full suite: 495 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Closes #239
