### PR TITLE
fix: advance nested has relationship paths

### DIFF
--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -580,14 +580,19 @@ component
 			q = q.getQB();
 		}
 
-		arguments.relationQuery = invoke(
-			arguments.relationQuery,
-			"whereExists",
-			{ "query" : q }
-		);
+		var parentQuery            = arguments.relationQuery;
+		arguments.relationQuery    = q;
+		arguments.relationshipName = listRest( arguments.relationshipName, "." );
+		var nestedQuery            = hasNested( argumentCollection = arguments );
+		if ( structKeyExists( nestedQuery, "getQB" ) ) {
+			nestedQuery = nestedQuery.getQB();
+		}
 
-		var result = hasNested( argumentCollection = arguments );
-		return structKeyExists( result, "getQB" ) ? result.getQB() : result;
+		return invoke(
+			parentQuery,
+			"whereExists",
+			{ "query" : nestedQuery }
+		);
 	}
 
 	/**

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -411,6 +411,25 @@ component
 		string combinator = "and",
 		boolean negate    = false
 	) {
+		if ( listLen( arguments.relationshipName, "." ) > 1 ) {
+			var nestedArguments = { "relationshipName" : listRest( arguments.relationshipName, "." ) };
+			if ( structKeyExists( arguments, "operator" ) ) {
+				nestedArguments.operator = arguments.operator;
+			}
+			if ( structKeyExists( arguments, "count" ) ) {
+				nestedArguments.count = arguments.count;
+			}
+
+			return whereHas(
+				relationshipName = listFirst( arguments.relationshipName, "." ),
+				callback         = function( q ) {
+					q.has( argumentCollection = nestedArguments );
+				},
+				combinator = arguments.combinator,
+				negate     = arguments.negate
+			);
+		}
+
 		var relation = getEntity().ignoreLoadedGuard( function() {
 			var relationName = listFirst( relationshipName, "." );
 			return getEntity().withoutRelationshipConstraints( relationName, function() {
@@ -422,26 +441,6 @@ component
 			.addCompareConstraints()
 			.clearOrders()
 			.select( relation.raw( 1 ) );
-
-		if ( listLen( arguments.relationshipName, "." ) > 1 ) {
-			arguments.relationshipName = listRest( arguments.relationshipName, "." );
-
-			if ( structKeyExists( arguments.relationQuery, "retrieveQuery" ) ) {
-				arguments.relationQuery = arguments.relationQuery.retrieveQuery();
-			}
-
-			var nested = hasNested( argumentCollection = arguments );
-			if ( structKeyExists( nested, "getQB" ) ) {
-				nested = nested.getQB();
-			}
-			whereExists(
-				query      = nested,
-				combinator = arguments.combinator,
-				negate     = arguments.negate
-			);
-
-			return this;
-		}
 
 		arguments.relationQuery.when( !isNull( arguments.operator ) && !isNull( arguments.count ), function( q ) {
 			q.having( q.raw( "COUNT(*)" ), operator, count );
@@ -518,81 +517,6 @@ component
 	) {
 		arguments.combinator = "or";
 		return doesntHave( argumentCollection = arguments );
-	}
-
-	/**
-	 * Checks for the existence of a nested relationship when executing the query.
-	 *
-	 * @relationQuery     The currently configured existence check query.
-	 * @relationshipName  The relationship to check.  Can be a dot-delimited
-	 *                    list of nested relationships.
-	 * @operator          An optional operator to constrain the check.
-	 * @count             An optional count to constrain the check.
-	 *
-	 * @return            quick.models.QuickQB
-	 */
-	private any function hasNested(
-		required any relationQuery,
-		required string relationshipName,
-		any operator,
-		numeric count
-	) {
-		var relation = relationQuery
-			.getEntity()
-			.ignoreLoadedGuard( function() {
-				var relationName = listFirst( relationshipName, "." );
-				return relationQuery
-					.getEntity()
-					.withoutRelationshipConstraints( relationName, function() {
-						return invoke( relationQuery.getEntity(), relationName );
-					} );
-			} );
-
-		if ( listLen( arguments.relationshipName, "." ) == 1 ) {
-			var q = relation
-				.addCompareConstraints()
-				.when( !isNull( arguments.operator ) && !isNull( arguments.count ), function( q ) {
-					q.having( q.raw( "COUNT(*)" ), operator, count );
-				} );
-
-			if ( structKeyExists( q, "retrieveQuery" ) ) {
-				q = q.retrieveQuery();
-			}
-
-			if ( structKeyExists( q, "getQB" ) ) {
-				q = q.getQB();
-			}
-
-			return invoke(
-				arguments.relationQuery,
-				"whereExists",
-				{ "query" : q }
-			);
-		}
-
-		var q = relation.addCompareConstraints();
-
-		if ( structKeyExists( q, "retrieveQuery" ) ) {
-			q = q.retrieveQuery();
-		}
-
-		if ( structKeyExists( q, "getQB" ) ) {
-			q = q.getQB();
-		}
-
-		var parentQuery            = arguments.relationQuery;
-		arguments.relationQuery    = q;
-		arguments.relationshipName = listRest( arguments.relationshipName, "." );
-		var nestedQuery            = hasNested( argumentCollection = arguments );
-		if ( structKeyExists( nestedQuery, "getQB" ) ) {
-			nestedQuery = nestedQuery.getQB();
-		}
-
-		return invoke(
-			parentQuery,
-			"whereExists",
-			{ "query" : nestedQuery }
-		);
 	}
 
 	/**

--- a/tests/resources/app/models/Permission.cfc
+++ b/tests/resources/app/models/Permission.cfc
@@ -7,4 +7,8 @@ component extends="quick.models.BaseEntity" accessors="true" {
         return belongsToMany( "Role" );
     }
 
+    function usersThroughRoles() {
+        return hasManyThrough( [ "roles", "users" ] );
+    }
+
 }

--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -171,6 +171,10 @@ component extends="quick.models.BaseEntity" accessors="true" {
 		return hasManyThrough( [ "roles", "permissions" ] );
 	}
 
+	function commentsThroughPosts() {
+		return hasManyThrough( [ "posts", "comments" ] );
+	}
+
 	function permissionsDeep() {
 		return hasManyDeep(
 			relationName = "Permission",

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -194,6 +194,14 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						expect( posts ).toBeArray();
 						expect( posts ).notToBeEmpty();
 					} );
+
+					it( "can traverse two belongsToMany relationships before a hasMany relationship", function() {
+						var posts = getInstance( "Post" ).has( "tags.posts.comments" ).get();
+
+						expect( posts ).toBeArray();
+						expect( posts ).toHaveLength( 3 );
+					} );
+
 					it( "can join after populating a cloned query builder", function() {
 						var posts = getInstance( "Post" ).newQuery();
 						posts.populateQuery( posts.getQB().clone() );

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -224,6 +224,21 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						expect( countries ).toBeArray();
 						expect( countries ).toHaveLength( 2 );
 					} );
+
+					it( "can eager load and check three nested hasManyThrough relationships", function() {
+						var query = getInstance( "Country" )
+							.with( "permissions.usersThroughRoles.commentsThroughPosts" )
+							.has( "permissions.usersThroughRoles.commentsThroughPosts" );
+
+						expect( query.toSQL() ).toInclude( "EXISTS" );
+
+						var countries = getInstance( "Country" )
+							.has( "permissions.usersThroughRoles.commentsThroughPosts" )
+							.get();
+
+						expect( countries ).toBeArray();
+						expect( countries ).toHaveLength( 2 );
+					} );
 				} );
 
 				describe( "hasOne", function() {


### PR DESCRIPTION
## Issue review

Issues #238 and #153 both report stack overflows from public `has()` calls across relationship paths longer than two segments. #153 specifically traverses `BelongsToMany -> BelongsToMany -> hasMany`.

I rate both **10/10** for Quick. Arbitrarily deep relationship paths are part of the public `has()` contract, and a stack overflow is severe and difficult for callers to diagnose. The main implementation concern is preserving each relationship type's specialized comparison and pivot-table behavior while composing the nested query.

## Reproduction

I recreated both reports with public Quick entity flows:

- #238: three nested `hasManyThrough` relationships.
- #153: `Post.has("tags.posts.comments")`, which traverses two `BelongsToMany` relationships followed by a polymorphic `hasMany`.

On current `next` with `qb 14.0.0-beta.3`, both tests reproduced a `StackOverflowError`. The #153 regression overflowed after about 35 seconds.

## Root cause and fix

The old `hasNested()` recursion did not advance the remaining relationship path, which recursively resolved the same relationship forever.

An initial path-advancement repair stopped the overflow but generated invalid SQL for #153 by losing the enclosing `tags` query and referencing `tags.id` outside its scope. The final implementation composes nested `has()` calls through the established `whereHas()` relationship path. That lets each relationship type build and nest its own comparison constraints, including `BelongsToMany` pivot queries, and removes the duplicate recursive implementation.

Both regression tests use public Quick builder/entity APIs and execute the generated queries.

## Validation

- Before fix: focused suite produced 2 `StackOverflowError` errors.
- After fix: focused relationship-query suite: 39 passed, 0 failed, 0 errors.
- Full suite: 497 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Closes #238
Closes #153
