### PR TITLE
test: cover pagination ordered by subquery attributes

### DIFF
--- a/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
@@ -29,6 +29,40 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				);
 			} );
 
+			it( "can paginate while ordering by a subquery attribute", function() {
+				var page = getInstance( "User" )
+					.addSubselect( "latestPostId", ( qb ) => {
+						qb.from( "my_posts" )
+							.select( "post_pk" )
+							.whereColumn( "my_posts.user_id", "=", "users.id" )
+							.orderByDesc( "published_date" )
+							.limit( 1 );
+					} )
+					.orderByDesc( "latestPostId" )
+					.paginate( page = 1, maxRows = 2 );
+
+				expect( page.results ).toHaveLength( 2 );
+				expect( page.results[ 1 ].getLatestPostId() ).notToBeNull();
+				expect( page.results[ 2 ].getLatestPostId() ).notToBeNull();
+			} );
+
+			it( "uses native SQL Server pagination when ordering by a subquery attribute", function() {
+				var sql = getInstance( "User" )
+					.addSubselect( "latestPostId", ( qb ) => {
+						qb.from( "my_posts" )
+							.select( "post_pk" )
+							.whereColumn( "my_posts.user_id", "=", "users.id" )
+							.limit( 1 );
+					} )
+					.orderByDesc( "latestPostId" )
+					.setGrammar( getInstance( "SqlServerGrammar@qb" ) )
+					.forPage( page = 1, maxRows = 2 )
+					.toSQL();
+
+				expect( sql ).toInclude( "ORDER BY [latestPostId] DESC OFFSET 0 ROWS FETCH NEXT 2 ROWS ONLY" );
+				expect( sql ).notToInclude( "ROW_NUMBER()" );
+			} );
+
 			it( "can add a subquery to an entity using a relationship", function() {
 				var elpete = getInstance( "User" ).withLatestPostIdRelationship().findOrFail( 1 );
 				expect( elpete.getLatestPostId() ).notToBeNull();


### PR DESCRIPTION
## Issue review

Issue #236 reports SQL Server pagination failing when ordering by a column alias produced by a subquery. The old qb SQL placed the aliased subselect and `ROW_NUMBER() OVER (ORDER BY alias)` in the same projection scope, where SQL Server could not resolve the alias.

I rate this **8/10** for Quick. Paginating ordered computed attributes is a valid and useful entity-query workflow. The argument against a Quick production change is ownership: SQL pagination compilation belongs to qb, and changing it in Quick would duplicate dialect logic.

## Reproduction result

The reported SQL no longer reproduces on current `next` with the required `qb 14.0.0-beta.3`.

qb's current SQL Server grammar uses native `OFFSET ... FETCH NEXT` pagination. The compiled order is applied directly as `ORDER BY [latestPostId] DESC`, so there is no same-scope `ROW_NUMBER()` reference to the subquery alias.

## Change

- Adds a public Quick integration test that executes pagination ordered by a subquery-derived attribute.
- Adds SQL Server compilation coverage proving the same public query emits `OFFSET ... FETCH NEXT` and does not emit `ROW_NUMBER()`.
- No production change is needed because the latest qb behavior already resolves the issue.

## Validation

- Focused subquery suite: 13 passed, 0 failed, 0 errors.
- Full suite: 497 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Closes #236
