### PR TITLE
fix: recognize key columns mapped to aliases

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2834,7 +2834,16 @@ component accessors="true" {
 						meta.attributes[ meta.localMetaData.discriminatorColumn ] = paramAttribute( { "name" : meta.localMetaData.discriminatorColumn } );
 					}
 					arrayWrap( variables._key ).each( function( key ) {
-						if ( !meta.attributes.keyExists( key ) ) {
+						var keyIsDefined = meta.attributes.keyExists( key );
+						if ( !keyIsDefined ) {
+							for ( var attribute in meta.attributes ) {
+								if ( compareNoCase( meta.attributes[ attribute ].column, key ) == 0 ) {
+									keyIsDefined = true;
+									break;
+								}
+							}
+						}
+						if ( !keyIsDefined ) {
 							var keyProp                     = paramAttribute( { "name" : key } );
 							meta.attributes[ keyProp.name ] = keyProp;
 						}

--- a/tests/resources/app/models/AliasedComposite.cfc
+++ b/tests/resources/app/models/AliasedComposite.cfc
@@ -1,0 +1,16 @@
+component table="composites" extends="quick.models.BaseEntity" accessors="true" {
+
+    property name="groupId" column="a";
+    property name="memberId" column="b";
+
+    variables._key = [ "a", "b" ];
+
+    this.memento = {
+        "defaultIncludes": [ "groupId", "memberId" ]
+    };
+
+    function keyType() {
+        return variables._wirebox.getInstance( "NullKeyType@quick" );
+    }
+
+}

--- a/tests/specs/integration/BaseEntity/AliasedCompositeKeySpec.cfc
+++ b/tests/specs/integration/BaseEntity/AliasedCompositeKeySpec.cfc
@@ -1,0 +1,17 @@
+component extends="tests.resources.ModuleIntegrationSpec" {
+
+	function run() {
+		describe( "Aliased Composite Key Spec", function() {
+			it( "supports physical column names in a composite key with aliased properties", function() {
+				var composite = getInstance( "AliasedComposite" ).findOrFail( [ 1, 2 ] );
+
+				expect( composite.getGroupId() ).toBe( 1 );
+				expect( composite.getMemberId() ).toBe( 2 );
+				expect( composite.keyNames() ).toBe( [ "a", "b" ] );
+				expect( composite.keyValues() ).toBe( [ 1, 2 ] );
+				expect( composite.getMemento() ).toBe( { "groupId" : 1, "memberId" : 2 } );
+			} );
+		} );
+	}
+
+}


### PR DESCRIPTION
## Issue review

Issue #235 reports that a composite `_key` declared with physical database column names breaks aliased entity properties and mementos.

I rate this **10/10** for Quick. Quick explicitly supports column aliases, and primary-key configuration should accept the physical columns that actually define the database key. Requiring aliases only would be surprising and makes schema-oriented key declarations fragile. The main implementation concern is preserving synthetic key attributes for genuinely undeclared keys.

## Reproduction

I added an entity backed by the existing composite-key table with:

- properties `groupId`/`memberId` mapped to columns `a`/`b`;
- `_key = [ "a", "b" ]`;
- a memento including the aliased properties.

On current `next` with `qb 14.0.0-beta.3`, `findOrFail( [ 1, 2 ] )` found the row, but `getGroupId()` returned null. The public regression failed before the fix.

## Root cause and fix

Metadata inspection checked whether each configured key existed only as an attribute alias. A key expressed as a mapped physical column therefore caused Quick to synthesize a duplicate attribute. That duplicate replaced the column-to-alias lookup, so hydration populated the physical-name variable instead of the declared aliased property.

The fix recognizes a configured key when it matches either an attribute alias or an attribute's physical column. Quick still synthesizes metadata for keys that are genuinely undeclared.

The regression verifies public lookup, aliased getters, `keyNames()`, `keyValues()`, and `getMemento()`.

## Validation

- Before fix: focused public integration test failed (`getGroupId()` was null).
- After fix: focused suite: 1 passed, 0 failed, 0 errors.
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Closes #235
