### PR TITLE
test: cover discriminated cast mementos

### DIFF
--- a/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeCastsSpec.cfc
@@ -114,9 +114,12 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( pn.getConfirmed() ).toBe( "casted-null" );
 			} );
 
-			it( "correctly casts child entities", () => {
+			it( "casts single table discriminated child entities loaded through the parent", () => {
 				var product = getInstance( "BaseProduct" ).firstOrFail();
+
+				expect( product ).toBeInstanceOf( "ProductBook" );
 				expect( product.getMetadata() ).toBeStruct();
+				expect( product.getMemento().metadata ).toBeStruct();
 			} );
 
 			it( "can maintain casts when loading a discriminated child through the parent", () => {


### PR DESCRIPTION
## Issue review

Issue #233 reports that casts declared on a single-table-inheritance parent were skipped when Quick materialized a discriminated child, leaving JSON as an encoded string in the public memento.

I rate this **10/10** for Quick. Discrimination should change the concrete entity type, not the meaning of inherited attributes. Cast consistency is particularly important because otherwise getters and serialized API output silently change shape. The implementation risk is ensuring parent metadata is transferred without double-casting child values.

## Reproduction result and history

The issue no longer reproduces on current `next` with `qb 14.0.0-beta.3`.

The linked Ortus community thread confirms the fix shipped with Quick 9.0.0. Commit `288b81b` corrected discriminated-child hydration so attribute assignment applies inherited casts, and later discriminated-entity coverage protects related metadata transfer.

Current coverage checked the casted getter but did not assert the exact reported surface: `getMemento()`.

## Change

- Strengthens the public integration test to confirm the parent query returns the expected discriminated child type.
- Confirms `JsonCast@quick` returns a struct through the entity getter.
- Confirms the public memento also contains a struct rather than an encoded JSON string.
- No production change is needed because the behavior is already fixed.

## Validation

- Focused attribute-cast suite: 15 passed, 0 failed, 0 errors.
- Full suite: 495 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Closes #233
