### PR TITLE
test: cover date updates through query receivers

### DIFF
--- a/tests/specs/integration/BaseEntity/UpdateAllSpec.cfc
+++ b/tests/specs/integration/BaseEntity/UpdateAllSpec.cfc
@@ -17,6 +17,32 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( postA.getBody() ).toBe( "The new body" );
 				expect( postB.getBody() ).toBe( "The new body" );
 			} );
+
+			it( "can update date values after switching to query results", function() {
+				var originalDate = getInstance( "User" ).findOrFail( 1 ).getModifiedDate();
+				var futureDate   = now().add( "d", 1 );
+
+				var result = getInstance( "User" )
+					.where( "id", 1 )
+					.asQuery()
+					.update( { "modified_date" : futureDate } );
+
+				expect( result.result.recordCount ).toBe( 1 );
+				expect( getInstance( "User" ).findOrFail( 1 ).getModifiedDate() ).notToBe( originalDate );
+			} );
+
+			it( "can update date values through the underlying query", function() {
+				var originalDate = getInstance( "User" ).findOrFail( 1 ).getModifiedDate();
+				var futureDate   = now().add( "d", 2 );
+
+				var result = getInstance( "User" )
+					.where( "id", 1 )
+					.retrieveQuery()
+					.update( { "modified_date" : futureDate } );
+
+				expect( result.result.recordCount ).toBe( 1 );
+				expect( getInstance( "User" ).findOrFail( 1 ).getModifiedDate() ).notToBe( originalDate );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #228

## Issue review

**Recommendation: 8/10.** Quick should preserve qb-compatible mutation behavior after callers intentionally switch from a Quick builder to a query result receiver. A CFML date is a normal qb update value and should not be mistaken for a nested QuickBuilder payload.

Reasons for:
- `asQuery()` and `retrieveQuery()` are public escape hatches into qb, so their returned builders should accept qb-supported date values.
- The original failure was a runtime `CasterException`, making otherwise valid update statements unusable.
- Regression coverage protects the compatibility boundary between Quick and qb.

Tradeoffs:
- `updateAll()` remains the more entity-aware Quick API and is preferable for ordinary mass updates.
- The underlying behavior belongs substantially to qb compatibility rather than Quick entity semantics.

## Reproduction

I attempted the reported update through both public paths using the current `next` dependencies (`qb 14.0.0-beta.3`). The original cast exception no longer reproduces. The current `QuickQB.update()` only treats a struct as a nested Quick builder when it also exposes `isQuickBuilder`, a guard introduced by the existing qb compatibility work.

This PR adds integration coverage proving both paths execute the date update and persist a changed timestamp.

## Validation

- Focused: 3 passed, 0 failed, 0 errors
- Full suite: 497 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`