### PR TITLE
fix: refresh scoped virtual projections

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1067,13 +1067,19 @@ component accessors="true" {
 	 * @return  quick.models.BaseEntity
 	 */
 	public any function fresh() {
-		return newQuery()
+		var freshEntity = isNull( variables._refreshQuery ) ? newQuery() : variables._refreshQuery.clone().offset( 0 );
+		var freshData   = freshEntity
+			.from( tableName() )
 			.where( function( q ) {
 				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
-					q.where( keyName, keyValue );
+					q.where( this.qualifyColumn( keyName ), keyValue );
 				} );
 			} )
 			.first();
+		if ( !isStruct( freshData ) || structKeyExists( freshData, "isQuickEntity" ) ) {
+			return freshData;
+		}
+		return newEntity().hydrate( freshData ).set_refreshQuery( variables._refreshQuery );
 	}
 
 	/**

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -200,6 +200,12 @@ component accessors="true" {
 	 */
 	property name="_virtualAttributes" persistent="false";
 
+	/**
+	 * A snapshot of the query used to load this entity. It is replayed by refresh
+	 * so scoped projections and other query customizations stay in sync.
+	 */
+	property name="_refreshQuery" persistent="false";
+
 
 	/**
 	 * A boolean flag indicating that the entity has been loaded from the database.
@@ -1079,16 +1085,21 @@ component accessors="true" {
 	public any function refresh() {
 		variables._relationshipsData   = {};
 		variables._relationshipsLoaded = {};
+		var refreshedEntity            = isNull( variables._refreshQuery ) ? newQuery() : variables._refreshQuery
+			.clone()
+			.offset( 0 );
+		var refreshedData = refreshedEntity
+			.from( tableName() )
+			.where( function( q ) {
+				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
+					q.where( this.qualifyColumn( keyName ), keyValue );
+				} );
+			} )
+			.first();
 		assignAttributesData(
-			newQuery()
-				.from( tableName() )
-				.where( function( q ) {
-					arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
-						q.where( this.qualifyColumn( keyName ), keyValue );
-					} );
-				} )
-				.first()
-				.retrieveAttributesData()
+			isStruct( refreshedData ) && !structKeyExists( refreshedData, "isQuickEntity" )
+			 ? refreshedData
+			 : refreshedData.retrieveAttributesData()
 		);
 		return this;
 	}

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -393,7 +393,14 @@ component accessors="true" transientCache="false" {
 	 */
 	private array function getEntities( any columns, struct options = {} ) {
 		var results = variables.qb.get( argumentCollection = arguments );
-		return variables._asQuery ? results : results.map( variables.loadEntity );
+		if ( variables._asQuery ) {
+			return results;
+		}
+
+		var refreshQuery = variables.qb.clone();
+		return results.map( function( data ) {
+			return loadEntity( data, refreshQuery );
+		} );
 	}
 
 	/**
@@ -1530,7 +1537,17 @@ component accessors="true" transientCache="false" {
 	 *
 	 * @return  quick.models.BaseEntity
 	 */
-	public any function loadEntity( required struct data ) {
+	public any function loadEntity( required struct data, any refreshQuery ) {
+		var loadedData     = arguments.data;
+		var hasVirtualData = getEntity()
+			.get_virtualAttributes()
+			.some( function( attribute ) {
+				return loadedData.keyExists( attribute );
+			} );
+		if ( hasVirtualData && isNull( arguments.refreshQuery ) ) {
+			arguments.refreshQuery = variables.qb.clone();
+		}
+
 		if (
 			getEntity().get_loadChildren()
 			&&
@@ -1569,20 +1586,28 @@ component accessors="true" transientCache="false" {
 				}
 			}
 
-			return childClass
+			var childEntity = childClass
 				.assignAttributesData( arguments.data )
 				.assignOriginalAttributes( arguments.data )
 				.set_preventLazyLoading( variables._preventLazyLoading )
 				.set_lazyLoadingViolationCallback( variables._lazyLoadingViolationCallback )
 				.markLoaded();
+			if ( hasVirtualData ) {
+				childEntity.set_refreshQuery( arguments.refreshQuery );
+			}
+			return childEntity;
 		} else {
-			return getEntity()
+			var entity = getEntity()
 				.newEntity()
 				.assignAttributesData( arguments.data )
 				.assignOriginalAttributes( arguments.data )
 				.set_preventLazyLoading( variables._preventLazyLoading )
 				.set_lazyLoadingViolationCallback( variables._lazyLoadingViolationCallback )
 				.markLoaded();
+			if ( hasVirtualData ) {
+				entity.set_refreshQuery( arguments.refreshQuery );
+			}
+			return entity;
 		}
 	}
 

--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -93,6 +93,10 @@ component extends="quick.models.BaseEntity" accessors="true" {
         */
 	}
 
+	function scopeWithFullName( qb ) {
+		qb.appendVirtualAttribute( "fullName" ).selectRaw( "CONCAT(first_name, ' ', last_name) AS fullName" );
+	}
+
 	function scopeWithLatestPostIdRelationship( qb ) {
 		qb.addSubselect(
 			"latestPostId",

--- a/tests/specs/integration/BaseEntity/GetSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GetSpec.cfc
@@ -39,6 +39,22 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getFullName() ).toBe( "Ada Peterson" );
 			} );
 
+			it( "reapplies subselects when retrieving fresh and refreshed entities", function() {
+				var user = getInstance( "User" ).withLatestPostId().findOrFail( 1 );
+				expect( user.getLatestPostId() ).toBe( 523526 );
+
+				queryExecute(
+					"UPDATE `my_posts` SET `created_date` = ? WHERE `post_pk` = ?",
+					[ "2030-01-01 00:00:00", 1245 ]
+				);
+
+				var freshUser = user.fresh();
+				expect( freshUser.getLatestPostId() ).toBe( 1245 );
+
+				user.refresh();
+				expect( user.getLatestPostId() ).toBe( 1245 );
+			} );
+
 			it( "can get a fresh instance from the database", function() {
 				var user = getInstance( "User" ).find( 1 );
 				expect( user.getUsername() ).toBe( "elpete" );

--- a/tests/specs/integration/BaseEntity/GetSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GetSpec.cfc
@@ -28,6 +28,17 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getUsername() ).toBe( "new_username" );
 			} );
 
+			it( "reapplies scoped projections when refreshing", function() {
+				var user = getInstance( "User" ).withFullName().findOrFail( 1 );
+				expect( user.getFullName() ).toBe( "Eric Peterson" );
+
+				queryExecute( "UPDATE `users` SET `first_name` = ? WHERE `id` = ?", [ "Ada", 1 ] );
+				user.refresh();
+
+				expect( user.getFirstName() ).toBe( "Ada" );
+				expect( user.getFullName() ).toBe( "Ada Peterson" );
+			} );
+
 			it( "can get a fresh instance from the database", function() {
 				var user = getInstance( "User" ).find( 1 );
 				expect( user.getUsername() ).toBe( "elpete" );


### PR DESCRIPTION
Closes #220
Closes #169

## Issue review

**Recommendation: 9/10.** Both reports describe the same correctness boundary: fresh or refreshed entities should not retain or discard derived values when the persisted data is reloaded. Replaying the projection that produced virtual data is a strong fit because `fresh()` and `refresh()` promise a current database representation.

Reasons for:
- Stale computed values leave one entity containing mutually inconsistent attributes.
- Dropped subselects make a fresh entity structurally different from the entity it replaces.
- Callers should not need to know whether a value came from a global scope, local scope, or explicit subselect.
- The originating qb query is the authoritative definition of raw and derived projections.

Tradeoffs:
- Entities containing virtual query data retain a cloned query snapshot until discarded.
- Replaying a scoped query preserves its original constraints; if the row no longer matches, the query cannot retrieve it, consistent with the scoped view that produced the entity.

## Reproduction

For #220, a public entity flow using `withFullName()` reproduced a stale virtual value after `refresh()`: the persisted attribute changed but the derived projection did not.

For #169, a public entity flow using `withLatestPostId()` reproduced the dropped subselect after `fresh()`. After changing which post was latest, the regression test expected the new post id but received an empty value. The focused bundle had 35 passes and 1 failure before implementation.

## Implementation

- Capture the underlying qb query when a loaded result contains virtual attributes.
- Replay that snapshot during both `fresh()` and `refresh()`, constrained by the entity key.
- Rehydrate raw replay results from `fresh()` into a normal Quick entity and retain the snapshot for later refreshes.
- Keep the existing path for entities without virtual query data.
- Add public integration regressions covering scoped projections and subselects.

## Validation

- Focused GetSpec: 36 passed, 0 failed, 0 errors
- Adjacent Subqueries/GlobalScope/ChildClass bundles: 48 passed, 0 failed, 0 errors, 1 skipped
- Full suite: 497 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Dependency: latest prerelease `qb 14.0.0-beta.3`.