### PR TITLE
fix: reset cached queries with entity state

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1033,6 +1033,9 @@ component accessors="true" {
 	 * @return  quick.models.BaseEntity
 	 */
 	public any function reset( boolean toNew = false ) {
+		if ( variables.keyExists( "_quickBuilder" ) ) {
+			structDelete( variables, "_quickBuilder" );
+		}
 		assignAttributesData( arguments.toNew ? {} : variables._originalAttributes );
 		if ( arguments.toNew ) {
 			assignOriginalAttributes( {} );

--- a/tests/specs/integration/BaseEntity/AttributeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeSpec.cfc
@@ -104,6 +104,14 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getUsername() ).toBe( "elpete" );
 			} );
 
+			it( "resets the cached query when resetting an entity", function() {
+				var users = getInstance( "User" );
+
+				users.where( "id", 1 );
+
+				expect( users.reset().get() ).toHaveLength( 5 );
+			} );
+
 			it( "shows all the attributes in the memento of a newly created object", function() {
 				var memento = getInstance( "User" ).getMemento();
 				if ( structCount( memento ) != 14 ) {


### PR DESCRIPTION
Closes #208

## Issue review

**Recommendation: 7/10.** Restoring the historical `reset()` behavior is worthwhile. Although `resetQuery()` is the explicit builder-only API, `reset()` previously reset both entity state and its underlying query, and leaving a hidden cached predicate behind is surprising.

Reasons for:
- This is a documented behavioral regression from the pre-split implementation.
- `reset()` otherwise presents the entity as restored while subsequent forwarded query calls still retain old state.
- Discarding the cached builder gives the entity the same clean query configuration as a newly resolved entity.

Tradeoffs:
- Callers that intentionally wanted to reset attributes while retaining a configured query must now keep/query the builder separately.
- `resetQuery()` remains the clearer API when only query state should change.

## Reproduction

I reproduced the issue through the public entity flow: apply an ID predicate, call `reset()`, then execute `get()`. Before the fix the result still contained one row instead of all five, producing 16 passes and 1 failure in the focused bundle.

## Implementation

- Remove the cached QuickBuilder during `BaseEntity.reset()`.
- Allow the next forwarded query call to construct a clean builder with normal defaults and scopes.
- Add a database-agnostic integration regression rather than asserting grammar-specific SQL.

## Validation

- Focused: 17 passed, 0 failed, 0 errors
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Dependency: latest prerelease `qb 14.0.0-beta.3`.