### PR TITLE
fix: synchronize loaded has-many relationships

### DIFF
--- a/models/Relationships/BelongsTo.cfc
+++ b/models/Relationships/BelongsTo.cfc
@@ -330,6 +330,23 @@ component
 	}
 
 	/**
+	 * Creates the related parent entity, associates it to the child, and caches
+	 * it as the loaded relationship value.  The child entity is not saved.
+	 *
+	 * @attributes  The attributes for the new related entity.
+	 *
+	 * @return      quick.models.BaseEntity
+	 */
+	public any function create( struct attributes = {} ) {
+		var createdEntity = variables.related
+			.newEntity()
+			.fill( arguments.attributes )
+			.save();
+		associate( createdEntity );
+		return createdEntity;
+	}
+
+	/**
 	 * Removes an entity as the parent of the relationship.
 	 * For example, if a Post belongs to a User, dissociate will set the
 	 * foreign key column on the Post entity to null.

--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -272,7 +272,9 @@ component
 			}, {} ),
 			force = true
 		);
-		return saveMany( argumentCollection = arguments );
+		var savedEntities = saveMany( argumentCollection = arguments );
+		variables.parent.assignRelationship( variables.relationMethodName, savedEntities );
+		return savedEntities;
 	}
 
 	/**
@@ -284,11 +286,20 @@ component
 	 * @return        [quick.models.BaseEntity]
 	 */
 	public array function saveMany( required any entities ) {
-		arguments.entities = isArray( arguments.entities ) ? arguments.entities : [ arguments.entities ];
+		arguments.entities        = isArray( arguments.entities ) ? arguments.entities : [ arguments.entities ];
+		var relationshipWasLoaded = variables.parent.isRelationshipLoaded( variables.relationMethodName );
+		var loadedEntities        = relationshipWasLoaded ? variables.parent.retrieveRelationship(
+			variables.relationMethodName
+		) : [];
 
-		return arguments.entities.map( function( entity ) {
+		var savedEntities = arguments.entities.map( function( entity ) {
 			return save( arguments.entity );
 		} );
+		if ( relationshipWasLoaded ) {
+			loadedEntities.append( savedEntities, true );
+			variables.parent.assignRelationship( variables.relationMethodName, loadedEntities );
+		}
+		return savedEntities;
 	}
 
 	/**

--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -303,6 +303,31 @@ component
 	}
 
 	/**
+	 * Deletes entities matching the relationship query and synchronizes a loaded parent cache.
+	 *
+	 * @ids  An optional array of related entity ids to delete.
+	 *
+	 * @return  { "query": QueryBuilder Return Format, "result": struct }
+	 */
+	public struct function deleteAll( array ids = [] ) {
+		var result = variables.relationshipBuilder.deleteAll( arguments.ids );
+
+		if ( variables.parent.isRelationshipLoaded( variables.relationMethodName ) ) {
+			if ( arguments.ids.isEmpty() ) {
+				var loadedValue = variables.parent.retrieveRelationship( variables.relationMethodName );
+				variables.parent.assignRelationship(
+					variables.relationMethodName,
+					isArray( loadedValue ) ? [] : javacast( "null", "" )
+				);
+			} else {
+				variables.parent.clearRelationship( variables.relationMethodName );
+			}
+		}
+
+		return result;
+	}
+
+	/**
 	 * Associates an entity or key value for an entity to the parent entity.
 	 *
 	 * @entity   An entity or key value for an entity to associate.

--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -327,12 +327,36 @@ component
 	/**
 	 * Creates a new entity, associates it to the parent entity, and returns it.
 	 *
-	 * @attributes  The attributes for the new related entity.
+	 * @attributes           The attributes for the new related entity.
+	 * @inverseRelationship  An optional relationship name on the new entity to
+	 *                       seed with the parent before saving.
 	 *
 	 * @return      quick.models.BaseEntity
 	 */
-	public any function create( struct attributes = {} ) {
-		return newEntity().fill( arguments.attributes ).save();
+	public any function create( struct attributes = {}, string inverseRelationship ) {
+		var createdEntity = newEntity().fill( arguments.attributes );
+		if ( !isNull( arguments.inverseRelationship ) ) {
+			if ( !createdEntity.hasRelationship( arguments.inverseRelationship ) ) {
+				throw(
+					type    = "RelationshipNotFound",
+					message = "The [#arguments.inverseRelationship#] relationship was not found on the [#createdEntity.entityName()#] entity."
+				);
+			}
+			createdEntity.assignRelationship( arguments.inverseRelationship, variables.parent );
+		}
+		createdEntity.save();
+
+		if ( variables.parent.isRelationshipLoaded( variables.relationMethodName ) ) {
+			var loadedValue = variables.parent.retrieveRelationship( variables.relationMethodName );
+			if ( isArray( loadedValue ) ) {
+				loadedValue.append( createdEntity );
+				variables.parent.assignRelationship( variables.relationMethodName, loadedValue );
+			} else {
+				variables.parent.assignRelationship( variables.relationMethodName, createdEntity );
+			}
+		}
+
+		return createdEntity;
 	}
 
 	/**

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToSpec.cfc
@@ -83,6 +83,23 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.posts().count() ).toBe( 3 );
 			} );
 
+			it( "assigns a newly created related entity to the belongsTo relationship", function() {
+				var post      = getInstance( "Post" ).findOrFail( 7777 );
+				var newAuthor = post
+					.author()
+					.create( {
+						"username"   : "relationship-author",
+						"first_name" : "Relationship",
+						"last_name"  : "Author",
+						"password"   : hash( "password" )
+					} );
+
+				expect( post.isRelationshipLoaded( "author" ) ).toBeTrue();
+				expect( post.getAuthor().isSameAs( newAuthor ) ).toBeTrue();
+				expect( post.getUser_Id() ).toBe( newAuthor.getId() );
+				expect( post.fresh().getAuthor() ).toBeNull();
+			} );
+
 			it( "can set the associated relationship by calling a relationship setter", function() {
 				var user    = getInstance( "User" ).find( 1 );
 				var newPost = getInstance( "Post" ).create( {

--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -63,6 +63,22 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( posts[ 2 ].getAuthor().getId() ).toBe( user.getId() );
 			} );
 
+			it( "updates an already-loaded relationship after saving many entities", function() {
+				var user = getInstance( "User" ).find( 1 );
+				expect( user.getPosts() ).toHaveLength( 2 );
+
+				var savedPosts = user
+					.posts()
+					.saveMany( [
+						getInstance( "Post" ).fill( { "body" : "A cached post" } ),
+						getInstance( "Post" ).fill( { "body" : "Another cached post" } )
+					] );
+
+				expect( user.getPosts() ).toHaveLength( 4 );
+				expect( user.getPosts()[ 3 ].isSameAs( savedPosts[ 1 ] ) ).toBeTrue();
+				expect( user.getPosts()[ 4 ].isSameAs( savedPosts[ 2 ] ) ).toBeTrue();
+			} );
+
 			it( "can save many ids at a time", function() {
 				var newPostA = getInstance( "Post" );
 				newPostA.setBody( "A new post by me!" );
@@ -96,7 +112,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getPosts() ).toHaveLength( 2 );
 				var posts = user.setPosts( newPost );
 
-				var posts = user.fresh().getPosts();
+				var posts = user.getPosts();
 				expect( posts ).toBeArray();
 				expect( posts ).toHaveLength( 1 );
 				expect( posts[ 1 ].keyValues() ).toBe( newPost.keyValues() );

--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -121,11 +121,30 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 			it( "can create new related entities directly", function() {
 				var user = getInstance( "User" ).find( 1 );
 				expect( user.getPosts() ).toHaveLength( 2 );
-				var newPost = user.posts().create( { "body" : "A new post created directly here!" } );
+				var newPost = user.posts().create( { "body" : "A new post created directly here!" }, "author" );
 				expect( newPost.isLoaded() ).toBeTrue();
 				expect( newPost.retrieveAttribute( "user_id" ) ).toBe( user.getId() );
 				expect( newPost.getBody() ).toBe( "A new post created directly here!" );
-				expect( user.fresh().getPosts() ).toHaveLength( 3 );
+				expect( newPost.isRelationshipLoaded( "author" ) ).toBeTrue();
+				expect( newPost.getAuthor().isSameAs( user ) ).toBeTrue();
+				expect( user.getPosts() ).toHaveLength( 3 );
+				expect( user.getPosts()[ 3 ].isSameAs( newPost ) ).toBeTrue();
+			} );
+
+			it( "does not initialize an unloaded parent relationship when creating", function() {
+				var user = getInstance( "User" ).find( 1 );
+
+				user.posts().create( { "body" : "A new post without loading the collection" } );
+
+				expect( user.isRelationshipLoaded( "posts" ) ).toBeFalse();
+			} );
+
+			it( "rejects an unknown inverse relationship when creating", function() {
+				var user = getInstance( "User" ).find( 1 );
+
+				expect( function() {
+					user.posts().create( { "body" : "This should not be saved" }, "missingRelationship" );
+				} ).toThrow( "RelationshipNotFound" );
 			} );
 
 			it( "can first off of the relationship", function() {

--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -79,6 +79,18 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getPosts()[ 4 ].isSameAs( savedPosts[ 2 ] ) ).toBeTrue();
 			} );
 
+			it( "clears an already-loaded relationship after deleting all related entities", function() {
+				var user = getInstance( "User" ).findOrFail( 1 );
+				expect( user.getPosts() ).toHaveLength( 2 );
+
+				var result = user.posts().deleteAll();
+
+				expect( result.result.recordCount ).toBe( 2 );
+				expect( user.isRelationshipLoaded( "posts" ) ).toBeTrue();
+				expect( user.getPosts() ).toBeArray().toBeEmpty();
+				expect( user.fresh().getPosts() ).toBeArray().toBeEmpty();
+			} );
+
 			it( "can save many ids at a time", function() {
 				var newPostA = getInstance( "Post" );
 				newPostA.setBody( "A new post by me!" );


### PR DESCRIPTION
Closes #190
Closes #149
Closes #125
Closes #124

## Issue review

### #190 / #125 — synchronize loaded has-many relationships

**Recommendation: 9/10.** Mutating a relationship should update an already-loaded relationship cache. Returning stale data until `refresh()` is incorrect and unnecessarily expensive.

### #149 — assign relationships when creating through relationships

**Recommendation: 8/10.** Created related entities should expose relationship state Quick already knows, without an immediate query.

### #124 — preserve relationship constraints in `deleteAll`

**Recommendation: 10/10.** A relationship deletion must keep its foreign-key constraint and bindings. Current Quick/qb already does; the new public regression protects the executed result.

Reasons for:

- `BelongsTo.create()` knows the created parent and can safely associate/cache it.
- A loaded has-many collection represents an accepted snapshot; relationship mutations should keep that snapshot coherent.
- Seeding the inverse before saving makes it available to lifecycle events.
- Owning `deleteAll()` at the relationship layer allows Quick to synchronize or invalidate the parent cache after the database mutation.

Tradeoffs:

- Quick cannot safely infer an inverse alias such as `author` from `User.posts()`; the inverse relationship name is therefore optional and explicit.
- An unloaded parent collection is deliberately left unloaded because other related rows may already exist.
- `BelongsTo.create()` updates the child foreign key in memory but does not silently save the existing child.
- An ID-restricted relationship deletion invalidates a loaded cache instead of partially filtering composite identifiers in memory; the next getter reloads authoritative state.

## Reproduction

For #190, direct `saveMany()` reproduced stale loaded data: after loading two posts and saving two more, `getPosts()` still returned two.

For #149, public regressions showed:

- `post.author().create(...)` was forwarded through the builder and errored because no relationship-level `create()` existed.
- `user.posts().create(..., "author")` created the post but left its inverse relationship unloaded and required a refreshed parent to see it.

For #125, a public regression loaded two posts, called `user.posts().deleteAll()`, and showed that the database rows were deleted while `user.getPosts()` still returned the stale two-item cache.

For #124, the historical `true` foreign-key binding no longer reproduces with qb 14.0.0-beta.3: the same regression deletes exactly two constrained posts and a fresh parent returns an empty collection.

All tests use public Quick entity and relationship APIs.

## Implementation

- Keep loaded has-many caches synchronized after `saveMany()` and replacement setters.
- Add `BelongsTo.create()` to create the parent, associate it to the existing child, and cache the relationship.
- Extend has-one/has-many `create()` with an optional inverse relationship name, seeded before save.
- Append a created child to an already-loaded collection, while leaving an unloaded collection untouched.
- Reject unknown inverse relationship names before saving.
- Add relationship-owned `deleteAll()` that clears a fully deleted loaded relationship and invalidates ID-restricted loaded caches.

## Validation

- Focused `HasManySpec`: 17 passed, 0 failed, 0 errors.
- Full suite: 500 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Dependency: latest prerelease `qb 14.0.0-beta.3`.
