### PR TITLE
feat: fill relationships on new entities

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2984,16 +2984,21 @@ component accessors="true" {
 			relationship.relationshipClass != "PolymorphicBelongsTo"
 		) {
 			if ( !isLoaded() ) {
-				var relationshipValue = arguments.missingMethodArguments[ 1 ];
-				var relatedEntity     = relationship.getRelated();
-				var fillRelatedEntity = function( value ) {
-					return isStruct( arguments.value ) && !structKeyExists( arguments.value, "isQuickEntity" )
-					 ? relatedEntity.newEntity().fill( arguments.value )
-					 : arguments.value;
-				};
-				var filledRelationship = isArray( relationshipValue )
-				 ? relationshipValue.map( fillRelatedEntity )
-				 : fillRelatedEntity( relationshipValue );
+				var relationshipValue  = arguments.missingMethodArguments[ 1 ];
+				var relatedEntity      = relationship.getRelated();
+				var filledRelationship = relationshipValue;
+				if ( isArray( relationshipValue ) ) {
+					filledRelationship = [];
+					for ( var value in relationshipValue ) {
+						filledRelationship.append(
+							isStruct( value ) && !structKeyExists( value, "isQuickEntity" )
+							 ? relatedEntity.newEntity().fill( value )
+							 : value
+						);
+					}
+				} else if ( isStruct( relationshipValue ) && !structKeyExists( relationshipValue, "isQuickEntity" ) ) {
+					filledRelationship = relatedEntity.newEntity().fill( relationshipValue );
+				}
 				assignRelationship( relationshipName, filledRelationship );
 				return filledRelationship;
 			}

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -159,6 +159,11 @@ component accessors="true" {
 	property name="_relationshipsLoaded" persistent="false";
 
 	/**
+	 * Relationships filled while this entity is new and waiting to be persisted.
+	 */
+	property name="_deferredRelationships" persistent="false";
+
+	/**
 	 * Discriminated chilrent property
 	 **/
 	property name="_discriminations" persistent="false";
@@ -270,6 +275,7 @@ component accessors="true" {
 		param variables._data                     = {};
 		param variables._relationshipsData        = {};
 		param variables._relationshipsLoaded      = {};
+		variables._deferredRelationships          = [];
 		param variables._with                     = [];
 		variables._withoutRelationshipConstraints = createObject( "java", "java.util.HashSet" ).init();
 		variables._applyingGlobalScopes           = false;
@@ -1284,9 +1290,10 @@ component accessors="true" {
 		if ( arguments.toNew ) {
 			assignOriginalAttributes( {} );
 		}
-		variables._relationshipsData   = {};
-		variables._relationshipsLoaded = {};
-		variables._loaded              = arguments.toNew ? false : variables._loaded;
+		variables._relationshipsData     = {};
+		variables._relationshipsLoaded   = {};
+		variables._deferredRelationships = [];
+		variables._loaded                = arguments.toNew ? false : variables._loaded;
 
 		return this;
 	}
@@ -1494,6 +1501,15 @@ component accessors="true" {
 					"entity"  : this,
 					"options" : arguments.options
 				}
+			);
+		}
+		var deferredRelationships        = variables._deferredRelationships.duplicate();
+		variables._deferredRelationships = [];
+		for ( var relationshipName in deferredRelationships ) {
+			invoke(
+				this,
+				"set#relationshipName#",
+				{ "1" : retrieveRelationship( relationshipName ) }
 			);
 		}
 		variables._saving = false;
@@ -1954,8 +1970,9 @@ component accessors="true" {
 	 * @returns  quick.models.BaseEntity
 	 */
 	public any function clearRelationships() {
-		variables._relationshipsData   = {};
-		variables._relationshipsLoaded = {};
+		variables._relationshipsData     = {};
+		variables._relationshipsLoaded   = {};
+		variables._deferredRelationships = [];
 		return this;
 	}
 
@@ -1969,6 +1986,7 @@ component accessors="true" {
 	public any function clearRelationship( required string name ) {
 		variables._relationshipsData.delete( arguments.name );
 		variables._relationshipsLoaded.delete( arguments.name );
+		variables._deferredRelationships.delete( arguments.name );
 		return this;
 	}
 
@@ -2983,6 +3001,23 @@ component accessors="true" {
 			relationship.relationshipClass != "BelongsTo" &&
 			relationship.relationshipClass != "PolymorphicBelongsTo"
 		) {
+			if ( !isLoaded() ) {
+				var relationshipValue = arguments.missingMethodArguments[ 1 ];
+				var relatedEntity     = relationship.getRelated();
+				var fillRelatedEntity = function( value ) {
+					return isStruct( arguments.value ) && !structKeyExists( arguments.value, "isQuickEntity" )
+					 ? relatedEntity.newEntity().fill( arguments.value )
+					 : arguments.value;
+				};
+				var filledRelationship = isArray( relationshipValue )
+				 ? relationshipValue.map( fillRelatedEntity )
+				 : fillRelatedEntity( relationshipValue );
+				assignRelationship( relationshipName, filledRelationship );
+				if ( !variables._deferredRelationships.findNoCase( relationshipName ) ) {
+					variables._deferredRelationships.append( relationshipName );
+				}
+				return filledRelationship;
+			}
 			guardAgainstNotLoaded(
 				"This instance is not loaded so it cannot set the [#relationshipName#] relationship.  " &
 				"Save the new entity first before trying to save related entities."

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -159,11 +159,6 @@ component accessors="true" {
 	property name="_relationshipsLoaded" persistent="false";
 
 	/**
-	 * Relationships filled while this entity is new and waiting to be persisted.
-	 */
-	property name="_deferredRelationships" persistent="false";
-
-	/**
 	 * Discriminated chilrent property
 	 **/
 	property name="_discriminations" persistent="false";
@@ -275,7 +270,6 @@ component accessors="true" {
 		param variables._data                     = {};
 		param variables._relationshipsData        = {};
 		param variables._relationshipsLoaded      = {};
-		variables._deferredRelationships          = [];
 		param variables._with                     = [];
 		variables._withoutRelationshipConstraints = createObject( "java", "java.util.HashSet" ).init();
 		variables._applyingGlobalScopes           = false;
@@ -1290,10 +1284,9 @@ component accessors="true" {
 		if ( arguments.toNew ) {
 			assignOriginalAttributes( {} );
 		}
-		variables._relationshipsData     = {};
-		variables._relationshipsLoaded   = {};
-		variables._deferredRelationships = [];
-		variables._loaded                = arguments.toNew ? false : variables._loaded;
+		variables._relationshipsData   = {};
+		variables._relationshipsLoaded = {};
+		variables._loaded              = arguments.toNew ? false : variables._loaded;
 
 		return this;
 	}
@@ -1501,15 +1494,6 @@ component accessors="true" {
 					"entity"  : this,
 					"options" : arguments.options
 				}
-			);
-		}
-		var deferredRelationships        = variables._deferredRelationships.duplicate();
-		variables._deferredRelationships = [];
-		for ( var relationshipName in deferredRelationships ) {
-			invoke(
-				this,
-				"set#relationshipName#",
-				{ "1" : retrieveRelationship( relationshipName ) }
 			);
 		}
 		variables._saving = false;
@@ -1970,9 +1954,8 @@ component accessors="true" {
 	 * @returns  quick.models.BaseEntity
 	 */
 	public any function clearRelationships() {
-		variables._relationshipsData     = {};
-		variables._relationshipsLoaded   = {};
-		variables._deferredRelationships = [];
+		variables._relationshipsData   = {};
+		variables._relationshipsLoaded = {};
 		return this;
 	}
 
@@ -1986,7 +1969,6 @@ component accessors="true" {
 	public any function clearRelationship( required string name ) {
 		variables._relationshipsData.delete( arguments.name );
 		variables._relationshipsLoaded.delete( arguments.name );
-		variables._deferredRelationships.delete( arguments.name );
 		return this;
 	}
 
@@ -3013,9 +2995,6 @@ component accessors="true" {
 				 ? relationshipValue.map( fillRelatedEntity )
 				 : fillRelatedEntity( relationshipValue );
 				assignRelationship( relationshipName, filledRelationship );
-				if ( !variables._deferredRelationships.findNoCase( relationshipName ) ) {
-					variables._deferredRelationships.append( relationshipName );
-				}
 				return filledRelationship;
 			}
 			guardAgainstNotLoaded(

--- a/tests/specs/integration/BaseEntity/CreateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CreateSpec.cfc
@@ -36,6 +36,26 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				).notToBeNull();
 			} );
 
+			it( "persists relationships filled before creating the parent", function() {
+				var user = getInstance( "User" ).create( {
+					"username"   : "aggregate-user",
+					"first_name" : "Aggregate",
+					"last_name"  : "User",
+					"password"   : hash( "password" ),
+					"posts"      : [
+						{ "body" : "First child" },
+						{ "body" : "Second child" }
+					]
+				} );
+
+				expect( user.isLoaded() ).toBeTrue();
+				expect( user.getPosts() ).toHaveLength( 2 );
+				expect( user.getPosts()[ 1 ].isLoaded() ).toBeTrue();
+				expect( user.getPosts()[ 1 ].getUser_Id() ).toBe( user.getId() );
+				expect( user.getPosts()[ 2 ].isLoaded() ).toBeTrue();
+				expect( user.getPosts()[ 2 ].getUser_Id() ).toBe( user.getId() );
+			} );
+
 			it( "can create a new entity with a json cast", () => {
 				var newTheme = getInstance( "Theme" ).create( {
 					slug    : "theme-new",

--- a/tests/specs/integration/BaseEntity/CreateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CreateSpec.cfc
@@ -36,7 +36,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				).notToBeNull();
 			} );
 
-			it( "persists relationships filled before creating the parent", function() {
+			it( "creates only the root while retaining filled relationships in memory", function() {
 				var user = getInstance( "User" ).create( {
 					"username"   : "aggregate-user",
 					"first_name" : "Aggregate",
@@ -50,10 +50,9 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 				expect( user.isLoaded() ).toBeTrue();
 				expect( user.getPosts() ).toHaveLength( 2 );
-				expect( user.getPosts()[ 1 ].isLoaded() ).toBeTrue();
-				expect( user.getPosts()[ 1 ].getUser_Id() ).toBe( user.getId() );
-				expect( user.getPosts()[ 2 ].isLoaded() ).toBeTrue();
-				expect( user.getPosts()[ 2 ].getUser_Id() ).toBe( user.getId() );
+				expect( user.getPosts()[ 1 ].isLoaded() ).toBeFalse();
+				expect( user.getPosts()[ 2 ].isLoaded() ).toBeFalse();
+				expect( user.fresh().getPosts() ).toBeEmpty();
 			} );
 
 			it( "can create a new entity with a json cast", () => {

--- a/tests/specs/integration/BaseEntity/FillSpec.cfc
+++ b/tests/specs/integration/BaseEntity/FillSpec.cfc
@@ -78,6 +78,20 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getPosts()[ 2 ].isLoaded() ).toBeFalse();
 				expect( user.getPosts()[ 2 ].getBody() ).toBe( "Struct child" );
 			} );
+
+			it( "creates new relationship instances when filling the same relationship multiple times", function() {
+				var user = getInstance( "User" );
+
+				user.fill( { "posts" : [ { "body" : "First fill" } ] } );
+				var firstPost = user.getPosts()[ 1 ];
+
+				user.fill( { "posts" : [ { "body" : "Second fill" } ] } );
+				var secondPost = user.getPosts()[ 1 ];
+
+				expect( user.getPosts() ).toHaveLength( 1 );
+				expect( secondPost.getBody() ).toBe( "Second fill" );
+				expect( firstPost.getBody() ).toBe( "First fill" );
+			} );
 		} );
 	}
 

--- a/tests/specs/integration/BaseEntity/FillSpec.cfc
+++ b/tests/specs/integration/BaseEntity/FillSpec.cfc
@@ -60,6 +60,24 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} ).notToThrow();
 				expect( user.isNullAttribute( "updatedDate" ) ).toBeTrue();
 			} );
+
+			it( "can fill relationships on a new entity without persisting the aggregate", function() {
+				var user = getInstance( "User" ).fill( {
+					"posts" : [
+						getInstance( "Post" ).fill( { "body" : "Entity child" } ),
+						{ "body" : "Struct child" }
+					]
+				} );
+
+				expect( user.isLoaded() ).toBeFalse();
+				expect( user.getPosts() ).toHaveLength( 2 );
+				expect( user.getPosts()[ 1 ] ).toBeInstanceOf( "Post" );
+				expect( user.getPosts()[ 1 ].isLoaded() ).toBeFalse();
+				expect( user.getPosts()[ 1 ].getBody() ).toBe( "Entity child" );
+				expect( user.getPosts()[ 2 ] ).toBeInstanceOf( "Post" );
+				expect( user.getPosts()[ 2 ].isLoaded() ).toBeFalse();
+				expect( user.getPosts()[ 2 ].getBody() ).toBe( "Struct child" );
+			} );
 		} );
 	}
 

--- a/tests/specs/integration/GoodErrorMessagesSpec.cfc
+++ b/tests/specs/integration/GoodErrorMessagesSpec.cfc
@@ -64,18 +64,17 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				skip = server.keyExists( "boxlang" )
 			);
 
-			it( "throws a helpful error message when trying to set a belongsToMany relationship when the relationship is not loaded", function() {
-				expect( function() {
-					getInstance( "Post" ).create( {
-						"user_id"       : 1,
-						"body"          : "A new post body",
-						"publishedDate" : now(),
-						"tags"          : [ 1, 2 ]
-					} );
-				} ).toThrow(
-					type  = "QuickEntityNotLoaded",
-					regex = "This instance is not loaded so it cannot set the \[tags\] relationship\.  Save the new entity first before trying to save related entities\."
-				);
+			it( "persists filled relationships after creating the parent entity", function() {
+				var post = getInstance( "Post" ).create( {
+					"user_id"       : 1,
+					"body"          : "A new post body",
+					"publishedDate" : now(),
+					"tags"          : [ 1, 2 ]
+				} );
+
+				expect( post.isLoaded() ).toBeTrue();
+				expect( post.getTags() ).toHaveLength( 2 );
+				expect( post.getTags().map( ( tag ) => tag.getId() ) ).toBe( [ 1, 2 ] );
 			} );
 		} );
 	}

--- a/tests/specs/integration/GoodErrorMessagesSpec.cfc
+++ b/tests/specs/integration/GoodErrorMessagesSpec.cfc
@@ -64,7 +64,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				skip = server.keyExists( "boxlang" )
 			);
 
-			it( "persists filled relationships after creating the parent entity", function() {
+			it( "does not persist a filled belongsToMany relationship when creating the parent", function() {
 				var post = getInstance( "Post" ).create( {
 					"user_id"       : 1,
 					"body"          : "A new post body",
@@ -73,8 +73,8 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} );
 
 				expect( post.isLoaded() ).toBeTrue();
-				expect( post.getTags() ).toHaveLength( 2 );
-				expect( post.getTags().map( ( tag ) => tag.getId() ) ).toBe( [ 1, 2 ] );
+				expect( post.getTags() ).toBe( [ 1, 2 ] );
+				expect( post.fresh().getTags() ).toBeEmpty();
 			} );
 		} );
 	}


### PR DESCRIPTION
Closes #179

## Issue review

**Recommendation: 8/10 for in-memory aggregate construction; not for implicit aggregate persistence.** Building a relationship graph before persistence is a strong fit for Quick because it enables validation and removes an artificial create/update difference. Automatically saving that graph is not a fit: Quick intentionally makes persistence boundaries explicit, and a cascading `save()` would look too much like a unit-of-work API while lacking those guarantees.

## Behavior

- `fill()` on a new entity accepts relationship data.
- Related attribute structs are normalized into unloaded Quick entities and cached on the root, so normal relationship getters expose the graph for validation.
- `create()` / `save()` persists only the root entity.
- Related entities remain unloaded and belong-to-many identifiers remain only in the in-memory relationship cache.
- Callers explicitly choose how and when to persist or attach each relationship through the existing relationship APIs.

## Test-first revision

I first changed the public `create()` regressions to require root-only persistence. Against the prior cascading implementation, the focused run had 14 passes and 2 failures: child entities were loaded/persisted, and belongs-to-many identifiers had been resolved and attached. After removing deferred relationship writes, all 16 focused specs pass.

The existing public `fill()` regression also verifies that an entity and a child struct both become unloaded Quick entities in the cached relationship graph.

## Validation

- Red phase: 14 passed, 2 failed, 0 errors.
- Green phase: focused `CreateSpec`, `FillSpec`, and `GoodErrorMessagesSpec` suites have 16 passed, 0 failed, 0 errors.
- `box run-script format`
- `git diff --check`

Dependency: `qb 14.0.0-beta.3`.
