### PR TITLE
feat: add relationship loaded hooks

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -42,7 +42,8 @@ component {
 				"quickPreUpdate",
 				"quickPostUpdate",
 				"quickPreDelete",
-				"quickPostDelete"
+				"quickPostDelete",
+				"quickRelationshipLoaded"
 			]
 		};
 

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1458,6 +1458,7 @@ component accessors="true" {
 					var relationship = invoke( attributes.entity, attributes.relationshipName );
 					relationship.setRelationMethodName( attributes.relationshipName );
 					assignRelationship( attributes.relationshipName, relationship.get() );
+					attributes.entity.fireRelationshipLoaded( attributes.relationshipName );
 				}
 			}
 			cfthread(
@@ -1471,6 +1472,7 @@ component accessors="true" {
 					var relationship = invoke( this, n );
 					relationship.setRelationMethodName( n );
 					assignRelationship( n, relationship.get() );
+					fireRelationshipLoaded( n );
 				}
 			}
 		}
@@ -1531,6 +1533,48 @@ component accessors="true" {
 			variables._relationshipsData[ arguments.name ] = arguments.value;
 		}
 		variables._relationshipsLoaded[ arguments.name ] = true;
+		return this;
+	}
+
+	/**
+	 * Fires relationship-loaded hooks for each entity in a loaded relationship.
+	 * Calls a relationship-specific method such as `postsLoaded( entity )` and
+	 * announces the `quickRelationshipLoaded` interception point.
+	 *
+	 * @name  The name of the relationship that was loaded.
+	 *
+	 * @returns  quick.models.BaseEntity
+	 */
+	public any function fireRelationshipLoaded( required string name ) {
+		if ( variables._withoutFiringEvents ) {
+			return this;
+		}
+
+		var relationshipData = retrieveRelationship( arguments.name );
+		if ( isNull( relationshipData ) ) {
+			return this;
+		}
+
+		var relationshipEntities = isArray( relationshipData ) ? relationshipData : [ relationshipData ];
+		var relationshipMethod   = arguments.name & "Loaded";
+		for ( var relatedEntity in relationshipEntities ) {
+			if ( eventMethodExists( relationshipMethod ) ) {
+				invoke(
+					this,
+					relationshipMethod,
+					{ entity : relatedEntity }
+				);
+			}
+			fireEvent(
+				"relationshipLoaded",
+				{
+					entity           : relatedEntity,
+					parent           : this,
+					relationshipName : arguments.name
+				}
+			);
+		}
+
 		return this;
 	}
 
@@ -2516,6 +2560,7 @@ component accessors="true" {
 			);
 			relationship.setRelationMethodName( relationshipName );
 			assignRelationship( relationshipName, relationship.get() );
+			fireRelationshipLoaded( relationshipName );
 		}
 
 		return retrieveRelationship( relationshipName );

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -755,11 +755,18 @@ component accessors="true" transientCache="false" {
 		callback( relation );
 		var hasMatches = relation.addEagerConstraints( arguments.entities, getEntity() );
 		relation.with( renestEagerLoads( nestedEagerLoads ) );
-		return relation.match(
+		var matchedEntities = relation.match(
 			relation.initRelation( arguments.entities, arguments.relationName ),
 			hasMatches ? relation.getEager( variables._asQuery, variables._withAliases ) : [],
 			arguments.relationName
 		);
+		var loadedRelationshipName = arguments.relationName;
+		matchedEntities.each( function( entity ) {
+			if ( isStruct( arguments.entity ) && structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+				arguments.entity.fireRelationshipLoaded( loadedRelationshipName );
+			}
+		} );
+		return matchedEntities;
 	}
 
 	/**

--- a/tests/resources/app/models/RelationshipLoadedUser.cfc
+++ b/tests/resources/app/models/RelationshipLoadedUser.cfc
@@ -1,0 +1,17 @@
+component
+	table    ="users"
+	extends  ="quick.models.BaseEntity"
+	accessors="true"
+{
+
+	property name="id";
+
+	function posts() {
+		return hasMany( "Post", "user_id" );
+	}
+
+	function postsLoaded( entity ) {
+		arguments.entity.assignRelationship( "loadedByUser", this );
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/Events/RelationshipLoadedSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/RelationshipLoadedSpec.cfc
@@ -1,0 +1,65 @@
+component extends="tests.resources.ModuleIntegrationSpec" {
+
+	function beforeAll() {
+		super.beforeAll();
+		controller
+			.getInterceptorService()
+			.registerInterceptor( interceptorObject = this, interceptorName = "RelationshipLoadedSpec" );
+	}
+
+	function afterAll() {
+		controller.getInterceptorService().unregister( "RelationshipLoadedSpec" );
+		super.afterAll();
+	}
+
+	function run() {
+		describe( "relationshipLoaded", function() {
+			beforeEach( function() {
+				variables.relationshipLoadedEvents = [];
+			} );
+
+			it( "calls a relationship-specific method for lazily loaded entities", function() {
+				var user  = getInstance( "RelationshipLoadedUser" ).findOrFail( 1 );
+				var posts = user.getPosts();
+
+				expect( posts ).toHaveLength( 2 );
+				posts.each( function( post ) {
+					expect( post.retrieveRelationship( "loadedByUser" ).isSameAs( user ) ).toBeTrue();
+				} );
+			} );
+
+			it( "calls a relationship-specific method for eagerly loaded entities", function() {
+				var user = getInstance( "RelationshipLoadedUser" ).with( "posts" ).findOrFail( 1 );
+
+				expect( user.getPosts() ).toHaveLength( 2 );
+				user.getPosts()
+					.each( function( post ) {
+						expect( post.retrieveRelationship( "loadedByUser" ).isSameAs( user ) ).toBeTrue();
+					} );
+			} );
+
+			it( "announces a relationshipLoaded interception point for each related entity", function() {
+				var user = getInstance( "RelationshipLoadedUser" ).findOrFail( 1 );
+				user.getPosts();
+
+				expect( variables.relationshipLoadedEvents ).toHaveLength( 2 );
+				variables.relationshipLoadedEvents.each( function( eventData ) {
+					expect( eventData.relationshipName ).toBe( "posts" );
+					expect( eventData.parent.isSameAs( user ) ).toBeTrue();
+					expect( eventData.entity ).toBeInstanceOf( "Post" );
+				} );
+			} );
+		} );
+	}
+
+	function quickRelationshipLoaded(
+		event,
+		interceptData,
+		buffer,
+		rc,
+		prc
+	) {
+		variables.relationshipLoadedEvents.append( arguments.interceptData );
+	}
+
+}


### PR DESCRIPTION
Closes #176

## Issue review

**Recommendation: 8/10 — a good fit for Quick.**

Relationship post-processing is a natural extension of Quick’s lifecycle hooks. It is especially useful for attaching runtime-only parent context, decorating related entities, and centralizing relationship-specific setup without spreading that work across handlers and services.

Reasons in favor:
- follows Quick’s existing implicit lifecycle-method convention
- works consistently for lazy and eager loading
- provides both a targeted `<relationshipName>Loaded( entity )` hook and a generic `quickRelationshipLoaded` interception point
- fires once per actual related entity, which matches the issue’s parent-reference use case

Tradeoffs:
- hooks add implicit behavior to relationship reads and can be surprising if they mutate persistent fields
- user callbacks can introduce extra work or N+1 queries if they perform database access
- empty and null relationships do not fire because no child entity was loaded
- `withoutFiringEvents()` suppresses these hooks along with other Quick lifecycle events

## Reproduction / test-first result

The feature did not exist. Public API tests loaded a `hasMany` relationship through both `getPosts()` and `with( "posts" )`. Before implementation, the focused bundle reported 0 passed, 1 failed, and 2 errors: the implicit method was never called and the interception point emitted no events.

## Implementation

- call `<relationshipName>Loaded( entity )` once for every related Quick entity
- announce `quickRelationshipLoaded` with `entity`, `parent`, and `relationshipName`
- cover lazy loading, explicit `loadRelationship()`, parallel relationship loading, and eager loading paths
- avoid firing for null/empty results or plain struct results

## Validation

- focused event/eager-loading coverage: 39 passed, 0 failed, 0 errors
- full suite: 498 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`
- dependency baseline: qb `14.0.0-beta.3` (`qb@be`)
