### PR TITLE
perf: cache qualified entity columns

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -564,6 +564,7 @@ component accessors="true" {
 				variables._columns[ clearedAttr.column ]     = clearedAttr;
 				variables._meta.attributes[ arguments.name ] = variables._attributes[ arguments.name ];
 				variables._meta.originalMetadata.properties.append( variables._attributes[ arguments.name ] );
+				variables._meta.qualifiedColumnsCacheKey = createUUID();
 			}
 		}
 		if ( arguments.setToNull ) {
@@ -932,6 +933,7 @@ component accessors="true" {
 				variables._columns[ attr.column ]            = attr;
 				variables._meta.attributes[ arguments.name ] = variables._attributes[ arguments.name ];
 				variables._meta.originalMetadata.properties.append( variables._attributes[ arguments.name ] );
+				variables._meta.qualifiedColumnsCacheKey = createUUID();
 			}
 		} else {
 			guardAgainstNonExistentAttribute( arguments.name );
@@ -968,11 +970,16 @@ component accessors="true" {
 	 * @return       [string]
 	 */
 	public array function retrieveQualifiedColumns() {
-		var attributes = retrieveColumnNames();
-		arraySort( attributes, "textnocase" );
-		return attributes.map( function( column ) {
-			return this.qualifyColumn( column );
-		} );
+		var cacheKey = "quick-metadata:#variables._mapping#-qualified-columns:#variables._meta.qualifiedColumnsCacheKey#:#hash( tableName() )#";
+		return duplicate(
+			variables._cache.getOrSet( cacheKey, function() {
+				var attributes = retrieveColumnNames();
+				arraySort( attributes, "textnocase" );
+				return attributes.map( function( column ) {
+					return this.qualifyColumn( column );
+				} );
+			} )
+		);
 	}
 
 	/*=====================================
@@ -2846,10 +2853,11 @@ component accessors="true" {
 			);
 		}
 
-		variables._fullName        = variables._meta.fullName;
-		variables._entityName      = variables._meta.entityName;
-		variables._table           = variables._meta.table;
-		variables._hasParentEntity = variables._meta.hasParentEntity;
+		variables._fullName                            = variables._meta.fullName;
+		variables._entityName                          = variables._meta.entityName;
+		variables._table                               = variables._meta.table;
+		variables._hasParentEntity                     = variables._meta.hasParentEntity;
+		param variables._meta.qualifiedColumnsCacheKey = "declared";
 
 		if ( variables._hasParentEntity ) {
 			variables._parentDefinition = variables._meta.parentDefinition;

--- a/tests/resources/app/models/QualifiedColumnsCacheEntity.cfc
+++ b/tests/resources/app/models/QualifiedColumnsCacheEntity.cfc
@@ -1,0 +1,21 @@
+component
+	table    ="users"
+	extends  ="quick.models.BaseEntity"
+	accessors="true"
+{
+
+	property name="id";
+	property name="username";
+	property name="firstName" column="first_name";
+
+	public string function qualifyColumn(
+		required string column,
+		string tableName        = this.tableName(),
+		boolean useParentLookup = true
+	) {
+		param request.qualifiedColumnsCalls = 0;
+		request.qualifiedColumnsCalls++;
+		return super.qualifyColumn( argumentCollection = arguments );
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
@@ -2,6 +2,48 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 	function run() {
 		describe( "Columns", function() {
+			it( "caches qualified columns across entity instances", function() {
+				request.qualifiedColumnsCalls = 0;
+
+				var firstColumns          = getInstance( "QualifiedColumnsCacheEntity" ).retrieveQualifiedColumns();
+				var callsAfterFirstLookup = request.qualifiedColumnsCalls;
+				var secondColumns         = getInstance( "QualifiedColumnsCacheEntity" ).retrieveQualifiedColumns();
+
+				expect( callsAfterFirstLookup ).toBeGT( 0 );
+				expect( request.qualifiedColumnsCalls ).toBe( callsAfterFirstLookup );
+				expect( secondColumns ).toBe( firstColumns );
+
+				firstColumns.append( "mutated.column" );
+				expect( getInstance( "QualifiedColumnsCacheEntity" ).retrieveQualifiedColumns() ).notToInclude(
+					"mutated.column"
+				);
+			} );
+
+			it( "caches qualified columns separately for table aliases", function() {
+				request.qualifiedColumnsCalls = 0;
+
+				getInstance( "QualifiedColumnsCacheEntity" ).withAlias( "cached_user" ).retrieveQualifiedColumns();
+				var callsAfterFirstLookup = request.qualifiedColumnsCalls;
+				var columns               = getInstance( "QualifiedColumnsCacheEntity" )
+					.withAlias( "cached_user" )
+					.retrieveQualifiedColumns();
+
+				expect( callsAfterFirstLookup ).toBeGT( 0 );
+				expect( request.qualifiedColumnsCalls ).toBe( callsAfterFirstLookup );
+				expect( columns ).toInclude( "cached_user.id" );
+			} );
+
+			it( "keeps runtime persistent attributes isolated from declared column caches", function() {
+				var dynamicEntity = getInstance( "QualifiedColumnsCacheEntity" );
+				dynamicEntity.forceAssignAttribute( "runtime_column", "value" );
+
+				expect( dynamicEntity.retrieveQualifiedColumns() ).toInclude( "users.runtime_column" );
+				expect( dynamicEntity.newEntity().retrieveQualifiedColumns() ).toInclude( "users.runtime_column" );
+				expect( getInstance( "QualifiedColumnsCacheEntity" ).retrieveQualifiedColumns() ).notToInclude(
+					"users.runtime_column"
+				);
+			} );
+
 			it( "can access the attributes by their alias", function() {
 				var link = getInstance( "Link" ).findOrFail( 1 );
 


### PR DESCRIPTION
Closes #172

## Issue review

**Recommendation: 9/10 — a strong, low-risk performance fit for Quick.**

`retrieveQualifiedColumns()` is called while constructing every entity query, including every relationship entity instantiated by repeated subselect scopes. Its result is metadata-derived and stable for a mapping/table combination, so recomputing the attribute reduction, sort, and qualification on every instance is unnecessary.

Reasons in favor:
- removes repeated O(n) metadata traversal and sorting from a hot construction path
- reuses Quick’s existing metadata CacheBox cache lifecycle
- virtual attributes are already excluded and therefore do not invalidate the cache
- table aliases receive independent cache entries
- runtime-added persistent attributes receive a separate cache generation

Tradeoffs:
- cached arrays must be defensively copied to prevent caller mutation from corrupting later queries
- alias-specific entries consume a small amount of cache space
- applications that dynamically add persistent columns intentionally create additional cache generations

## Reproduction / test-first result

A public test entity counted calls to its `qualifyColumn()` override across separate WireBox entity instances. Before implementation, the focused Columns bundle reported 4 passed and 1 failure because the second instance repeated all qualification work (6 calls instead of the cached 3).

## Implementation

- cache the sorted, fully qualified column array by entity mapping, metadata generation, and table/alias
- return a defensive duplicate on every public call
- keep virtual attributes on the existing declared cache generation
- create a new generation when `forceAssignAttribute()` or `forceClearAttribute()` adds a persistent runtime column

## Validation

- focused column coverage: 7 passed, 0 failed, 0 errors
- adjacent column/inheritance/subquery/eager-loading coverage: 74 passed, 0 failed, 0 errors
- full suite: 498 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`
- dependency baseline: qb `14.0.0-beta.3` (`qb@be`)
