### PR TITLE
fix: eager load one-through relationships

### DIFF
--- a/models/Relationships/BelongsToThrough.cfc
+++ b/models/Relationships/BelongsToThrough.cfc
@@ -108,7 +108,7 @@ component extends="quick.models.Relationships.BaseRelationship" {
 	public boolean function addEagerConstraints( required array entities, required any baseEntity ) {
 		var allKeys = getKeys(
 			entities,
-			getLocalKeys(),
+			variables.closestToParent.getForeignKeys(),
 			arguments.baseEntity
 		);
 
@@ -117,13 +117,13 @@ component extends="quick.models.Relationships.BaseRelationship" {
 		}
 
 		performJoin( variables.relationshipBuilder );
-		var foreignKeys             = getForeignKeys();
-		var qualifiedForeignKeyList = foreignKeys
-			.reduce( function( acc, foreignKey, i ) {
+		var relatedKeys             = variables.closestToParent.getLocalKeys();
+		var qualifiedForeignKeyList = relatedKeys
+			.reduce( function( acc, relatedKey, i ) {
 				if ( i != 1 ) {
 					acc.append( "," );
 				}
-				acc.append( variables.closestToParent.qualifyColumn( foreignKey ) );
+				acc.append( variables.closestToParent.qualifyColumn( relatedKey ) );
 				return acc;
 			}, [] )
 			.toList();
@@ -142,10 +142,10 @@ component extends="quick.models.Relationships.BaseRelationship" {
 			.where( function( q1 ) {
 				allKeys.each( function( keys ) {
 					q1.orWhere( function( q2 ) {
-						arrayZipEach( [ foreignKeys, keys ], function( foreignKey, keyValue ) {
+						arrayZipEach( [ relatedKeys, keys ], function( relatedKey, keyValue ) {
 							q2.where(
-								variables.closestToParent.qualifyColumn( foreignKey ),
-								variables.closestToParent.generateQueryParamStruct( foreignKey, keyValue )
+								variables.closestToParent.qualifyColumn( relatedKey ),
+								variables.closestToParent.generateQueryParamStruct( relatedKey, keyValue )
 							);
 						} );
 					} );
@@ -292,10 +292,11 @@ component extends="quick.models.Relationships.BaseRelationship" {
 	) {
 		var dictionary = buildDictionary( arguments.results );
 		arguments.entities.each( function( entity ) {
-			var key = getLocalKeys()
-				.map( function( localKey ) {
-					return structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( localKey ) : entity[
-						localKey
+			var key = variables.closestToParent
+				.getForeignKeys()
+				.map( function( foreignKey ) {
+					return structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( foreignKey ) : entity[
+						foreignKey
 					];
 				} )
 				.toList();

--- a/models/Relationships/HasOneOrManyThrough.cfc
+++ b/models/Relationships/HasOneOrManyThrough.cfc
@@ -226,6 +226,42 @@ component extends="quick.models.Relationships.BaseRelationship" accessors="true"
 	}
 
 	/**
+	 * Matches the array of entity results to a single value for the relation.
+	 *
+	 * @entities  The entities being eager loaded.
+	 * @results   The relationship results.
+	 * @relation  The name of the relation being loaded.
+	 *
+	 * @doc_generic  quick.models.BaseEntity
+	 * @return       [quick.models.BaseEntity]
+	 */
+	public array function matchOne(
+		required array entities,
+		required array results,
+		required string relation
+	) {
+		var dictionary = buildDictionary( arguments.results );
+		arguments.entities.each( function( entity ) {
+			var key = variables.closestToParent
+				.getLocalKeys()
+				.map( function( localKey ) {
+					return structKeyExists( entity, "isQuickEntity" ) ? entity.retrieveAttribute( localKey ) : entity[
+						localKey
+					];
+				} )
+				.toList();
+			if ( structKeyExists( dictionary, key ) ) {
+				if ( structKeyExists( arguments.entity, "isQuickEntity" ) ) {
+					arguments.entity.assignRelationship( relation, dictionary[ key ][ 1 ] );
+				} else {
+					arguments.entity[ relation ] = dictionary[ key ][ 1 ];
+				}
+			}
+		} );
+		return arguments.entities;
+	}
+
+	/**
 	 * Gets the query used to check for relation existance.
 	 *
 	 * @base    The base entity for the query.

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToThroughSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToThroughSpec.cfc
@@ -2,6 +2,13 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 	function run() {
 		describe( "Belongs To Through Spec", function() {
+			it( "can eager load the owning entity through other relationships", function() {
+				var post = getInstance( "Post" ).with( "country" ).findOrFail( 523526 );
+
+				expect( post.getCountry() ).notToBeNull();
+				expect( post.getCountry().getId() ).toBe( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
+			} );
+
 			it( "can get the owning entity through other relationships", function() {
 				var post = getInstance( "Post" ).findOrFail( 523526 );
 				expect( post.getCountry() ).notToBeNull();

--- a/tests/specs/integration/BaseEntity/Relationships/HasOneThroughSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasOneThroughSpec.cfc
@@ -2,6 +2,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 	function run() {
 		describe( "Has One Through Spec", function() {
+			it( "can eager load the related entity through another entity", function() {
+				var country = getInstance( "Country@something" )
+					.with( "latestPost" )
+					.findOrFail( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
+
+				expect( country.getLatestPost() ).notToBeNull();
+				expect( country.getLatestPost().getPost_Pk() ).toBe( 523526 );
+			} );
+
 			it( "can get the related entity through another entity", function() {
 				var country = getInstance( "Country@something" ).find( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
 				expect( country.getLatestPost() ).notToBeNull();


### PR DESCRIPTION
Closes #170

## Issue review

The report was correct and remained partially unresolved. `BelongsToThrough.match()` was replaced with an inline implementation in 2024, but `HasOneThrough.match()` still called an undefined inherited `matchOne()` method. This is a clear correctness bug and should be fixed.

While reproducing it through the public eager-loading API, I found the prior `BelongsToThrough` repair was also incomplete: its eager path read the wrong keys from the parent and applied joins, projections, and constraints to the related entity instead of the relationship builder that is actually executed.

## Reproduction

Tests were added first through normal Quick entity flows:
- `Country.with( "latestPost" )` reproduced `No matching function [MATCHONE] found`
- `Post.with( "country" )` first reproduced an array-key length error, then exposed that the eager query contained no joins, constraints, or `__QuickThroughKey__` projection

Before implementation, the two focused bundles reported 2 passed and 2 errors.

## Implementation

- add the missing single-result matcher to `HasOneOrManyThrough` for `HasOneThrough`
- match through results using the closest relationship’s configured local keys
- constrain `BelongsToThrough` from the parent’s foreign-key values
- select and filter using the intermediate related keys
- apply eager joins and constraints to the executed relationship builder
- retain existing lazy-loading behavior

## Validation

- focused one-through coverage: 4 passed, 0 failed, 0 errors
- adjacent through/eager/as-query coverage: 63 passed, 0 failed, 0 errors
- full suite: 497 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`
- dependency baseline: qb `14.0.0-beta.3` (`qb@be`)
