### PR TITLE
fix: preserve eager loading key types

### DIFF
--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -369,12 +369,10 @@ component accessors="true" implements="IRelationship" {
 					}
 					keyValues.append( value );
 				}
-				acc.append( keyValues.toList() );
+				acc.append( keyValues );
 				return acc;
 			}, [] )
-		).map( function( key ) {
-			return key.listToArray();
-		} );
+		);
 	}
 
 	/**

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -243,6 +243,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
 			} );
 
+			it( "preserves numeric key types when eager loading a belongs to many relationship", function() {
+				getInstance( "Post" ).with( "tags" ).get();
+
+				expect( variables.queries ).toHaveLength( 2, "Only two queries should have been executed." );
+				variables.queries[ 2 ].bindings.each( function( binding ) {
+					expect( binding.cfsqltype ).toBe( "INTEGER" );
+				} );
+			} );
+
 			it( "can eager load a has many through relationship", function() {
 				var countries = getInstance( "Country" ).with( "posts" ).get();
 				expect( countries ).toBeArray();


### PR DESCRIPTION
Closes #166

## Issue review

**Recommendation: 10/10.** This is a database-portability correctness bug in a core eager-loading path. Quick should preserve key value types while constructing relationship constraints, especially because PostgreSQL correctly rejects comparisons between integer columns and varchar parameters.

Reasons for:
- The current conversion through a comma-delimited list changes numeric CFML values into strings.
- The resulting `VARCHAR` bindings fail against strictly typed databases even though the entity keys were numeric.
- The fix removes a lossy internal conversion and keeps the existing public API unchanged.
- The behavior benefits all eager-loaded relationship types that share `getKeys()`.

Tradeoffs:
- Deduplication now operates on arrays of native values rather than serialized list strings. The existing relationship and composite-key suite verifies that behavior on the supported runtime.

## Reproduction

I reproduced the underlying failure through the public Quick flow `getInstance( "Post" ).with( "tags" ).get()`. The query itself succeeds on the MySQL test datasource, but the intercepted belongs-to-many eager query showed every numeric post key bound as `VARCHAR`. The new test expected `INTEGER`; before implementation the focused bundle had 27 passes and 1 failure with `Expected [INTEGER] but received [VARCHAR]`.

The repository previously received PR #167 for this issue, but it was closed without merging. This implementation revalidates the report against current `next` and current qb rather than relying on that old patch.

## Implementation

- Preserve each eager key tuple as an array of its original CFML values.
- Remove the list serialization and deserialization that coerced numeric keys to strings.
- Add a public integration regression that eager loads a belongs-to-many relationship and verifies the generated relationship bindings remain integer typed.

## Validation

- Focused EagerLoadingSpec: 28 passed, 0 failed, 0 errors
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Dependency: latest prerelease `qb 14.0.0-beta.3`.