### PR TITLE
test: cover QuickCollection eager loading

### DIFF
--- a/extras/QuickCollection.cfc
+++ b/extras/QuickCollection.cfc
@@ -6,6 +6,22 @@
 component extends="cfcollection.models.Collection" {
 
 	/**
+	 * Returns a shallow array copy of the collection.
+	 *
+	 * Collection items can be Quick entities, which contain engine-managed
+	 * objects that cannot be deep-duplicated on every CFML engine.
+	 *
+	 * @return [any]
+	 */
+	public array function toArray() {
+		var items = [];
+		for ( var item in variables.collection ) {
+			arrayAppend( items, item );
+		}
+		return items;
+	}
+
+	/**
 	 * Returns a new QuickCollection for the passed in data.
 	 *
 	 * @data     The data to collect.

--- a/tests/specs/integration/QuickCollectionSpec.cfc
+++ b/tests/specs/integration/QuickCollectionSpec.cfc
@@ -31,8 +31,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					expectAll( posts.get() ).toSatisfy( function( post ) {
 						return post.isRelationshipLoaded( "author" );
 					}, "The relationship should now be loaded." );
-				},
-				skip = server.keyExists( "boxlang" )
+				}
 			);
 
 			it(
@@ -45,8 +44,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						return post.isRelationshipLoaded( "author" ) && post.isRelationshipLoaded( "tags" );
 					}, "Both relationships should be eager loaded." );
 					expect( variables.queries ).toHaveLength( 3 );
-				},
-				skip = server.keyExists( "boxlang" )
+				}
 			);
 
 			it(
@@ -60,8 +58,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						return post.isRelationshipLoaded( "author" ) && post.isRelationshipLoaded( "tags" );
 					}, "Both relationships should be loaded." );
 					expect( variables.queries ).toHaveLength( 3 );
-				},
-				skip = server.keyExists( "boxlang" )
+				}
 			);
 		} );
 	}

--- a/tests/specs/integration/QuickCollectionSpec.cfc
+++ b/tests/specs/integration/QuickCollectionSpec.cfc
@@ -34,6 +34,35 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				},
 				skip = server.keyExists( "boxlang" )
 			);
+
+			it(
+				title = "can eager load relationships when retrieving a QuickCollection",
+				body  = function() {
+					var posts = getInstance( "CollectionPost" ).with( [ "author", "tags" ] ).get();
+
+					expect( posts ).toBeInstanceOf( "extras.QuickCollection" );
+					expectAll( posts.get() ).toSatisfy( function( post ) {
+						return post.isRelationshipLoaded( "author" ) && post.isRelationshipLoaded( "tags" );
+					}, "Both relationships should be eager loaded." );
+					expect( variables.queries ).toHaveLength( 3 );
+				},
+				skip = server.keyExists( "boxlang" )
+			);
+
+			it(
+				title = "can load multiple relationships on an existing QuickCollection",
+				body  = function() {
+					var posts = getInstance( "CollectionPost" ).all();
+
+					posts.load( [ "author", "tags" ] );
+
+					expectAll( posts.get() ).toSatisfy( function( post ) {
+						return post.isRelationshipLoaded( "author" ) && post.isRelationshipLoaded( "tags" );
+					}, "Both relationships should be loaded." );
+					expect( variables.queries ).toHaveLength( 3 );
+				},
+				skip = server.keyExists( "boxlang" )
+			);
 		} );
 	}
 


### PR DESCRIPTION
Closes #160

## Issue review

**Recommendation: 10/10.** Quick entities that opt into `QuickCollection` should retain the same eager-loading guarantees as the default array collection on every supported engine. The collection type is a documented Quick extension point, so relationship loading and collection conversion should work transparently.

Reasons for:
- `newCollection()` is a supported entity customization point.
- Both query-time `with()` and collection-time `load()` are documented public relationship APIs.
- BoxLang support requires only avoiding an unnecessary deep duplication of Quick entities.

Tradeoffs:
- `QuickCollection.toArray()` now returns a shallow array copy. This preserves entity identity and avoids attempting to duplicate engine-managed state inside entity CFCs, which is the appropriate collection behavior.

## Reproduction review

The original eager-loading exception no longer reproduces on current `next` with qb `14.0.0-beta.3`. Both public paths work:
- `getInstance( "CollectionPost" ).with( [ "author", "tags" ] ).get()`
- `getInstance( "CollectionPost" ).all().load( [ "author", "tags" ] )`

After enabling the same tests on BoxLang, all three errored while `cfcollection` deep-duplicated Quick entities in `Collection.toArray()`. BoxLang reached an engine-managed `ScheduledThreadPoolExecutor` inside the entity graph and correctly reported that it could not duplicate it.

## Implementation

- Runs all `QuickCollectionSpec` coverage on BoxLang instead of skipping it.
- Overrides `QuickCollection.toArray()` to return a shallow array copy.
- Keeps the tests on public Quick and QuickCollection APIs.
- Covers query-time eager loading, collection-time eager loading, relationship hydration, collection type, and query count.

## Validation

- BoxLang focused QuickCollectionSpec: 3 passed, 0 failed, 0 errors, 0 skipped
- BoxLang full suite: 524 passed, 0 failed, 0 errors, 2 skipped
- Lucee 6 focused QuickCollectionSpec: 3 passed, 0 failed, 0 errors, 0 skipped
- `box run-script format:check`
- `git diff --check`

Dependency: latest prerelease `qb 14.0.0-beta.3`.
