### PR TITLE
fix: transform default relationships to mementos

### DIFF
--- a/models/Relationships/BaseRelationship.cfc
+++ b/models/Relationships/BaseRelationship.cfc
@@ -321,7 +321,18 @@ component accessors="true" implements="IRelationship" {
 	 * @return   quick.models.BaseEntity or [quick.models.BaseEntity]
 	 */
 	public any function get() {
-		return variables.getResults();
+		var results = variables.getResults();
+		if ( isNull( results ) ) {
+			return javacast( "null", "" );
+		}
+		if (
+			!isArray( results ) &&
+			structKeyExists( results, "isQuickEntity" ) &&
+			variables.relationshipBuilder.get_asMemento()
+		) {
+			return results.getMemento( argumentCollection = variables.relationshipBuilder.get_asMementoSettings() );
+		}
+		return results;
 	}
 
 	public any function getResults() {

--- a/tests/specs/integration/BaseEntity/Relationships/WithDefaultSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/WithDefaultSpec.cfc
@@ -28,6 +28,22 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( author.isLoaded() ).toBeFalse( "A default model is not loaded" );
 				expect( author.retrieveAttributesData() ).toBeEmpty();
 			} );
+
+			it( "returns the default entity as a memento when requested from the relationship", function() {
+				var user            = getInstance( "User" ).findOrFail( 2 );
+				var expectedMemento = user
+					.latestPostWithEmptyDefault()
+					.get()
+					.getMemento();
+				var postMemento = user
+					.latestPostWithEmptyDefault()
+					.asMemento()
+					.get();
+
+				expect( postMemento ).toBeStruct();
+				expect( postMemento ).notToBeComponent();
+				expect( postMemento ).toBe( expectedMemento );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #159

## Issue review

**Recommendation: 9/10.** This is a small but real consistency bug. `asMemento()` is an explicit output contract, and a relationship configured with `withDefault()` should honor it exactly as a persisted related entity does.

Reasons for:
- The two equivalent public flows in the issue should return the same representation.
- Returning a component from an `asMemento()` chain is surprising and can break serialization.
- Fixing the shared relationship boundary covers has-one, belongs-to, and other to-one defaults consistently.

Tradeoffs:
- The relationship wrapper now performs one final transformation only when the result is still a Quick entity and the related builder requested mementos. Existing database results are already structs and are left untouched.

## Reproduction

I reproduced the report through the public API with a user that has no latest post:
- `user.latestPostWithEmptyDefault().get().getMemento()` returned a struct.
- `user.latestPostWithEmptyDefault().asMemento().get()` returned an `app.models.Post` component.

The focused bundle had 3 passes and 1 failure before implementation: the actual value was a Component instead of a Struct.

## Implementation

- Let relationship `get()` detect a default Quick entity left after the normal result lookup.
- When the related builder has `asMemento()` enabled, transform that default with the same memento settings.
- Preserve null, array, and already-transformed struct results unchanged.
- Add a public integration regression comparing the two flows from the issue.

## Validation

- Focused WithDefaultSpec: 4 passed, 0 failed, 0 errors
- Adjacent WithDefault/Memento/BelongsTo/HasOne bundles: 29 passed, 0 failed, 0 errors
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Dependency: latest prerelease `qb 14.0.0-beta.3`.