### PR TITLE
feat: add whereBelongsTo relationship constraints

### DIFF
--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -404,6 +404,98 @@ component
 	}
 
 	/**
+	 * Constrains the query to entities belonging to one or more related entities.
+	 * The relationship name defaults to the lower-camel-cased related entity name.
+	 *
+	 * @related           A related Quick entity, an array of entities, or a collection of entities.
+	 * @relationshipName  The belongsTo relationship to use.
+	 * @combinator        The boolean combinator for the clause. Default: "and".
+	 *
+	 * @return            quick.models.QuickQB
+	 */
+	public QuickQB function whereBelongsTo(
+		required any related,
+		string relationshipName,
+		string combinator = "and"
+	) {
+		var relatedEntities = isArray( arguments.related )
+		 ? arguments.related
+		 : (
+			isStruct( arguments.related ) && structKeyExists( arguments.related, "isQuickEntity" )
+			 ? [ arguments.related ]
+			 : arguments.related.get()
+		);
+
+		if ( relatedEntities.isEmpty() ) {
+			throw(
+				type    = "QuickInvalidWhereBelongsTo",
+				message = "whereBelongsTo requires at least one related entity."
+			);
+		}
+
+		if ( isNull( arguments.relationshipName ) ) {
+			var relatedEntityName      = relatedEntities[ 1 ].entityName();
+			arguments.relationshipName = lCase( left( relatedEntityName, 1 ) ) & removeChars( relatedEntityName, 1, 1 );
+		}
+		var resolvedRelationshipName = arguments.relationshipName;
+
+		var relation = getEntity().ignoreLoadedGuard( function() {
+			return getEntity().withoutRelationshipConstraints( resolvedRelationshipName, function() {
+				return invoke( getEntity(), resolvedRelationshipName );
+			} );
+		} );
+
+		if ( relation.relationshipClass != "BelongsTo" ) {
+			throw(
+				type    = "QuickInvalidWhereBelongsTo",
+				message = "Relationship [#resolvedRelationshipName#] must be a belongsTo relationship."
+			);
+		}
+
+		var relatedMapping = relation.getRelated().mappingName();
+		var foreignKeys    = relation.getForeignKeys();
+		var localKeys      = relation.getLocalKeys();
+		relatedEntities.each( function( relatedEntity ) {
+			if (
+				!isStruct( relatedEntity ) ||
+				!structKeyExists( relatedEntity, "isQuickEntity" ) ||
+				relatedEntity.mappingName() != relatedMapping
+			) {
+				throw(
+					type    = "QuickInvalidWhereBelongsTo",
+					message = "All whereBelongsTo entities must match [#relatedMapping#]."
+				);
+			}
+		} );
+
+		return where(
+			column = function( q ) {
+				relatedEntities.each( function( relatedEntity ) {
+					q.orWhere( function( q2 ) {
+						for ( var i = 1; i <= foreignKeys.len(); i++ ) {
+							q2.where( foreignKeys[ i ], relatedEntity.retrieveAttribute( localKeys[ i ] ) );
+						}
+					} );
+				} );
+			},
+			combinator = arguments.combinator
+		);
+	}
+
+	/**
+	 * Adds a whereBelongsTo constraint using an OR combinator.
+	 *
+	 * @related           A related Quick entity, an array of entities, or a collection of entities.
+	 * @relationshipName  The belongsTo relationship to use.
+	 *
+	 * @return            quick.models.QuickQB
+	 */
+	public QuickQB function orWhereBelongsTo( required any related, string relationshipName ) {
+		arguments.combinator = "or";
+		return whereBelongsTo( argumentCollection = arguments );
+	}
+
+	/**
 	 * Checks for the existence of a relationship when executing the query.
 	 *
 	 * @relationshipName  The relationship to check.  Can also be a dot-delimited list of nested relationships.

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -407,17 +407,23 @@ component
 	 * Constrains the query to entities belonging to one or more related entities.
 	 * The relationship name defaults to the lower-camel-cased related entity name.
 	 *
-	 * @related           A related Quick entity, an array of entities, or a collection of entities.
 	 * @relationshipName  The belongsTo relationship to use.
+	 *                    A related entity can be passed here as a shortcut that infers the relationship name.
+	 * @related           A related Quick entity, an array of entities, or a collection of entities.
 	 * @combinator        The boolean combinator for the clause. Default: "and".
 	 *
 	 * @return            quick.models.QuickQB
 	 */
 	public QuickQB function whereBelongsTo(
-		required any related,
-		string relationshipName,
+		required any relationshipName,
+		any related,
 		string combinator = "and"
 	) {
+		if ( isNull( arguments.related ) ) {
+			arguments.related = arguments.relationshipName;
+			arguments.delete( "relationshipName" );
+		}
+
 		var relatedEntities = isArray( arguments.related )
 		 ? arguments.related
 		 : (
@@ -433,7 +439,7 @@ component
 			);
 		}
 
-		if ( isNull( arguments.relationshipName ) ) {
+		if ( !arguments.keyExists( "relationshipName" ) || isNull( arguments.relationshipName ) ) {
 			var relatedEntityName      = relatedEntities[ 1 ].entityName();
 			arguments.relationshipName = lCase( left( relatedEntityName, 1 ) ) & removeChars( relatedEntityName, 1, 1 );
 		}
@@ -485,12 +491,13 @@ component
 	/**
 	 * Adds a whereBelongsTo constraint using an OR combinator.
 	 *
-	 * @related           A related Quick entity, an array of entities, or a collection of entities.
 	 * @relationshipName  The belongsTo relationship to use.
+	 *                    A related entity can be passed here as a shortcut that infers the relationship name.
+	 * @related           A related Quick entity, an array of entities, or a collection of entities.
 	 *
 	 * @return            quick.models.QuickQB
 	 */
-	public QuickQB function orWhereBelongsTo( required any related, string relationshipName ) {
+	public QuickQB function orWhereBelongsTo( required any relationshipName, any related ) {
 		arguments.combinator = "or";
 		return whereBelongsTo( argumentCollection = arguments );
 	}

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -5,7 +5,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 			describe( "whereBelongsTo", function() {
 				it( "constrains a query using a named belongsTo relationship", function() {
 					var author = getInstance( "User" ).findOrFail( 1 );
-					var posts  = getInstance( "Post" ).whereBelongsTo( author, "author" ).get();
+					var posts  = getInstance( "Post" ).whereBelongsTo( "author", author ).get();
 
 					expect( posts ).toHaveLength( 2 );
 					expectAll( posts ).toSatisfy( function( post ) {
@@ -25,7 +25,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 				it( "constrains a query to an array of related entities", function() {
 					var authors = getInstance( "User" ).whereIn( "id", [ 1, 4 ] ).get();
-					var posts   = getInstance( "Post" ).whereBelongsTo( authors, "author" ).get();
+					var posts   = getInstance( "Post" ).whereBelongsTo( "author", authors ).get();
 
 					expect( posts ).toHaveLength( 3 );
 					expectAll( posts ).toSatisfy( function( post ) {
@@ -38,7 +38,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						.where( "a", 1 )
 						.where( "b", 2 )
 						.firstOrFail();
-					var children = getInstance( "CompositeChild" ).whereBelongsTo( parent, "parent" ).get();
+					var children = getInstance( "CompositeChild" ).whereBelongsTo( "parent", parent ).get();
 
 					expect( children ).toHaveLength( 1 );
 					expect( children[ 1 ].getComposite_A() ).toBe( 1 );
@@ -49,7 +49,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					var author = getInstance( "User" ).findOrFail( 1 );
 					var posts  = getInstance( "Post" )
 						.where( "post_pk", 7777 )
-						.orWhereBelongsTo( author, "author" )
+						.orWhereBelongsTo( "author", author )
 						.get();
 
 					expect( posts ).toHaveLength( 3 );

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -2,6 +2,60 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 	function run() {
 		describe( "Querying Relationships Spec", function() {
+			describe( "whereBelongsTo", function() {
+				it( "constrains a query using a named belongsTo relationship", function() {
+					var author = getInstance( "User" ).findOrFail( 1 );
+					var posts  = getInstance( "Post" ).whereBelongsTo( author, "author" ).get();
+
+					expect( posts ).toHaveLength( 2 );
+					expectAll( posts ).toSatisfy( function( post ) {
+						return post.getUser_Id() == author.getId();
+					} );
+				} );
+
+				it( "infers a conventional belongsTo relationship name", function() {
+					var country = getInstance( "Country" ).findOrFail( "02B84D66-0AA0-F7FB-1F71AFC954843861" );
+					var users   = getInstance( "User" ).whereBelongsTo( country ).get();
+
+					expect( users ).toHaveLength( 2 );
+					expectAll( users ).toSatisfy( function( user ) {
+						return user.getCountry_Id() == country.getId();
+					} );
+				} );
+
+				it( "constrains a query to an array of related entities", function() {
+					var authors = getInstance( "User" ).whereIn( "id", [ 1, 4 ] ).get();
+					var posts   = getInstance( "Post" ).whereBelongsTo( authors, "author" ).get();
+
+					expect( posts ).toHaveLength( 3 );
+					expectAll( posts ).toSatisfy( function( post ) {
+						return [ 1, 4 ].contains( post.getUser_Id() );
+					} );
+				} );
+
+				it( "supports composite belongsTo relationships", function() {
+					var parent = getInstance( "Composite" )
+						.where( "a", 1 )
+						.where( "b", 2 )
+						.firstOrFail();
+					var children = getInstance( "CompositeChild" ).whereBelongsTo( parent, "parent" ).get();
+
+					expect( children ).toHaveLength( 1 );
+					expect( children[ 1 ].getComposite_A() ).toBe( 1 );
+					expect( children[ 1 ].getComposite_B() ).toBe( 2 );
+				} );
+
+				it( "supports an OR combinator", function() {
+					var author = getInstance( "User" ).findOrFail( 1 );
+					var posts  = getInstance( "Post" )
+						.where( "post_pk", 7777 )
+						.orWhereBelongsTo( author, "author" )
+						.get();
+
+					expect( posts ).toHaveLength( 3 );
+				} );
+			} );
+
 			describe( "has", function() {
 				describe( "hasMany", function() {
 					it( "can find only entities that have one or more related entities", function() {

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -29,7 +29,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 					expect( posts ).toHaveLength( 3 );
 					expectAll( posts ).toSatisfy( function( post ) {
-						return [ 1, 4 ].contains( post.getUser_Id() );
+						return arrayFind( [ 1, 4 ], post.getUser_Id() ) > 0;
 					} );
 				} );
 


### PR DESCRIPTION
Closes #155

## Issue review

**Recommendation: 9/10.** `whereBelongsTo` is a strong fit for Quick. It expresses a common foreign-key filter in relationship terms, avoids duplicating key and column knowledge at call sites, and keeps the relationship definition as the source of truth for aliases, custom keys, and composite keys.

The API deliberately supports only `BelongsTo` relationships. Relationship-name inference is local to this method and follows the conventional lower-camel-cased related entity name; aliased relationships such as `author` remain explicit.

## API

```cfml
whereBelongsTo( relationshipName, related, string combinator = "and" )
```

Examples:

```cfml
Post.whereBelongsTo( "author", user )
User.whereBelongsTo( country )
```

When `related` is null or omitted, the first argument is shifted into `related` and the relationship name is inferred. `orWhereBelongsTo` uses the same argument order and shortcut.

`related` may be one Quick entity, an array of entities, or a collection exposing `get()`. The method rejects empty inputs, mixed entity mappings, and relationships whose class is not `BelongsTo`.

## Test-first result

Public integration coverage exercises:

- an explicitly named aliased relationship using relationship-name-first ordering;
- the one-argument inference shortcut;
- multiple related entities;
- composite keys;
- OR composition using the matching argument order.

After changing the tests first, the prior implementation produced four argument type errors. After revising the signatures and shortcut logic, the focused `QueryingRelationshipsSpec` passes all 48 specs.

## Validation

- Red phase: 44 passed, 0 failed, 4 errors.
- Green phase: 48 passed, 0 failed, 0 errors.
- Full Lucee 6 suite: 556 passed, 0 failed, 0 errors, 3 skipped.
- Full GitHub Actions matrix: 27 of 27 checks passed.
- `box run-script format`
- `git diff --check`
- Rebased onto `next` after #313 and #274.

Dependency: `qb 14.0.0-beta.3`.
