### PR TITLE
feat: fill non-persistent entity properties

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -691,6 +691,12 @@ component accessors="true" {
 			if ( isNull( arguments.attributes[ key ] ) || !structKeyExists( arguments.attributes, key ) ) {
 				if ( hasAttribute( key ) ) {
 					clearAttribute( key, true );
+				} else if ( hasNonPersistentProperty( key ) ) {
+					invoke(
+						this,
+						"set#variables._meta.nonPersistentProperties[ key ].name#",
+						{ "1" : javacast( "null", "" ) }
+					);
 				} else if ( !arguments.ignoreNonExistentAttributes ) {
 					guardAgainstNonExistentAttribute( key );
 				}
@@ -710,6 +716,12 @@ component accessors="true" {
 				invoke(
 					this,
 					"set#retrieveAliasForColumn( key )#",
+					{ "1" : value }
+				);
+			} else if ( hasNonPersistentProperty( key ) ) {
+				invoke(
+					this,
+					"set#variables._meta.nonPersistentProperties[ key ].name#",
 					{ "1" : value }
 				);
 			} else if ( !arguments.ignoreNonExistentAttributes ) {
@@ -2935,10 +2947,15 @@ component accessors="true" {
 					);
 
 					param meta.originalMetadata.properties = [];
+					param meta.localMetadata.properties    = [];
 
 					meta[ "attributes" ] = generateAttributesFromProperties(
 						meta.hasParentEntity ? meta.localMetadata.properties : meta.originalMetadata.properties
 					);
+					meta[ "nonPersistentProperties" ] = generateNonPersistentProperties( meta.localMetadata.properties );
+					if ( meta.hasParentEntity ) {
+						meta.nonPersistentProperties.append( meta.parentDefinition.meta.nonPersistentProperties, false );
+					}
 					if ( structKeyExists( meta.localMetadata, "discriminatorColumn" ) ) {
 						meta.attributes[ meta.localMetaData.discriminatorColumn ] = paramAttribute( { "name" : meta.localMetaData.discriminatorColumn } );
 					}
@@ -3072,6 +3089,37 @@ component accessors="true" {
 			arguments.acc[ newProp.name ] = newProp;
 			return arguments.acc;
 		}, {} );
+	}
+
+	/**
+	 * Creates an internal property struct for each non-persistent, non-injected
+	 * property declared on the entity.
+	 *
+	 * @properties  The array of properties declared on the entity.
+	 *
+	 * @return      A struct of non-persistent properties for the entity.
+	 */
+	private struct function generateNonPersistentProperties( required array properties ) {
+		return arguments.properties.reduce( function( acc, prop ) {
+			var newProp     = paramAttribute( arguments.prop );
+			var annotations = newProp.keyExists( "annotations" ) && isStruct( newProp.annotations )
+			 ? newProp.annotations
+			 : {};
+			if ( newProp.persistent || newProp.keyExists( "inject" ) || annotations.keyExists( "inject" ) ) {
+				return arguments.acc;
+			}
+			arguments.acc[ newProp.name ] = newProp;
+			return arguments.acc;
+		}, {} );
+	}
+
+	/**
+	 * Returns whether the entity declares a fillable non-persistent property.
+	 *
+	 * @name  The property name to check.
+	 */
+	private boolean function hasNonPersistentProperty( required string name ) {
+		return variables._meta.nonPersistentProperties.keyExists( arguments.name );
 	}
 
 	private struct function generateCastsFromProperties( required array properties ) {
@@ -3365,8 +3413,10 @@ component accessors="true" {
 	 */
 	private boolean function isReadOnlyAttribute( required string name ) {
 		var alias = retrieveAliasForColumn( arguments.name );
-		return variables._attributes.keyExists( alias ) &&
-		variables._attributes[ alias ].readOnly;
+		return ( variables._attributes.keyExists( alias ) && variables._attributes[ alias ].readOnly ) || (
+			variables._meta.nonPersistentProperties.keyExists( arguments.name ) &&
+			variables._meta.nonPersistentProperties[ arguments.name ].readOnly
+		);
 	}
 
 	/**

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3092,8 +3092,8 @@ component accessors="true" {
 	}
 
 	/**
-	 * Creates an internal property struct for each non-persistent, non-injected
-	 * property declared on the entity.
+	 * Creates an internal property struct for each explicitly fillable,
+	 * non-persistent, non-injected property declared on the entity.
 	 *
 	 * @properties  The array of properties declared on the entity.
 	 *
@@ -3105,7 +3105,12 @@ component accessors="true" {
 			var annotations = newProp.keyExists( "annotations" ) && isStruct( newProp.annotations )
 			 ? newProp.annotations
 			 : {};
-			if ( newProp.persistent || newProp.keyExists( "inject" ) || annotations.keyExists( "inject" ) ) {
+			if (
+				newProp.persistent ||
+				!newProp.fillable ||
+				newProp.keyExists( "inject" ) ||
+				annotations.keyExists( "inject" )
+			) {
 				return arguments.acc;
 			}
 			arguments.acc[ newProp.name ] = newProp;
@@ -3185,8 +3190,17 @@ component accessors="true" {
 		) {
 			arguments.attr.persistent = arguments.attr.annotations.persistent;
 		}
+		if (
+			!arguments.attr.keyExists( "fillable" ) &&
+			arguments.attr.keyExists( "annotations" ) &&
+			isStruct( arguments.attr.annotations ) &&
+			arguments.attr.annotations.keyExists( "fillable" )
+		) {
+			arguments.attr.fillable = arguments.attr.annotations.fillable;
+		}
 		param attr.column         = arguments.attr.name;
 		param attr.persistent     = true;
+		param attr.fillable       = false;
 		param attr.nullValue      = "";
 		param attr.convertToNull  = true;
 		param attr.casts          = "";
@@ -3199,6 +3213,9 @@ component accessors="true" {
 		param attr.isParentColumn = false;
 		if ( !isBoolean( attr.persistent ) ) {
 			attr.persistent = lCase( trim( attr.persistent & "" ) ) == "true";
+		}
+		if ( !isBoolean( attr.fillable ) ) {
+			attr.fillable = lCase( trim( attr.fillable & "" ) ) == "true";
 		}
 		variables._nullValues[ attr.name ] = attr.nullValue;
 		return arguments.attr;

--- a/tests/resources/app/models/Post.cfc
+++ b/tests/resources/app/models/Post.cfc
@@ -10,7 +10,8 @@ component
 	property name="createdDate"   column="created_date";
 	property name="modifiedDate"  column="modified_date";
 	property name="publishedDate" column="published_date";
-	property name="lifecycleEventVar" persistent="false";
+	property name="lifecycleEventVar"      persistent="false" fillable="true";
+	property name="internalLifecycleState" persistent="false";
 
 	variables._key = "post_pk";
 

--- a/tests/resources/app/models/Post.cfc
+++ b/tests/resources/app/models/Post.cfc
@@ -10,6 +10,7 @@ component
 	property name="createdDate"   column="created_date";
 	property name="modifiedDate"  column="modified_date";
 	property name="publishedDate" column="published_date";
+	property name="lifecycleEventVar" persistent="false";
 
 	variables._key = "post_pk";
 

--- a/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
@@ -72,6 +72,12 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} ).notToThrow();
 			} );
 
+			it( "does not mass assign injected non-persistent properties", function() {
+				expect( function() {
+					getInstance( "Link" ).fill( { "wirebox" : "not-the-injector" } );
+				} ).toThrow( "AttributeNotFound" );
+			} );
+
 			it( "translates attributes to their column names", function() {
 				expect( function() {
 					getInstance( "Link" ).create( { url : "https://example.com" } );

--- a/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ColumnsSpec.cfc
@@ -78,6 +78,12 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} ).toThrow( "AttributeNotFound" );
 			} );
 
+			it( "does not mass assign non-persistent properties unless explicitly fillable", function() {
+				expect( function() {
+					getInstance( "Post" ).fill( { "internalLifecycleState" : "internal-only" } );
+				} ).toThrow( "AttributeNotFound" );
+			} );
+
 			it( "translates attributes to their column names", function() {
 				expect( function() {
 					getInstance( "Link" ).create( { url : "https://example.com" } );

--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -159,6 +159,20 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} ).toThrow( "RelationshipNotFound" );
 			} );
 
+			it( "can set non-persistent properties when creating related entities", function() {
+				var user    = getInstance( "User" ).find( 1 );
+				var newPost = user
+					.posts()
+					.create( {
+						"body"              : "A post with transient lifecycle state",
+						"lifecycleEventVar" : "skip-events"
+					} );
+
+				expect( newPost.isLoaded() ).toBeTrue();
+				expect( newPost.getLifecycleEventVar() ).toBe( "skip-events" );
+				expect( newPost.fresh().getLifecycleEventVar() ).toBeNull();
+			} );
+
 			it( "can first off of the relationship", function() {
 				var user = getInstance( "User" ).find( 1 );
 				var post = user.posts().first();


### PR DESCRIPTION
## Issue review

Issue #152 asks Quick to accept declared `persistent="false"` properties in `fill()` and `create()`, including relationship creation such as `user.posts().create(...)`.

I rate this **8/10** for Quick, provided it is explicit opt-in. Transient entity state is useful for lifecycle decisions and other behavior that intentionally never reaches the database, and supporting it in `fill()` keeps direct, builder, and relationship creation consistent. The tradeoff is that broadening mass assignment to every non-persistent property would expose internal state and potentially dependency-injected properties.

## Design

Non-persistent properties are fillable only when declared with `fillable="true"`:

```cfml
property name="lifecycleEvent" persistent="false" fillable="true";
```

Unmarked non-persistent properties and injected properties remain protected from mass assignment. Filled transient values use the normal accessor/custom-setter flow, support null, inherit across Quick entity subclasses, honor read-only metadata, and are never persisted.

## Test-first reproduction

I added a public `fill()` regression proving an unmarked non-persistent property must be rejected. Before the implementation change, it failed because no `AttributeNotFound` exception was thrown. The existing public relationship `create()` regression verifies that an opted-in transient value is accepted, then uses `fresh()` to prove it was not persisted.

## Validation

- Red phase: focused suites had 28 passed and 1 failed at the new opt-in boundary.
- Green phase: focused `ColumnsSpec` and `HasManySpec` suites have 29 passed, 0 failed, 0 errors.
- `box run-script format`
- `git diff --check`

Closes #152
