### PR TITLE
test: preserve bindings while chunking scoped queries

### DIFF
--- a/tests/resources/app/models/UserWithGlobalScope.cfc
+++ b/tests/resources/app/models/UserWithGlobalScope.cfc
@@ -8,8 +8,18 @@ component extends="User" table="users"  accessors="true" {
         qb.addSubselect( "teamName", "team.name" );
     }        
 
+    function scopeWithBoundCountryName( qb ) {
+        qb.addSubselect( "boundCountryName", function( q ) {
+            q.select( "name" )
+                .from( "countries" )
+                .whereColumn( "countries.id", "users.country_id" )
+                .where( "countries.id", "02B84D66-0AA0-F7FB-1F71AFC954843861" );
+        } );
+    }
+
     function applyGlobalScopes( qb ) {
         qb.withCountryName();
-        qb.withTeamName();        
+        qb.withTeamName();
+        qb.withBoundCountryName();
     }
 }

--- a/tests/specs/integration/BaseEntity/GlobalScopeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GlobalScopeSpec.cfc
@@ -65,6 +65,32 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.countryName ).toBe( "United States" );
 			} );
 
+			it( "preserves binding order when chunking a query with a bound global-scope subselect", function() {
+				var startDate = createDateTime( 2017, 1, 1, 0, 0, 0 );
+				var endDate   = createDateTime( 2018, 1, 1, 0, 0, 0 );
+				var query     = getInstance( "UserWithGlobalScope" )
+					.whereBetween( "created_date", startDate, endDate )
+					.where( "type", "admin" )
+					.activateGlobalScopes()
+					.retrieveQuery();
+				var bindingsBeforeChunk = query.getBindings().map( ( binding ) => binding.value );
+				var rows                = [];
+
+				query.chunk( 1, function( chunk ) {
+					rows.append( chunk, true );
+				} );
+
+				expect( rows ).toHaveLength( 1 );
+				expect( rows[ 1 ].username ).toBe( "elpete" );
+				expect( query.getBindings().map( ( binding ) => binding.value ) ).toBe( bindingsBeforeChunk );
+				expect( bindingsBeforeChunk ).toBe( [
+					"02B84D66-0AA0-F7FB-1F71AFC954843861",
+					startDate,
+					endDate,
+					"admin"
+				] );
+			} );
+
 			it( "subsequent entity calls using withoutGlobalScope do not cache memento keys", function() {
 				var userA = getInstance( "UserWithGlobalScope" ).findOrFail( 1 ).getMemento();
 


### PR DESCRIPTION
## Issue review

Issue #151 reports `chunk()` mutating/reordering bindings when its internal count runs against a Quick query containing global-scope subselect bindings.

I rate the behavior **10/10** to protect. Binding order must remain stable across aggregate and pagination helpers; swapped date, boolean, string, or UUID values can silently return incorrect data or produce database errors.

## Attempted reproduction

I recreated the historical query shape through public APIs on current `next` with `qb 14.0.0-beta.3`:

- a global scope adds a subselect containing a UUID binding;
- the outer query adds a two-binding date range and a string constraint;
- the query is handed from Quick to qb with `retrieveQuery()`;
- `chunk( 1, callback )` runs its internal count and result query;
- the test verifies the correct row and the exact four-value binding order before and after chunking.

The bug did not reproduce. Current qb documents aggregate queries as non-mutating, and the source query retained the UUID, both dates, and string in the correct order.

The original report was SQL Server-specific. This repository's integration environment is MySQL, so the SQL Server execution path could not be exercised here. The regression still covers the reported mutation mechanism independently of grammar.

## Implementation

No production change was justified without a current failure. This PR strengthens the global-scope fixture with a bound subselect and adds the exact chunk/binding-order regression.

## Validation

- Focused global-scope suite: 9 passed, 0 failed, 0 errors, 1 skipped.
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped.
- `box run-script format`
- `git diff --check`

Closes #151
