### PR TITLE
test: ignore non-persistent structs in dirty hashes

### DIFF
--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -17,6 +17,7 @@ component extends="quick.models.BaseEntity" accessors="true" {
 	property name="type";
 	property name="externalID";
 	property name="favoritePost_id";
+	property name="cacheMetadata" persistent="false";
 
 	property
 		name      ="address"

--- a/tests/specs/integration/BaseEntity/HydrateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/HydrateSpec.cfc
@@ -20,6 +20,28 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.retrieveAttribute( "last_name" ) ).toBe( "Peterson" );
 			} );
 
+			it( "ignores non-persistent struct properties when checking hydrated entities for changes", function() {
+				var memento = {
+					"cacheMetadata" : {
+						"source" : "cache",
+						"tags"   : [ "one", "two" ]
+					},
+					"id"         : 4,
+					"username"   : "elpete2",
+					"first_name" : "Another",
+					"last_name"  : "Peterson"
+				};
+				var user                 = getInstance( "User" ).hydrate( memento );
+				var updatedCacheMetadata = {
+					"source" : "refreshed-cache",
+					"tags"   : [ "three" ]
+				};
+				user.setCacheMetadata( updatedCacheMetadata );
+
+				expect( user.getCacheMetadata() ).toBe( updatedCacheMetadata );
+				expect( user.isDirty() ).toBeFalse();
+			} );
+
 			it( "can hydrate multiple entities at once from an array of structs", function() {
 				var mementos = [
 					{


### PR DESCRIPTION
## Issue review

Issue #146 reports attribute hashing failing when cached hydration data contains a declared non-persistent struct property.

I rate this **10/10** to protect. Dirty tracking must consider only database-backed attributes; transient cache metadata should neither be coerced into a hash string nor make an unchanged entity dirty.

## Attempted reproduction

The public regression now exercises the complete state transition on current `next` with qb 14.0.0-beta.3:

- declare a persistent-false struct property on an entity
- hydrate the entity from a cache-style struct containing nested metadata
- replace that non-persistent property with a different struct after hydration
- verify the replacement is visible through the entity accessor
- call public `isDirty()` and confirm the entity remains clean

The original exception does not reproduce. Current `computeAttributesHash()` filters candidate keys through `hasAttribute`, so changes to the transient property do not participate in the persistence hash.

## Implementation

No production change is necessary. This PR adds integration coverage through `hydrate()`, the generated property setter/getter, and `isDirty()` rather than testing the hash helper directly.

## Validation

- focused HydrateSpec: 3 passed, 0 failed, 0 errors
- full Lucee 6 suite: 537 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed

Closes #146
