### PR TITLE
Suggest likely missing query scope prefixes

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -2588,6 +2588,23 @@ component accessors="true" {
 		array exclusions              = []
 	) {
 		if ( !structKeyExists( variables, "scope#arguments.missingMethodName#" ) ) {
+			if (
+				arrayContainsNoCase( variables._meta.functionNames, arguments.missingMethodName ) &&
+				isCustomFunction( variables[ arguments.missingMethodName ] )
+			) {
+				var suggestedScopeName = "scope" & uCase( left( arguments.missingMethodName, 1 ) ) & mid(
+					arguments.missingMethodName,
+					2,
+					len( arguments.missingMethodName )
+				);
+				throw(
+					type    = "QuickMissingMethod",
+					message = "Quick could not use [#arguments.missingMethodName#] as a query scope. " &
+					"An entity function named [#arguments.missingMethodName#] exists. " &
+					"If that function is intended to be a query scope, rename it to [#suggestedScopeName#]. " &
+					"See https://quick.ortusbooks.com/guide/getting-started/query-scopes-and-subselects"
+				);
+			}
 			return;
 		}
 

--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -70,6 +70,10 @@ component extends="quick.models.BaseEntity" accessors="true" {
 		return qb.updateAll( { "password" : "" } ).result.recordcount;
 	}
 
+	function incorrectlyNamedScope( qb ) {
+		return qb.where( "type", "admin" );
+	}
+
 	function scopeWithLatestPostId( qb ) {
 		qb.addSubselect(
 			"latestPostId",

--- a/tests/specs/integration/BaseEntity/ScopeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ScopeSpec.cfc
@@ -17,6 +17,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				fail( "Expected a QuickMissingMethod exception" );
 			} );
 
+			it( "suggests an entity function that may be missing the scope prefix", function() {
+				expect( function() {
+					getInstance( "User" ).newQuery().incorrectlyNamedScope();
+				} ).toThrow(
+					type  = "QuickMissingMethod",
+					regex = "An entity function named \[incorrectlyNamedScope\] exists.*scopeIncorrectlyNamedScope.*https://quick.ortusbooks.com/guide/getting-started/query-scopes-and-subselects"
+				);
+			} );
+
 			it( "looks for missing methods as scopes", function() {
 				var users = getInstance( "User" ).latest().get();
 				expect( users ).toHaveLength( 5, "Five users should exist in the database and be returned." );


### PR DESCRIPTION
Closes #144

## Issue review

This is a useful, narrowly scoped improvement and a good fit for Quick.

Recommendation: **8/10 — implement.**

Reasons for:
- omitting the `scope` prefix is easy to do and the current qb exception does not point developers toward the mistake
- Quick already knows which functions belong to the concrete entity, so the suggestion is deterministic rather than fuzzy
- the message includes the exact corrected method name and current query-scope documentation

Tradeoffs:
- an entity-local function with the same requested name is only evidence, not proof, that the author intended a scope, so the wording is deliberately conditional
- inherited Quick framework methods must not be treated as candidates; the implementation limits suggestions to the entity function metadata Quick already computes with BaseEntity functions removed

## Test-first implementation

The regression uses Quick's public builder flow:

```cfml
getInstance( "User" ).newQuery().incorrectlyNamedScope()
```

Before the implementation it failed with the generic `QBMissingMethod` message. It now throws `QuickMissingMethod`, identifies `incorrectlyNamedScope`, suggests `scopeIncorrectlyNamedScope`, and links to the scope documentation.

The first implementation also demonstrated why the existing filtered entity metadata matters: checking the raw component variables caught inherited `update` and `delete` methods and caused 56 full-suite errors. Restricting the check to `meta.functionNames` preserves all framework forwarding behavior while still recognizing application entity functions.

## Validation

- focused `ScopeSpec`: 10 passed, 0 failed, 0 errors
- adjacent scope/compatibility/read-only suites: 64 passed, 0 failed, 0 errors
- full Lucee 6 suite with qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
