### PR TITLE
Add whereHasValue relationship shortcut

### DIFF
--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -669,6 +669,36 @@ component
 	}
 
 	/**
+	 * Checks for the existence of a relationship with a column value constraint.
+	 * This is a shortcut for passing a callback containing a single `where` clause to `whereHas`.
+	 *
+	 * @relationshipName  The relationship to check.
+	 * @column            The related column to constrain.
+	 * @operator          The operator or value for the constraint. When `value` is omitted, this is treated as the value and the operator is `=`.
+	 * @value             The optional value with which to constrain the related column.
+	 *
+	 * @return            quick.models.QuickQB
+	 */
+	public QuickQB function whereHasValue(
+		required string relationshipName,
+		required any column,
+		required any operator,
+		any value
+	) {
+		var whereArguments = {
+			"column"   : arguments.column,
+			"operator" : arguments.operator
+		};
+		if ( structKeyExists( arguments, "value" ) ) {
+			whereArguments[ "value" ] = arguments.value;
+		}
+
+		return whereHas( arguments.relationshipName, function( q ) {
+			invoke( q, "where", whereArguments );
+		} );
+	}
+
+	/**
 	 * Checks for the absence of a relationship when executing the query.
 	 * The absence check is constrained by a closure.
 	 *

--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -91,6 +91,34 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						expect( users ).toHaveLength( 1 );
 					} );
 
+					it( "can compare a column on a nested relationship using whereHasValue", function() {
+						var posts = getInstance( "Post" )
+							.whereHasValue(
+								"author.country",
+								"name",
+								"United States"
+							)
+							.orderBy( "post_pk" )
+							.get();
+
+						expect( posts ).toHaveLength( 2 );
+						expect( posts[ 1 ].getPost_Pk() ).toBe( 1245 );
+						expect( posts[ 2 ].getPost_Pk() ).toBe( 523526 );
+					} );
+
+					it( "supports custom comparison operators in whereHasValue", function() {
+						var posts = getInstance( "Post" )
+							.whereHasValue(
+								"author.country",
+								"name",
+								"<>",
+								"Argentina"
+							)
+							.get();
+
+						expect( posts ).toHaveLength( 2 );
+					} );
+
 					it( "can nest multiple levels", function() {
 						var countries = getInstance( "Country" )
 							.whereHas( "users.posts.comments", function( q ) {


### PR DESCRIPTION
Closes #143

## Issue review

This is a good fit for Quick because relationship existence checks are common and a one-column predicate should not require an otherwise ceremonial closure.

Recommendation: **9/10 — implement the explicit `whereHasValue` method.**

Reasons for:
- it substantially shortens the common case while keeping the relationship path visibly separate from the related column
- matching qb's `where(column, value)` and `where(column, operator, value)` forms makes the API predictable
- it naturally supports nested relationships and every value type qb's `where` accepts

Reasons against / tradeoffs:
- overloading `whereHas` would be shorter still, but it would make the second argument's meaning type-dependent and complicate the existing callback/count signature
- a new method expands the public surface, though its behavior is a very small composition of established APIs
- `whereHasValue` intentionally covers one predicate; callers with multiple or grouped predicates should continue using `whereHas` with a callback

## Test-first implementation

I added public integration tests before the method existed for:

```cfml
.whereHasValue( "author.country", "name", "United States" )
.whereHasValue( "author.country", "name", "<>", "Argentina" )
```

Both tests initially errored while the unknown method fell through to qb. The implementation now builds the corresponding `where` arguments and delegates to `whereHas`, so relationship resolution, nesting, SQL qualification, and binding behavior remain centralized in the existing path.

## Validation

- focused `QueryingRelationshipsSpec`: 39 passed, 0 failed, 0 errors
- full Lucee 6 suite with qb 14.0.0-beta.3: 497 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
