### PR TITLE
Surface missing methods inside qb callbacks

### DIFF
--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -476,11 +476,15 @@ component accessors="true" transientCache="false" {
 				arguments.onFalse( this );
 			}
 		} else {
+			var condition       = arguments.condition;
+			var onTrueCallback  = arguments.onTrue;
+			var onFalseCallback = arguments.onFalse;
+			var builder         = this;
 			variables.qb.withScoping( function() {
 				if ( condition ) {
-					onTrue( this );
+					onTrueCallback( builder );
 				} else {
-					onFalse( this );
+					onFalseCallback( builder );
 				}
 			} );
 		}
@@ -990,7 +994,17 @@ component accessors="true" transientCache="false" {
 			return result;
 		}
 
-		return javacast( "null", "" );
+		throw(
+			type    = "QuickMissingMethod",
+			message = arrayToList(
+				[
+					"Quick couldn't figure out what to do with [#arguments.missingMethodName#].",
+					"We tried checking columns, aliases, scopes, and relationships locally.",
+					"We also forwarded the call on to qb to see if it could do anything with it, but it couldn't."
+				],
+				" "
+			)
+		);
 	}
 
 	/**

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -476,16 +476,10 @@ component accessors="true" transientCache="false" {
 				arguments.onFalse( this );
 			}
 		} else {
-			var condition       = arguments.condition;
-			var onTrueCallback  = arguments.onTrue;
-			var onFalseCallback = arguments.onFalse;
-			var builder         = this;
+			var selectedCallback = arguments.condition ? arguments.onTrue : arguments.onFalse;
+			var builder          = this;
 			variables.qb.withScoping( function() {
-				if ( condition ) {
-					onTrueCallback( builder );
-				} else {
-					onFalseCallback( builder );
-				}
+				selectedCallback( builder );
 			} );
 		}
 

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -1007,7 +1007,23 @@ component
 			return result;
 		}
 
-		return super.onMissingMethod( argumentCollection = arguments );
+		try {
+			return super.onMissingMethod( argumentCollection = arguments );
+		} catch ( QBMissingMethod e ) {
+			throw(
+				type    = "QuickMissingMethod",
+				message = arrayToList(
+					[
+						"Quick couldn't figure out what to do with [#arguments.missingMethodName#].",
+						"The error returned was: #e.message#",
+						"We tried checking columns, aliases, scopes, and relationships locally.",
+						"We also forwarded the call on to qb to see if it could do anything with it, but it couldn't."
+					],
+					" "
+				),
+				extendedInfo = serializeJSON( e )
+			);
+		}
 	}
 
 	// override's super impl

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -1007,23 +1007,31 @@ component
 			return result;
 		}
 
+		var qbResult = javacast( "null", "" );
+		var qbError  = {};
 		try {
-			return super.onMissingMethod( argumentCollection = arguments );
+			qbResult = super.onMissingMethod( argumentCollection = arguments );
 		} catch ( QBMissingMethod e ) {
-			throw(
-				type    = "QuickMissingMethod",
-				message = arrayToList(
-					[
-						"Quick couldn't figure out what to do with [#arguments.missingMethodName#].",
-						"The error returned was: #e.message#",
-						"We tried checking columns, aliases, scopes, and relationships locally.",
-						"We also forwarded the call on to qb to see if it could do anything with it, but it couldn't."
-					],
-					" "
-				),
-				extendedInfo = serializeJSON( e )
-			);
+			qbError = e;
 		}
+
+		if ( !isNull( qbResult ) ) {
+			return qbResult;
+		}
+
+		throw(
+			type    = "QuickMissingMethod",
+			message = arrayToList(
+				[
+					"Quick couldn't figure out what to do with [#arguments.missingMethodName#].",
+					qbError.keyExists( "message" ) ? "The error returned was: #qbError.message#" : "qb did not return a result.",
+					"We tried checking columns, aliases, scopes, and relationships locally.",
+					"We also forwarded the call on to qb to see if it could do anything with it, but it couldn't."
+				],
+				" "
+			),
+			extendedInfo = serializeJSON( qbError )
+		);
 	}
 
 	// override's super impl

--- a/tests/specs/integration/BaseEntity/ScopeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ScopeSpec.cfc
@@ -3,19 +3,18 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 	function run() {
 		describe( "Scope Spec", function() {
 			it( "surfaces the missing method inside a when callback", function() {
-				var exception = {};
 				try {
 					getInstance( "User" ).when( true, function( q ) {
 						q.missingScopeInsideWhen();
 					} );
 				} catch ( any e ) {
-					exception = e;
+					expect( e.type ).toBe( "QuickMissingMethod" );
+					expect( e.message ).toInclude( "[missingScopeInsideWhen]" );
+					expect( e.message ).notToInclude( "[when]" );
+					return;
 				}
 
-				expect( exception ).notToBeEmpty();
-				expect( exception.type ).toBe( "QuickMissingMethod" );
-				expect( exception.message ).toInclude( "[missingScopeInsideWhen]" );
-				expect( exception.message ).notToInclude( "[when]" );
+				fail( "Expected a QuickMissingMethod exception" );
 			} );
 
 			it( "looks for missing methods as scopes", function() {

--- a/tests/specs/integration/BaseEntity/ScopeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/ScopeSpec.cfc
@@ -2,6 +2,22 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 	function run() {
 		describe( "Scope Spec", function() {
+			it( "surfaces the missing method inside a when callback", function() {
+				var exception = {};
+				try {
+					getInstance( "User" ).when( true, function( q ) {
+						q.missingScopeInsideWhen();
+					} );
+				} catch ( any e ) {
+					exception = e;
+				}
+
+				expect( exception ).notToBeEmpty();
+				expect( exception.type ).toBe( "QuickMissingMethod" );
+				expect( exception.message ).toInclude( "[missingScopeInsideWhen]" );
+				expect( exception.message ).notToInclude( "[when]" );
+			} );
+
 			it( "looks for missing methods as scopes", function() {
 				var users = getInstance( "User" ).latest().get();
 				expect( users ).toHaveLength( 5, "Five users should exist in the database and be returned." );


### PR DESCRIPTION
Closes #142

## Issue review

This is a valid error-reporting bug and a strong fit for Quick. The public call is `when`, but the actionable failure occurs on the Quick-aware builder passed to its callback. Reporting the wrapper method forces developers to read a nested message and can make a supported qb method look broken.

Recommendation: **9/10 — implement.**

Reasons for:
- the top-level exception should identify the method the developer needs to fix
- the correction applies to qb callbacks generally, not only `when`
- the implementation preserves the existing `QuickMissingMethod` text and underlying qb exception details

Tradeoffs:
- missing methods reached through `QuickQB` now become `QuickMissingMethod` at that boundary instead of bubbling as `QBMissingMethod` to an outer wrapper
- callers that inspect the outer method name in this erroneous path will now receive the more specific inner name

## Reproduction and fix

The regression was written first through the public Quick API:

```cfml
getInstance( "User" ).when( true, function( q ) {
    q.missingScopeInsideWhen();
} );
```

With the current `qb 14.0.0-beta.3`, the test failed because the top-level message said Quick could not handle `[when]`; the actual `[missingScopeInsideWhen]` error was nested later in the message.

`QuickQB.onMissingMethod` now converts qb's terminal missing-method exception at the point where the inner method name is still known. The outer entity handler therefore receives the already-actionable Quick exception and does not relabel it as `when`.

## Validation

- focused scope and error-message suites: 17 passed, 0 failed, 0 errors
- full Lucee 6 suite with qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
