### PR TITLE
Test raw expression table sources

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -363,6 +363,21 @@ component accessors="true" {
 	}
 
 	/**
+	 * Returns the table source for this entity's queries.
+	 *
+	 * Override this method to return a raw expression or another qb-supported
+	 * table source. The configured table name remains available for qualifying
+	 * entity columns.
+	 *
+	 * @builder  The builder that will receive the table source.
+	 *
+	 * @return   any
+	 */
+	public any function tableSource( required any builder ) {
+		return tableName();
+	}
+
+	/**
 	 * Returns the table name for this entity.
 	 *
 	 * @return  String
@@ -1091,7 +1106,7 @@ component accessors="true" {
 		var hasRefreshQuery = variables.keyExists( "_refreshQuery" ) && !isNull( variables._refreshQuery );
 		var freshEntity     = hasRefreshQuery ? variables._refreshQuery.clone().offset( 0 ) : newQuery();
 		var freshData       = freshEntity
-			.from( tableName() )
+			.from( tableSource( freshEntity ) )
 			.where( function( q ) {
 				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
 					q.where( this.qualifyColumn( keyName ), keyValue );
@@ -1118,7 +1133,7 @@ component accessors="true" {
 			.clone()
 			.offset( 0 );
 		var refreshedData = refreshedEntity
-			.from( tableName() )
+			.from( tableSource( refreshedEntity ) )
 			.where( function( q ) {
 				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
 					q.where( this.qualifyColumn( keyName ), keyValue );
@@ -2356,8 +2371,10 @@ component accessors="true" {
 			.setReturnFormat( "array" )
 			.set_preventLazyLoading( variables._preventLazyLoading )
 			.set_lazyLoadingViolationCallback( variables._lazyLoadingViolationCallback )
-			.mergeDefaultOptions( variables._queryOptions )
-			.from( tableName() )
+			.mergeDefaultOptions( variables._queryOptions );
+
+		newBuilder
+			.from( tableSource( newBuilder ) )
 			.addSelect( retrieveQualifiedColumns() )
 			.with( variables._with );
 

--- a/models/CBORMCompatEntity.cfc
+++ b/models/CBORMCompatEntity.cfc
@@ -156,13 +156,13 @@ component extends="quick.models.BaseEntity" accessors="true" {
 	}
 
 	function newCriteria() {
-		return variables._wirebox
+		var criteria = variables._wirebox
 			.getInstance( "CBORMCriteriaBuilderCompat@quick" )
 			.setEntity( this )
 			.setReturnFormat( "array" )
-			.mergeDefaultOptions( variables._queryOptions )
-			.from( tableName() )
-			.addSelect( retrieveQualifiedColumns() );
+			.mergeDefaultOptions( variables._queryOptions );
+
+		return criteria.from( tableSource( criteria ) ).addSelect( retrieveQualifiedColumns() );
 	}
 
 	private void function guardAgainstCompositePrimaryKeys() {

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1573,7 +1573,7 @@ component accessors="true" transientCache="false" {
 	 * @return  quick.models.QuickQB
 	 */
 	public any function newQuickQB() {
-		return variables._wirebox
+		var newQB = variables._wirebox
 			.getInstance( "QuickQB@quick" )
 			.setQuickBuilder( this )
 			.setEntity( getEntity() )
@@ -1581,8 +1581,9 @@ component accessors="true" transientCache="false" {
 			.mergeDefaultOptions( getEntity().get_queryOptions() )
 			.setColumnFormatter( function( column ) {
 				return qualifyColumn( column );
-			} )
-			.from( getEntity().tableName() );
+			} );
+
+		return newQB.from( getEntity().tableSource( newQB ) );
 	}
 
 	public any function retrieveQuery() {

--- a/tests/resources/app/models/RawExpressionUser.cfc
+++ b/tests/resources/app/models/RawExpressionUser.cfc
@@ -1,0 +1,7 @@
+component extends="User" table="users" accessors="true" {
+
+	public any function tableSource( required any builder ) {
+		return arguments.builder.raw( "users FORCE INDEX (PRIMARY)" );
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/QuerySpec.cfc
+++ b/tests/specs/integration/BaseEntity/QuerySpec.cfc
@@ -30,6 +30,16 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getUsername() ).toBe( "elpete" );
 			} );
 
+			it( "can use a raw expression as the table source", function() {
+				var users = getInstance( "User" ).newQuery();
+				users.from( users.raw( "users" ) );
+
+				var user = users.where( "username", "elpete" ).firstOrFail();
+
+				expect( user.getId() ).toBe( 1 );
+				expect( user.getUsername() ).toBe( "elpete" );
+			} );
+
 			it( "can use a QuickBuilder instance anywhere a QueryBuilder instance is accepted", function() {
 				var users = getInstance( "User" )
 					.whereIn( "username", getInstance( "User" ).select( "username" ).where( "type", "admin" ) )

--- a/tests/specs/integration/BaseEntity/QuerySpec.cfc
+++ b/tests/specs/integration/BaseEntity/QuerySpec.cfc
@@ -30,11 +30,11 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.getUsername() ).toBe( "elpete" );
 			} );
 
-			it( "can use a raw expression as the table source", function() {
-				var users = getInstance( "User" ).newQuery();
-				users.from( users.raw( "users" ) );
+			it( "can define a raw table source on an entity", function() {
+				var users = getInstance( "RawExpressionUser" ).where( "username", "elpete" );
+				expect( users.toSQL() ).toInclude( "FROM users FORCE INDEX (PRIMARY)" );
 
-				var user = users.where( "username", "elpete" ).firstOrFail();
+				var user = users.firstOrFail();
 
 				expect( user.getId() ).toBe( 1 );
 				expect( user.getUsername() ).toBe( "elpete" );


### PR DESCRIPTION
Closes #141

## Issue review

An entity-level raw table source is a good fit for Quick when applications need table hints or other qb-supported source expressions while retaining Quick attribute mapping.

Recommendation: **9/10 — implement.**

### Reasons for

- the raw source is declared once on the entity instead of repeated on every query
- qb already supports expression table sources
- Quick can keep the configured table name for column qualification while using a separate source for SQL generation
- the default remains fully backward-compatible

### Tradeoffs

- Quick cannot infer a qualifier from arbitrary SQL, so the entity's configured table name or alias remains authoritative for mapped columns
- raw source syntax is database-specific
- a custom source must expose the columns mapped by the entity

## Implementation

Entities can override `tableSource( builder )` and return any qb-supported table source, including `builder.raw(...)`. Quick uses that hook for normal entity queries, refreshed entities, reset builders, and CBORM-compatible criteria. The default implementation returns `tableName()`.

The regression entity declares `users FORCE INDEX (PRIMARY)` as its source. The test queries through the normal entity API, verifies the raw expression appears in generated SQL, and confirms the result hydrates as an entity. It does not manually replace `from()` in the test.

## Test-first evidence

The revised test was committed before the implementation and failed because the normal entity query emitted `FROM users`; the declared raw source was ignored. After adding the entity hook, the focused query suite passes 6/0/0.

## Validation

- focused QuerySpec: 6 passed, 0 failed, 0 errors
- full Lucee 6 suite: 537 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
- qb 14.0.0-beta.3
