### PR TITLE
Define doesntHave semantics for null belongsTo keys

### DIFF
--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -349,6 +349,16 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						expect( posts ).toBeArray();
 						expect( posts ).toHaveLength( 1 );
 					} );
+
+					it( "includes entities with null foreign keys", function() {
+						var users             = getInstance( "User" ).doesntHave( "country" ).get();
+						var usersWithNullKeys = getInstance( "User" ).whereNull( "countryId" ).get();
+
+						expect( users ).toHaveLength( 1 );
+						expect( usersWithNullKeys ).toHaveLength( 1 );
+						expect( users[ 1 ].getId() ).toBe( 3 );
+						expect( users[ 1 ].getId() ).toBe( usersWithNullKeys[ 1 ].getId() );
+					} );
 				} );
 
 				describe( "belongsToMany", function() {


### PR DESCRIPTION
Closes #136

## Issue review

The reported SQL is correct for `doesntHave`. A row with a null foreign key has no related entity, so it must be included in an absence query. Adding an implicit `IS NOT NULL` would redefine the method to mean “has a non-null foreign key whose target row is missing,” which is a narrower orphan-reference query.

Recommendation for the requested behavior change: **2/10 — do not implement.**

Reasons to retain the current behavior:
- `has` and `doesntHave` should remain logical complements
- null belongs-to keys represent absent relationships in lazy/eager loading as well as existence queries
- the current `NOT EXISTS` SQL has consistent semantics across relationship types
- callers can explicitly compose `.whereNotNull( "foreignKey" ).doesntHave( "relationship" )` when looking only for broken non-null references

Possible argument for the request:
- some data-integrity audits want dangling non-null foreign keys, and the current result includes ordinary optional relationships

That use case is real, but it should be expressed with the explicit null predicate rather than changing a core method's meaning.

## Public regression coverage

The new integration test queries `User.doesntHave( "country" )` and separately queries `User.whereNull( "countryId" )`. It proves both public queries identify the same fixture row, documenting that a null belongs-to key is intentionally an absent relationship.

No production change is included because the current behavior is correct.

## Validation

- focused `QueryingRelationshipsSpec`: 38 passed, 0 failed, 0 errors
- full Lucee 6 suite with qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
