### PR TITLE
Test eager loading on CBORM compatible entities

### DIFF
--- a/tests/resources/app/models/CompatUser.cfc
+++ b/tests/resources/app/models/CompatUser.cfc
@@ -19,4 +19,8 @@ component extends="quick.models.CBORMCompatEntity" table="users" accessors="true
         inverse="true"
         lazy="extra";
 
+    function posts() {
+        return hasMany( "Post", "user_id" );
+    }
+
 }

--- a/tests/specs/integration/CBORMCompatEntitySpec.cfc
+++ b/tests/specs/integration/CBORMCompatEntitySpec.cfc
@@ -163,6 +163,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( users[ 2 ].getUsername() ).toBe( "janedoe" );
 			} );
 
+			it( "can eager load relationships", function() {
+				var users = getInstance( "CompatUser" ).with( "posts" ).get();
+
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 5 );
+				expect( users[ 1 ].isRelationshipLoaded( "posts" ) ).toBeTrue();
+				expect( users[ 1 ].retrieveRelationship( "posts" ) ).toHaveLength( 2 );
+			} );
+
 			it( "new", function() {
 				var newUser = user.new();
 				expect( newUser.isLoaded() ).toBeFalse();


### PR DESCRIPTION
Closes #133

## Issue review

Eager loading must work for entities that extend `CBORMCompatEntity`; the compatibility overload of `get(id, returnNew)` should not leak into Quick's internal collection retrieval.

Recommendation: **10/10 — retain the current architecture and add the missing regression.**

Reasons for:
- eager loading is core Quick behavior and compatibility entities should not opt out of it
- relationship queries must always return an array to the eager matcher
- the public regression protects the distinction between entity-level CBORM `get` and builder-level Quick `get`

Tradeoffs:
- CBORM relationship property metadata is retained for compatibility, but executable Quick relationships still need a Quick relationship method
- changing the entity-level `get` defaults now would be separately breaking and is unnecessary for the eager-loading path

## Reproduction result

I added an explicit Quick `posts()` relationship to the existing `CompatUser` fixture and exercised:

```cfml
getInstance( "CompatUser" ).with( "posts" ).get()
```

The historical `getEager` array-type failure no longer reproduces. Current relationships execute eager retrieval through `relationshipBuilder.get()`, so the `CBORMCompatEntity.get(id, returnNew)` overload is not invoked. The result is an array of five compatibility entities, the relationship is marked loaded, and the first user's cached relationship contains two posts.

No production change is needed; the test locks in the fixed architecture through the public API.

## Validation

- focused `CBORMCompatEntitySpec`: 47 passed, 0 failed, 0 errors
- full Lucee 6 suite with qb 14.0.0-beta.3: 496 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
