### PR TITLE
Skip hasMany queries with null composite keys

### DIFF
--- a/models/Relationships/HasMany.cfc
+++ b/models/Relationships/HasMany.cfc
@@ -23,6 +23,11 @@ component extends="quick.models.Relationships.HasOneOrMany" accessors="true" {
 	 * @return       [quick.models.BaseEntity]
 	 */
 	public array function getResults() {
+		for ( var localKey in variables.localKeys ) {
+			if ( variables.parent.isNullAttribute( localKey ) ) {
+				return [];
+			}
+		}
 		return variables.relationshipBuilder.get();
 	}
 

--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -204,6 +204,14 @@ component extends="quick.models.BaseEntity" accessors="true" {
 		return hasOne( "Post", "user_id" ).latest();
 	}
 
+	function favoritePostsComposite() {
+		return hasMany(
+			"Post",
+			[ "user_id", "post_pk" ],
+			[ "id", "favoritePost_id" ]
+		);
+	}
+
 	function scopeWithLatestPost( qb ) {
 		qb.addSubselect( "latestPostId", "posts.post_pk" ).with( "dynamicLatestPost" );
 	}

--- a/tests/specs/integration/BaseEntity/Relationships/RelationshipLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/RelationshipLoadingSpec.cfc
@@ -78,6 +78,24 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} );
 			} );
 
+			it( "does not query a hasMany relationship when any composite local key is null", function() {
+				var user = getInstance( "User" ).findOrFail( 2 );
+
+				expect( variables.queries ).toHaveLength( 1 );
+				expect( user.getFavoritePostsComposite() ).toBeArray().toBeEmpty();
+				expect( variables.queries ).toHaveLength( 1 );
+			} );
+
+			it( "queries a hasMany relationship when all composite local keys have values", function() {
+				var user = getInstance( "User" ).findOrFail( 1 );
+
+				var favoritePosts = user.getFavoritePostsComposite();
+
+				expect( favoritePosts ).toHaveLength( 1 );
+				expect( favoritePosts[ 1 ].getPost_Pk() ).toBe( 1245 );
+				expect( variables.queries ).toHaveLength( 2 );
+			} );
+
 			it( "gets a new instance of an entity when calling fill", () => {
 				var elpete  = getInstance( "User" ).findOrFail( 1 );
 				var newPost = elpete.posts().fill( { "body" : "test body" } );


### PR DESCRIPTION
Closes #128

## Issue review

This is a valid bug and a strong fit for Quick. A declared composite relationship means all key components participate in the match; if any required local component is null, the relationship cannot produce a normal equality match and Quick should not issue a query containing a typed empty-string comparison.

Recommendation: **9/10 — short-circuit required composite keys.**

Reasons for:
- prevents invalid UUID/numeric comparisons on databases with strict typing
- avoids a query whose result is already known to be empty
- makes lazy `hasMany` behavior consistent with current eager loading, which omits key tuples containing a null component
- preserves normal querying when every composite component has a value

Tradeoffs:
- this treats every declared key component as required
- a schema intentionally relating rows where one component is null would need a separately designed optional-key API; inferring that from a normal key array would make lazy and eager semantics ambiguous
- the change is limited to `hasMany`, the relationship and failure mode reported here, rather than silently changing all composite relationship types

## Test-first reproduction and fix

The fixture defines a two-column `favoritePostsComposite` relationship using `User.id` and nullable `User.favoritePost_id`. The public regression loads a user whose second key is null and calls the normal relationship getter.

Before the fix, the getter returned an empty array but executed a second query, reproducing the dangerous SQL path. After the fix, `HasMany.getResults()` checks every local key with the entity's configured null semantics and returns an empty array before executing the prepared relationship builder.

A companion test loads a user with both key values, verifies the relationship query still executes, and verifies post `1245` is returned.

## Validation

- focused relationship-loading and has-many suites: 22 passed, 0 failed, 0 errors
- full Lucee 6 suite with qb 14.0.0-beta.3: 497 passed, 0 failed, 0 errors, 3 skipped
- formatter completed
- `git diff --check` passed
