### PR TITLE
test: cover polymorphic eager loading key names

### DIFF
--- a/tests/specs/integration/BaseEntity/Relationships/PolymorphicBelongsToSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/PolymorphicBelongsToSpec.cfc
@@ -15,6 +15,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( commentC.getCommentable() ).toBeInstanceOf( "app.models.Video" );
 				expect( commentC.getCommentable().getTitle() ).toBe( "Cello Wars" );
 			} );
+
+			it( "can eager load polymorphic entities with different primary key names", function() {
+				var comments = getInstance( "Comment" )
+					.with( "commentable" )
+					.orderBy( "id" )
+					.get();
+
+				expect( comments ).toHaveLength( 5 );
+				expect( comments[ 1 ].getCommentable() ).toBeInstanceOf( "app.models.Post" );
+				expect( comments[ 1 ].getCommentable().getPost_Pk() ).toBe( 1245 );
+				expect( comments[ 3 ].getCommentable() ).toBeInstanceOf( "app.models.Video" );
+				expect( comments[ 3 ].getCommentable().getId() ).toBe( 1245 );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #122

## Review

This is a good fit for Quick: polymorphic eager loading is a core relationship feature, and each possible target entity must be queried using its own primary-key metadata.

**Recommendation: 10/10.**

### Reasons for

- Eager and lazy loading should return the same relationship results.
- Supporting different primary-key names across polymorphic target types is required for heterogeneous models.
- The regression is inexpensive to preserve through the public API.

### Reasons against

- No meaningful product tradeoff. The historical implementation risk is that grouping several target types can accidentally reuse metadata from the first type.

## Attempted reproduction

I reproduced the issue's shape using the public Quick API: a mixed collection of comments eager-loads a polymorphic relationship whose `Post` target uses `post_pk` while its `Video` target uses `id`.

The failure no longer reproduces on current `next` with `qb@14.0.0-beta.3`. `PolymorphicBelongsTo#getResultsByType` now resolves `keyNames()` from each target type before executing that type's query. This PR adds the exact regression test so that behavior cannot silently regress.

## Validation

- Focused polymorphic relationship spec: 2 passed, 0 failed, 0 errors
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- Formatter completed
- `git diff --check` passed