### PR TITLE
test: cover has-one-through initial constraints

### DIFF
--- a/tests/resources/app/models/User.cfc
+++ b/tests/resources/app/models/User.cfc
@@ -216,6 +216,10 @@ component extends="quick.models.BaseEntity" accessors="true" {
 		return hasOne( "Post", "post_pk", "favoritePost_id" );
 	}
 
+	function favoritePostAuthor() {
+		return hasOneThrough( [ "favoritePost", "author" ] );
+	}
+
 	function latestPostWithEmptyDefault() {
 		return hasOne( "Post", "user_id" ).latest().withDefault();
 	}

--- a/tests/specs/integration/BaseEntity/Relationships/HasOneThroughSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasOneThroughSpec.cfc
@@ -9,6 +9,13 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( country.getLatestPost().getPost_Pk() ).toBe( 523526 );
 				expect( country.getLatestPost().getBody() ).toBe( "My second awesome post body" );
 			} );
+
+			it( "can start with a hasOne relationship", function() {
+				var user = getInstance( "User" ).findOrFail( 1 );
+
+				expect( user.getFavoritePostAuthor() ).notToBeNull();
+				expect( user.getFavoritePostAuthor().getId() ).toBe( user.getId() );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #119

## Review

This bug report is a strong fit for Quick. A `hasOneThrough` chain should support any valid relationship as its first hop, including `hasOne`; otherwise composition depends on an internal subclass detail.

**Recommendation: 10/10.**

### Reasons for

- Relationship chains should behave consistently across `hasOne` and `hasMany` first hops.
- The failure was an internal method-placement bug, not an unsupported relationship shape.
- The exact scenario is compact to preserve through the public API.

### Reasons against

- Deep relationship SQL is inherently more complex, so every additional relationship combination expands the regression surface.

## Attempted reproduction

I modeled the same relationship shape through the public API: `User.favoritePost` is a `hasOne`, and `Post.author` is a `belongsTo`; `User.favoritePostAuthor` composes them with `hasOneThrough`.

The historical `initialThroughConstraints` missing-method error no longer reproduces on current `next` with `qb@14.0.0-beta.3`. Commit `7b3b8d0` moved `initialThroughConstraints()` from `HasMany` to the shared `HasOneOrMany` implementation. This PR adds direct public-API coverage for that fix.

## Validation

- Focused has-one-through spec: 2 passed, 0 failed, 0 errors
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- Formatter completed
- `git diff --check` passed