### PR TITLE
test: compare whereHas through constraints

### DIFF
--- a/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/QueryingRelationshipsSpec.cfc
@@ -213,6 +213,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						expect( countries ).toHaveLength( 2 );
 					} );
 
+					it( "applies the same constraints as the expanded relationship path", function() {
+						var throughCountries = getInstance( "Country" )
+							.whereHas( "posts", ( q ) => q.where( "post_pk", 321 ) )
+							.get();
+						var expandedCountries = getInstance( "Country" )
+							.whereHas( "users.posts", ( q ) => q.where( "post_pk", 321 ) )
+							.get();
+
+						expect( throughCountries ).toHaveLength( 1 );
+						expect( throughCountries[ 1 ].getName() ).toBe( "Argentina" );
+						expect( throughCountries[ 1 ].getId() ).toBe( expandedCountries[ 1 ].getId() );
+					} );
+
 					it( "can find only entities that have a related hasManyThrough entity through multiple levels", function() {
 						var countries = getInstance( "Country" ).has( "comments" ).get();
 						expect( countries ).toBeArray();


### PR DESCRIPTION
Closes #116

## Review

This is a core correctness issue for Quick. A composed `hasManyThrough` relationship must apply the same intermediate and callback constraints as the equivalent expanded relationship path.

**Recommendation: 10/10.**

### Reasons for

- `whereHas` is commonly used for authorization and filtering, so over-inclusive results are dangerous.
- A named through relationship should be semantically equivalent to its expanded path.
- The regression can be asserted through the public query API with deterministic fixture data.

### Reasons against

- Through relationship SQL is complex and fixes can affect eager loading, nested constraints, and aliases, so broad regression testing is necessary.

## Attempted reproduction

I compared `Country.whereHas( "posts", callback )`, where `posts` is `hasManyThrough([ "users", "posts" ])`, with `Country.whereHas( "users.posts", callback )`. Both callbacks constrain the terminal post to `post_pk = 321`.

The issue no longer reproduces on current `next` with `qb@14.0.0-beta.3`: both forms return only Argentina. The relevant historical fixes include correcting through-constraint application and removing an extra join from `has`/`whereHas` that pulled back too many rows. This PR preserves exact equivalence coverage.

## Validation

- Focused querying-relationships spec: 38 passed, 0 failed, 0 errors
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- Formatter completed
- `git diff --check` passed