### PR TITLE
feat: support virtual attribute defaults

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3401,6 +3401,9 @@ component accessors="true" {
 			) {
 				variables._virtualAttributes.append( runtimeAttribute.name );
 			}
+			if ( runtimeAttribute.virtual && runtimeAttribute.keyExists( "defaultValue" ) ) {
+				forceAssignAttribute( runtimeAttribute.name, runtimeAttribute.defaultValue );
+			}
 		}
 		if ( isDiscriminatedChild() ) {
 			assignAttribute(
@@ -3678,18 +3681,39 @@ component accessors="true" {
 	/**
 	 * Creates a virtual attribute for the given name.
 	 *
-	 * @name    The attribute name to create.
+	 * @name                The attribute name to create.
+	 * @defaultValue        The default value for the virtual attribute.
+	 * @excludeFromMemento  Whether to exclude the virtual attribute from mementos.
 	 *
 	 * @return  quick.models.BaseEntity
 	 */
-	public any function appendVirtualAttribute( required string name, boolean excludeFromMemento = false ) {
+	public any function appendVirtualAttribute(
+		required string name,
+		any defaultValue,
+		boolean excludeFromMemento = false
+	) {
 		if ( isNull( retrieveAttributeDefinition( arguments.name ) ) ) {
-			var attr = paramAttribute( {
+			var attributeDefinition = {
 				"name"    : arguments.name,
 				"virtual" : true,
 				"exclude" : arguments.excludeFromMemento
-			} );
+			};
+			if ( arguments.keyExists( "defaultValue" ) ) {
+				attributeDefinition.defaultValue = arguments.defaultValue;
+			}
+			var attr = paramAttribute( attributeDefinition );
 			registerRuntimeAttribute( attr );
+			if (
+				!arguments.excludeFromMemento &&
+				structKeyExists( this, "memento" ) &&
+				structKeyExists( this.memento, "defaultIncludes" ) &&
+				!arrayContainsNoCase( this.memento.defaultIncludes, arguments.name )
+			) {
+				this.memento.defaultIncludes.append( arguments.name );
+			}
+			if ( arguments.keyExists( "defaultValue" ) ) {
+				forceAssignAttribute( arguments.name, arguments.defaultValue );
+			}
 		}
 		return this;
 	}

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1044,11 +1044,17 @@ component accessors="true" transientCache="false" {
 	/**
 	 * Creates a virtual attribute for the given name.
 	 *
-	 * @name    The attribute name to create.
+	 * @name                The attribute name to create.
+	 * @defaultValue        The default value for the virtual attribute.
+	 * @excludeFromMemento  Whether to exclude the virtual attribute from mementos.
 	 *
 	 * @return  quick.models.BaseEntity
 	 */
-	public any function appendVirtualAttribute( required string name, boolean excludeFromMemento = false ) {
+	public any function appendVirtualAttribute(
+		required string name,
+		any defaultValue,
+		boolean excludeFromMemento = false
+	) {
 		getEntity().appendVirtualAttribute( argumentCollection = arguments );
 		return this;
 	}

--- a/tests/specs/integration/BaseEntity/AttributeSpec.cfc
+++ b/tests/specs/integration/BaseEntity/AttributeSpec.cfc
@@ -30,6 +30,23 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( getInstance( "User" ).hasAttribute( "spawnedVirtual" ) ).toBeFalse();
 			} );
 
+			it( "can provide a default for a virtual attribute", function() {
+				var user    = getInstance( "User" ).appendVirtualAttribute( "hasPosts", false );
+				var newUser = user.newEntity();
+
+				expect( serializeJSON( user.getHasPosts() ) ).toBe( "false" );
+				expect( serializeJSON( user.getMemento().hasPosts ) ).toBe( "false" );
+				expect( serializeJSON( newUser.getHasPosts() ) ).toBe( "false" );
+				expect( serializeJSON( newUser.getMemento().hasPosts ) ).toBe( "false" );
+			} );
+
+			it( "can exclude a defaulted virtual attribute from mementos", function() {
+				var user = getInstance( "User" ).appendVirtualAttribute( "internalFlag", false, true );
+
+				expect( serializeJSON( user.getInternalFlag() ) ).toBe( "false" );
+				expect( user.getMemento() ).notToHaveKey( "internalFlag" );
+			} );
+
 			it( "can get any attribute using the `getColumnName` magic methods", function() {
 				var user = getInstance( "User" ).find( 1 );
 				expect( user.getId() ).toBe( 1 );


### PR DESCRIPTION
Closes #113

## Review

This improvement is a good fit for Quick. Virtual projections often represent counts or booleans, and a new entity needs a meaningful value before a query has populated the projection.

**Recommendation: 9/10.**

### Reasons for

- Avoids an unnecessary database refresh after saving a newly constructed entity.
- Makes virtual attributes behave more like declared properties with defaults.
- Ensures API mementos have stable types such as `false` instead of an empty string.
- Carries the default through `newEntity()` metadata reuse.

### Reasons against

- This intentionally changes the positional meaning of the second argument.
- Callers that currently use `appendVirtualAttribute( name, true )` to exclude an attribute must move that flag to the third argument or use the named `excludeFromMemento` argument.
- Dynamically mutating an entity's memento includes requires care when custom memento configuration is present.

## Implementation

- Changes the signature to `appendVirtualAttribute( name, defaultValue, excludeFromMemento = false )` on both `BaseEntity` and `QuickBuilder`.
- Stores the default in virtual-attribute metadata and initializes it on the current entity and entities produced by `newEntity()`.
- Adds a dynamically appended virtual attribute to default memento includes unless explicitly excluded.
- Preserves named internal `excludeFromMemento` calls.

## Test-first evidence

Before implementation, the public magic getter returned an empty string for `appendVirtualAttribute( "hasPosts", false )`; the new test failed with `Expected [false] but received [""]`.

Tests now verify:

- a false default through the generated/magic getter;
- the default in the normal memento flow;
- propagation through `newEntity()`; and
- the third-position memento exclusion flag.

## Validation

- Attribute, memento, and subquery specs: 35 passed, 0 failed, 0 errors
- Full suite: 497 passed, 0 failed, 0 errors, 3 skipped
- Formatter completed
- `git diff --check` passed
- Tested with `qb@14.0.0-beta.3`