### PR TITLE
feat: dispatch custom entity lifecycle events

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -77,6 +77,11 @@ component accessors="true" {
 	property name="_queryOptions" persistent="false";
 
 	/**
+	 * A map of lifecycle event names to custom interception points.
+	 */
+	property name="_dispatchesEvents" persistent="false";
+
+	/**
 	 * Boolean flag to prevent inserts and updates on the entity.
 	 */
 	property
@@ -277,6 +282,7 @@ component accessors="true" {
 		param variables._discriminators    = [];
 		param variables._loadChildren      = true;
 		param variables._queryOptions      = {};
+		param variables._dispatchesEvents  = {};
 		param variables._attributes        = {};
 		param variables._columns           = {};
 		param variables._virtualAttributes = [];
@@ -3343,16 +3349,29 @@ component accessors="true" {
 				{ eventData : arguments.eventData }
 			);
 		}
-		if ( !isNull( variables._interceptorService ) ) {
-			param variables.useAnnounceMethodForInterceptorService = structKeyExists(
-				variables._interceptorService,
-				"announce"
-			);
-			if ( variables.useAnnounceMethodForInterceptorService ) {
-				variables._interceptorService.announce( "quick" & arguments.eventName, arguments.eventData );
-			} else {
-				variables._interceptorService.processState( "quick" & arguments.eventName, arguments.eventData );
+		announceInterceptionPoint( "quick" & arguments.eventName, arguments.eventData );
+		if ( variables._dispatchesEvents.keyExists( arguments.eventName ) ) {
+			for ( var interceptionPoint in arrayWrap( variables._dispatchesEvents[ arguments.eventName ] ) ) {
+				announceInterceptionPoint( interceptionPoint, arguments.eventData );
 			}
+		}
+	}
+
+	/**
+	 * Announces an interception point using the configured interceptor service.
+	 *
+	 * @interceptionPoint  The interception point to announce.
+	 * @eventData          The data associated with the interception point.
+	 */
+	private void function announceInterceptionPoint( required string interceptionPoint, required struct eventData ) {
+		if ( isNull( variables._interceptorService ) ) {
+			return;
+		}
+		param variables.useAnnounceMethodForInterceptorService = structKeyExists( variables._interceptorService, "announce" );
+		if ( variables.useAnnounceMethodForInterceptorService ) {
+			variables._interceptorService.announce( arguments.interceptionPoint, arguments.eventData );
+		} else {
+			variables._interceptorService.processState( arguments.interceptionPoint, arguments.eventData );
 		}
 	}
 

--- a/tests/resources/app/models/Song.cfc
+++ b/tests/resources/app/models/Song.cfc
@@ -1,15 +1,15 @@
 component extends="quick.models.BaseEntity" accessors="true" {
 
-	variables._dispatchesEvents = {
-		"postInsert" : "onSongCreated",
-		"postSave"   : [ "onSongSaved", "onMediaSaved" ]
-	};
-
     property name="id";
     property name="title" nullValue="REALLY_NULL";
     property name="downloadUrl" column="download_url";
     property name="createdDate" column="created_date";
     property name="modifiedDate" column="modified_date";
+
+	variables._dispatchesEvents = {
+		"postInsert" : "onSongCreated",
+		"postSave"   : [ "onSongSaved", "onMediaSaved" ]
+	};
 
     function instanceReady( eventData ) {
         request.instanceReadyCalled = eventData;

--- a/tests/resources/app/models/Song.cfc
+++ b/tests/resources/app/models/Song.cfc
@@ -1,5 +1,10 @@
 component extends="quick.models.BaseEntity" accessors="true" {
 
+	variables._dispatchesEvents = {
+		"postInsert" : "onSongCreated",
+		"postSave"   : [ "onSongSaved", "onMediaSaved" ]
+	};
+
     property name="id";
     property name="title" nullValue="REALLY_NULL";
     property name="downloadUrl" column="download_url";

--- a/tests/specs/integration/BaseEntity/Events/CustomEventsSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/CustomEventsSpec.cfc
@@ -1,0 +1,60 @@
+component extends="tests.resources.ModuleIntegrationSpec" {
+
+	function beforeAll() {
+		super.beforeAll();
+		controller
+			.getInterceptorService()
+			.registerInterceptor(
+				interceptorObject = this,
+				interceptorName   = "CustomEventsSpec",
+				customPoints      = [
+					"onSongCreated",
+					"onSongSaved",
+					"onMediaSaved"
+				]
+			);
+	}
+
+	function afterAll() {
+		controller.getInterceptorService().unregister( "CustomEventsSpec" );
+		super.afterAll();
+	}
+
+	function run() {
+		describe( "custom entity events", function() {
+			beforeEach( function() {
+				variables.customEvents = [];
+			} );
+
+			it( "dispatches string and array interception points for lifecycle events", function() {
+				var song = getInstance( "Song" ).create( {
+					title        : "Rainbow Connection",
+					download_url : "https://open.spotify.com/track/1SJ4ycWow4yz6z4oFz8NAG"
+				} );
+
+				expect( variables.customEvents ).toBe( [
+					"onSongCreated",
+					"onSongSaved",
+					"onMediaSaved"
+				] );
+				expect( variables.customEventEntity.getId() ).toBe( song.getId() );
+			} );
+		} );
+	}
+
+	function onSongCreated( event, interceptData ) {
+		variables.customEvents.append( "onSongCreated" );
+		variables.customEventEntity = arguments.interceptData.entity;
+	}
+
+	function onSongSaved( event, interceptData ) {
+		variables.customEvents.append( "onSongSaved" );
+		variables.customEventEntity = arguments.interceptData.entity;
+	}
+
+	function onMediaSaved( event, interceptData ) {
+		variables.customEvents.append( "onMediaSaved" );
+		variables.customEventEntity = arguments.interceptData.entity;
+	}
+
+}


### PR DESCRIPTION
Closes #85

## Review

Entity-specific lifecycle interception points are a good fit for Quick. They let interceptors express domain intent directly instead of subscribing to every generic Quick event and branching on entity metadata.

**Recommendation: 8/10.**

### Reasons for

- Produces smaller, clearer interceptors such as `onOrderCreated`.
- Keeps domain event naming next to the entity lifecycle configuration.
- Supports one or several custom points for a lifecycle event.
- Reuses the exact Quick lifecycle event data and respects `withoutFiringEvents`.

### Reasons against

- Entity classes become aware of application interception-point names.
- Custom points still need to be registered with ColdBox so interceptors can observe them.
- Synchronous custom handlers add work to entity persistence and can make side effects less obvious.
- This is event dispatch, not a durable transactional event/outbox mechanism.

## Implementation

Entities can define:

```cfml
variables._dispatchesEvents = {
    "postInsert" : "onOrderCreated",
    "postSave"   : [ "onOrderSaved", "onAggregateChanged" ]
};
```

`fireEvent` continues to invoke the entity lifecycle method and announce the standard `quick...` point first, then announces each configured custom point using the same event data.

## Test-first evidence

Before implementation, creating the public test entity produced an empty custom-event list instead of `[ "onSongCreated", "onSongSaved", "onMediaSaved" ]`.

The integration test now registers those custom ColdBox points, creates a normal Quick entity, verifies string and array mappings in lifecycle order, and verifies the dispatched entity data.

## Validation

- Focused custom-event spec: 1 passed, 0 failed, 0 errors
- Full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- Formatter completed
- `git diff --check` passed
- Tested with `qb@14.0.0-beta.3`


## Documentation

The companion documentation is in [ortus-docs/quick-docs#66](https://github.com/ortus-docs/quick-docs/pull/66). It explicitly notes that `_dispatchesEvents` defines the Quick lifecycle mapping but does not register the custom interception points with ColdBox; applications must register each configured name separately.
