### PR TITLE
feat: create belongs-to-many related entities

### DIFF
--- a/models/Relationships/BelongsToMany.cfc
+++ b/models/Relationships/BelongsToMany.cfc
@@ -650,6 +650,31 @@ component
 	}
 
 	/**
+	 * Creates a new related entity and attaches it to the parent through the pivot table.
+	 *
+	 * @attributes                   Attributes for the related entity.
+	 * @pivotAttributes              Additional attributes for the pivot row.
+	 * @ignoreNonExistentAttributes  Whether to ignore attributes not defined on the related entity.
+	 * @options                      Options passed to the related entity save query.
+	 *
+	 * @return  quick.models.BaseEntity
+	 */
+	public any function create(
+		struct attributes                   = {},
+		struct pivotAttributes              = {},
+		boolean ignoreNonExistentAttributes = false,
+		struct options                      = {}
+	) {
+		var entity = variables.related.create(
+			arguments.attributes,
+			arguments.ignoreNonExistentAttributes,
+			arguments.options
+		);
+		attach( entity, arguments.pivotAttributes );
+		return entity;
+	}
+
+	/**
 	 * Associates one or more ids of the related entity to the parent entity.
 	 *
 	 * @id               The id or array of ids of the related entity.

--- a/tests/specs/integration/BaseEntity/Relationships/BelongsToManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/BelongsToManySpec.cfc
@@ -162,6 +162,26 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( pivot.getCreated_date() ).notToBeNull();
 				expect( pivot.getModified_date() ).notToBeNull();
 			} );
+
+			it( "creates and attaches a related entity", function() {
+				var post = getInstance( "Post" ).findOrFail( 1245 );
+				var tag  = post
+					.tagsWithPivot()
+					.create(
+						{ "name" : "testing" },
+						{
+							"context" : "created through relationship",
+							"active"  : true
+						}
+					);
+
+				expect( tag ).toBeInstanceOf( "Tag" );
+				expect( tag.isLoaded() ).toBeTrue();
+
+				var attached = post.tagsWithPivot().findOrFail( tag.getId() );
+				expect( attached.getPivot().getContext() ).toBe( "created through relationship" );
+				expect( attached.getPivot().getActive() ).toBeTrue();
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #84

## Review

This is the second PR in the belongs-to-many stack and now contains only relationship `create()` support. Pivot models, pivot attributes, constraints, timestamps, and persistence are implemented separately in #353.

Both PRs target `next`. Until #353 merges, GitHub will show its commits in this PR as the shared foundation. After #353 lands, this PR's production diff is one `BelongsToMany.create()` method.

The two relationship types requested by the issue have different semantics:

- **`belongsToMany.create`: 9/10.** The parent, related entity, and one pivot row are unambiguous.
- **Implicit `hasManyThrough.create`: 3/10.** A parent can have several intermediate entities or an arbitrarily deep chain, so Quick cannot infer which intermediate row should own the terminal entity.

This PR implements only the unambiguous belongs-to-many case.

## Implementation

```cfml
var tag = post.tags().create(
    { name : "testing" },
    { context : "created through relationship" }
);
```

The method:

1. Creates and returns the loaded related entity.
2. Attaches that entity to the parent.
3. Passes the optional pivot attributes to the pivot support from #353.

The related insert and pivot insert remain separate operations. Quick does not imply aggregate or unit-of-work persistence; callers requiring atomicity should provide their transaction boundary.

## Test-first evidence

Before implementation, the public `post.tagsWithPivot().create(...)` call errored because `create` was forwarded to qb and did not exist. The test now verifies the returned entity and reloads the relationship through Quick's public API to verify both the association and pivot values.

## Validation

- Focused stacked belongs-to-many suite: 12 passed, 0 failed, 0 errors
- Full stacked suite on Lucee 6: 567 passed, 0 failed, 0 errors, 3 skipped
- Formatter completed
- `git diff --check` passed

Depends on #353.
