### PR TITLE
test: distinguish UUID and GUID key types

### DIFF
--- a/tests/specs/integration/BaseEntity/GUIDPrimaryKeySpec.cfc
+++ b/tests/specs/integration/BaseEntity/GUIDPrimaryKeySpec.cfc
@@ -8,6 +8,14 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					var country = getInstance( "Actor" ).create( { "name" : "Tina Fey" } );
 
 					expect( country.getId() ).notToBeNumeric();
+					expect( country.getId() ).toHaveLength( 36 );
+					expect(
+						reFindNoCase(
+							"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+							country.getId()
+						)
+					).toBe( 1 );
+					expect( getInstance( "Actor" ).find( country.getId() ) ).notToBeNull();
 				} );
 			},
 			skip = !server.keyExists( "lucee" ) && !server.keyExists( "boxlang" )

--- a/tests/specs/integration/BaseEntity/UUIDPrimaryKeySpec.cfc
+++ b/tests/specs/integration/BaseEntity/UUIDPrimaryKeySpec.cfc
@@ -6,6 +6,11 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var country = getInstance( "Country" ).create( { "name" : "Wakanda" } );
 
 				expect( country.getId() ).notToBeNumeric();
+				expect( country.getId() ).toHaveLength( 35 );
+				expect( reFindNoCase( "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{16}$", country.getId() ) ).toBe(
+					1
+				);
+				expect( getInstance( "Country" ).find( country.getId() ) ).notToBeNull();
 			} );
 		} );
 	}


### PR DESCRIPTION
Closes #80

## Review

Distinguishing CFML UUIDs from standard GUIDs is a good fit for Quick because key generation must match qb's schema column type exactly.

**Recommendation: 10/10.**

### Reasons for

- Prevents generated key truncation or incompatible database values.
- Gives explicit, portable intent: `UUIDKeyType` pairs with qb `uuid`, while `GUIDKeyType` pairs with qb `guid`.
- Both values are assigned before insert and work through ordinary Quick persistence.
- Exact format tests are inexpensive.

### Reasons against

- The similar names remain easy to confuse without clear documentation.
- GUID support can vary by CFML engine; the existing GUID integration spec retains its engine guard.

## Attempted reproduction

The requested adjustment is already implemented on current `next`:

- `UUIDKeyType` uses `createUUID()`, matching qb's 35-character `uuid` column.
- `GUIDKeyType` uses `createGUID()`, matching qb's 36-character `guid` column.

The existing tests only asserted that generated keys were non-numeric, which would not detect the original type ambiguity. This PR verifies the exact UUID/GUID shapes and confirms each generated key can be found again through the normal Quick API.

## Validation

- Focused UUID/GUID specs: 2 passed, 0 failed, 0 errors
- Full suite: 495 passed, 0 failed, 0 errors, 3 skipped
- Formatter completed
- `git diff --check` passed
- Tested with `qb@14.0.0-beta.3`