### PR TITLE
Add createAll for multiple entities

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1335,6 +1335,39 @@ component accessors="true" {
 		return newEntity().fill( arguments.attributes, arguments.ignoreNonExistentAttributes ).save( arguments.options );
 	}
 
+	/**
+	 * Creates new entities for each provided attribute struct and returns them in
+	 * the entity's configured collection type.
+	 *
+	 * Each entity is saved independently so casts, generated keys, timestamps,
+	 * and entity lifecycle events behave the same as they do for `create`.
+	 *
+	 * @attributes                   An array of attribute structs.
+	 * @ignoreNonExistentAttributes  If true, skips attributes that do not exist.
+	 * @options                      Any options to pass to `queryExecute`. Default: {}.
+	 *
+	 * @throws                       QuickReadOnlyException
+	 *
+	 * @return                       array of quick.models.BaseEntity
+	 */
+	public any function createAll(
+		array attributes                    = [],
+		boolean ignoreNonExistentAttributes = false,
+		struct options                      = {}
+	) {
+		var ignoreAttributes = arguments.ignoreNonExistentAttributes;
+		var queryOptions     = arguments.options;
+		return newCollection(
+			arguments.attributes.map( function( entityAttributes ) {
+				return create(
+					attributes                  = entityAttributes,
+					ignoreNonExistentAttributes = ignoreAttributes,
+					options                     = queryOptions
+				);
+			} )
+		);
+	}
+
 	/*=====================================
     =            Relationships            =
     =====================================*/

--- a/tests/specs/integration/BaseEntity/CreateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CreateSpec.cfc
@@ -48,6 +48,33 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( newTheme.isNullAttribute( "config" ) ).toBeFalse();
 				expect( newTheme.getConfig() ).toBe( { "message" : "I should be cast to JSON" } );
 			} );
+
+			it( "can create and return multiple entities", function() {
+				var users = getInstance( "User" ).createAll( [
+					{
+						"username"  : "first-new-user",
+						"firstName" : "First",
+						"lastName"  : "User"
+					},
+					{
+						"username"  : "second-new-user",
+						"firstName" : "Second",
+						"lastName"  : "User"
+					}
+				] );
+
+				expect( users ).toBeArray();
+				expect( users ).toHaveLength( 2 );
+				expect( users[ 1 ].isLoaded() ).toBeTrue();
+				expect( users[ 1 ].getId() ).notToBeNull();
+				expect( users[ 1 ].getFirstName() ).toBe( "First" );
+				expect( users[ 2 ].isLoaded() ).toBeTrue();
+				expect( users[ 2 ].getId() ).notToBeNull();
+				expect( users[ 2 ].getFirstName() ).toBe( "Second" );
+				expect( getInstance( "User" ).whereIn( "username", [ "first-new-user", "second-new-user" ] ).count() ).toBe(
+					2
+				);
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #62

## Issue review

**Recommendation: 8/10 — implement.** `createAll` is a natural companion to `create` when callers need saved entity instances back. It keeps generated keys, casts, timestamps, custom collections, and lifecycle events intact. The tradeoff is deliberate: unlike qb’s bulk `insert`, this executes one insert per entity, so callers prioritizing throughput over entity behavior should continue using qb insert/upsert operations.

## Implementation

- adds `BaseEntity.createAll(attributes, ignoreNonExistentAttributes, options)`
- creates every item through Quick’s normal public `create` and `save` flow
- returns the model’s configured collection type via `newCollection`
- returns loaded entities with generated primary keys

## Test-first evidence

The public API regression initially errored with `QuickMissingMethod` because `createAll` did not exist. It now creates two records, returns both loaded entities, and verifies persistence through a separate Quick query.

## Validation

- focused CreateSpec: 4 passed, 0 failed, 0 errors
- full Lucee 6 suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Uses `qb@14.0.0-beta.3`.