### PR TITLE
Test scoped subselects when using all

### DIFF
--- a/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SubqueriesSpec.cfc
@@ -63,6 +63,17 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( sql ).notToInclude( "ROW_NUMBER()" );
 			} );
 
+			it( "keeps scoped subselects when retrieving all entities", function() {
+				var users = getInstance( "User" ).withLatestPostId().all();
+
+				expect( users ).toHaveLength( 5 );
+				expect( users[ 1 ].getLatestPostId() ).toBe( 523526 );
+				expect( variables.queries ).toHaveLength(
+					1,
+					"Only one query should have been executed. #arrayLen( variables.queries )# were instead."
+				);
+			} );
+
 			it( "can add a subquery to an entity using a relationship", function() {
 				var elpete = getInstance( "User" ).withLatestPostIdRelationship().findOrFail( 1 );
 				expect( elpete.getLatestPostId() ).notToBeNull();


### PR DESCRIPTION
Closes #60

## Issue review

**Recommendation: 8/10 — preserve and test.** `.all()` and `.get()` should hydrate the same selected fields; differing behavior is surprising and breaks substitutability. The only downside is a small additional integration test.

## Reproduction note

The reported failure could not be reproduced on current `next` with `qb@14.0.0-beta.3`. A `withLatestPostId()` scope followed by `.all()` hydrates the subselected virtual attribute correctly and executes one query.

## Implementation

- adds a public-API regression for a scoped subselect followed by `.all()`
- asserts the full collection is returned
- asserts the projected value is available from the hydrated entity getter
- asserts only one database query is executed

## Validation

- focused SubqueriesSpec: 12 passed, 0 failed, 0 errors
- full Lucee 6 suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Uses `qb@14.0.0-beta.3`.