### PR TITLE
Add built-in soft delete support

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -90,6 +90,22 @@ component accessors="true" {
 		persistent="false";
 
 	/**
+	 * Whether this entity uses soft deletes and the attribute that stores the deletion timestamp.
+	 */
+	property
+		name      ="_softDeletes"
+		default   ="false"
+		persistent="false";
+
+	/**
+	 * The attribute that stores the soft-delete timestamp.
+	 */
+	property
+		name      ="_softDeleteColumn"
+		default   ="deletedAt"
+		persistent="false";
+
+	/**
 	 * The primary key name for the entity.
 	 */
 	property
@@ -318,6 +334,8 @@ component accessors="true" {
 		param variables._discriminatorValue      = "";
 		param variables._hasDiscriminatorValue   = false;
 		param variables._singleTableInheritance  = false;
+		param variables._softDeletes             = false;
+		param variables._softDeleteColumn        = "deletedAt";
 		variables._saving                        = false;
 		return this;
 	}
@@ -1791,14 +1809,43 @@ component accessors="true" {
 			"Did you maybe mean to use `deleteAll`?"
 		);
 
-		var deleteQuery       = newQuery();
-		var entityKeyNames    = keyNames();
-		var entityKeyValues   = keyValues();
-		var deleteConstraints = deleteQuery.getQB().forNestedWhere();
-		for ( var i = 1; i <= entityKeyNames.len(); i++ ) {
-			deleteConstraints.where( entityKeyNames[ i ], entityKeyValues[ i ] );
+		if ( usesSoftDeletes() ) {
+			var column       = getSoftDeleteColumn();
+			var deletedAt    = now();
+			var deleteQuery  = newQuery().withoutGlobalScope( "softDeletes" );
+			var entityKeys   = keyNames();
+			var entityValues = keyValues();
+			for ( var i = 1; i <= entityKeys.len(); i++ ) {
+				deleteQuery.where( entityKeys[ i ], entityValues[ i ] );
+			}
+			deleteQuery.updateAll( { "#column#" : deletedAt } );
+			assignAttribute( column, deletedAt );
+			assignOriginalAttributes( retrieveAttributesData() );
+			fireEvent( "postDelete", { entity : this } );
+			return this;
 		}
-		deleteQuery.getQB().addNestedWhereQuery( deleteConstraints );
+
+		forceDelete( fireEvents = false );
+		fireEvent( "postDelete", { entity : this } );
+		return this;
+	}
+
+	/**
+	 * Permanently deletes a loaded entity, bypassing soft deletes.
+	 */
+	public any function forceDelete( boolean fireEvents = true ) {
+		guardReadOnly();
+		guardAgainstNotLoaded( "This instance is not loaded so it cannot be force deleted." );
+		if ( arguments.fireEvents ) {
+			fireEvent( "preDelete", { entity : this } );
+		}
+
+		var deleteQuery  = newQuery().withoutGlobalScope( "softDeletes" );
+		var entityKeys   = keyNames();
+		var entityValues = keyValues();
+		for ( var i = 1; i <= entityKeys.len(); i++ ) {
+			deleteQuery.where( entityKeys[ i ], entityValues[ i ] );
+		}
 		deleteQuery.delete();
 
 		if ( hasParentEntity() ) {
@@ -1813,7 +1860,9 @@ component accessors="true" {
 		}
 
 		variables._loaded = false;
-		fireEvent( "postDelete", { entity : this } );
+		if ( arguments.fireEvents ) {
+			fireEvent( "postDelete", { entity : this } );
+		}
 		return this;
 	}
 
@@ -3458,6 +3507,52 @@ component accessors="true" {
 		return this;
 	}
 
+	/**
+	 * Returns whether this entity is configured to use soft deletes.
+	 */
+	public boolean function usesSoftDeletes() {
+		return variables._softDeletes;
+	}
+
+	/**
+	 * Returns the entity attribute that stores the soft-delete timestamp.
+	 */
+	public string function getSoftDeleteColumn() {
+		return variables._softDeleteColumn;
+	}
+
+	/**
+	 * Returns whether this entity has been soft deleted.
+	 */
+	public boolean function trashed() {
+		return usesSoftDeletes() && !isNullAttribute( getSoftDeleteColumn() );
+	}
+
+	/**
+	 * Restores a soft-deleted entity.
+	 */
+	public any function restore() {
+		if ( !usesSoftDeletes() ) {
+			throw(
+				type    = "QuickSoftDeletesNotEnabled",
+				message = "[#entityName()#] is not configured to use soft deletes."
+			);
+		}
+		guardAgainstNotLoaded( "This instance is not loaded so it cannot be restored." );
+		var column = getSoftDeleteColumn();
+		newQuery()
+			.withoutGlobalScope( "softDeletes" )
+			.where( function( q ) {
+				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
+					q.where( keyName, keyValue );
+				} );
+			} )
+			.updateAll( { "#column#" : "" } );
+		clearAttribute( column );
+		assignOriginalAttributes( retrieveAttributesData() );
+		return this;
+	}
+
 
 	/**
 	 * If the quickbuilder instance exists return it, else create it, cache it and return it
@@ -3603,6 +3698,12 @@ component accessors="true" {
 				meta[ "table" ]                                    = meta.originalMetadata.table;
 				param meta.originalMetadata.readonly               = false;
 				meta[ "readonly" ]                                 = meta.originalMetadata.readonly;
+				param meta.originalMetadata.softDeletes            = false;
+				param meta.originalMetadata.softDeleteColumn       = "deletedAt";
+				meta[ "softDeletes" ] = isBoolean( meta.originalMetadata.softDeletes )
+				 ? meta.originalMetadata.softDeletes
+				 : lCase( trim( meta.originalMetadata.softDeletes & "" ) ) == "true";
+				meta[ "softDeleteColumn" ]                         = meta.originalMetadata.softDeleteColumn;
 				param meta.originalMetadata.joincolumn             = "";
 				param meta.originalMetadata.discriminatorValue     = "";
 				param meta.originalMetadata.singleTableInheritance = false;
@@ -3719,6 +3820,8 @@ component accessors="true" {
 			variables._queryOptions = { datasource : variables._meta.originalMetadata.datasource };
 		}
 		variables._readonly                = variables._meta.readonly;
+		variables._softDeletes             = variables._meta.softDeletes;
+		variables._softDeleteColumn        = variables._meta.softDeleteColumn;
 		variables._attributes              = variables._meta.attributes;
 		variables._columns                 = variables._meta.columns;
 		variables._functionNames           = variables._meta.functionNames;
@@ -3766,6 +3869,12 @@ component accessors="true" {
 					structDelete( variables, attributeName );
 				}
 			}
+		}
+		if ( variables._softDeletes && !hasAttribute( variables._softDeleteColumn ) ) {
+			throw(
+				type    = "QuickSoftDeleteColumnNotFound",
+				message = "The soft delete attribute [#variables._softDeleteColumn#] was not found on [#entityName()#]."
+			);
 		}
 		variables._casts = variables._meta.casts;
 	}

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -102,7 +102,7 @@ component accessors="true" {
 	 */
 	property
 		name      ="_softDeleteColumn"
-		default   ="deletedAt"
+		default   ="deletedDate"
 		persistent="false";
 
 	/**
@@ -335,7 +335,7 @@ component accessors="true" {
 		param variables._hasDiscriminatorValue   = false;
 		param variables._singleTableInheritance  = false;
 		param variables._softDeletes             = false;
-		param variables._softDeleteColumn        = "deletedAt";
+		param variables._softDeleteColumn        = "deletedDate";
 		variables._saving                        = false;
 		return this;
 	}
@@ -1810,16 +1810,16 @@ component accessors="true" {
 		);
 
 		if ( usesSoftDeletes() ) {
-			var column       = getSoftDeleteColumn();
-			var deletedAt    = now();
+			var column       = retrieveSoftDeleteColumn();
+			var deletedDate  = now();
 			var deleteQuery  = newQuery().withoutGlobalScope( "softDeletes" );
 			var entityKeys   = keyNames();
 			var entityValues = keyValues();
 			for ( var i = 1; i <= entityKeys.len(); i++ ) {
 				deleteQuery.where( entityKeys[ i ], entityValues[ i ] );
 			}
-			deleteQuery.updateAll( { "#column#" : deletedAt } );
-			assignAttribute( column, deletedAt );
+			deleteQuery.updateAll( { "#column#" : deletedDate } );
+			assignAttribute( column, deletedDate );
 			assignOriginalAttributes( retrieveAttributesData() );
 			fireEvent( "postDelete", { entity : this } );
 			return this;
@@ -3517,15 +3517,15 @@ component accessors="true" {
 	/**
 	 * Returns the entity attribute that stores the soft-delete timestamp.
 	 */
-	public string function getSoftDeleteColumn() {
+	public string function retrieveSoftDeleteColumn() {
 		return variables._softDeleteColumn;
 	}
 
 	/**
 	 * Returns whether this entity has been soft deleted.
 	 */
-	public boolean function trashed() {
-		return usesSoftDeletes() && !isNullAttribute( getSoftDeleteColumn() );
+	public boolean function isTrashed() {
+		return usesSoftDeletes() && !isNullAttribute( retrieveSoftDeleteColumn() );
 	}
 
 	/**
@@ -3539,17 +3539,8 @@ component accessors="true" {
 			);
 		}
 		guardAgainstNotLoaded( "This instance is not loaded so it cannot be restored." );
-		var column       = getSoftDeleteColumn();
-		var restoreQuery = newQuery().withoutGlobalScope( "softDeletes" );
-		var entityKeys   = keyNames();
-		var entityValues = keyValues();
-		for ( var i = 1; i <= entityKeys.len(); i++ ) {
-			restoreQuery.where( entityKeys[ i ], entityValues[ i ] );
-		}
-		restoreQuery.updateAll( { "#column#" : "" } );
-		clearAttribute( column );
-		assignOriginalAttributes( retrieveAttributesData() );
-		return this;
+		var column = retrieveSoftDeleteColumn();
+		return update( { "#column#" : "" } );
 	}
 
 
@@ -3693,13 +3684,13 @@ component accessors="true" {
 				meta[ "entityName" ]                   = meta.originalMetadata.entityName;
 				param meta.localMetadata.properties    = [];
 				guardDuplicatePropertyNames( meta.localMetadata, meta.mapping );
-				param meta.originalMetadata.table                  = variables._str.plural( variables._str.snake( meta.entityName ) );
-				meta[ "table" ]                                    = meta.originalMetadata.table;
-				param meta.originalMetadata.readonly               = false;
-				meta[ "readonly" ]                                 = meta.originalMetadata.readonly;
-				param meta.originalMetadata.softDeletes            = false;
-				param meta.originalMetadata.softDeleteColumn       = "deletedAt";
-				meta[ "softDeletes" ] = isBoolean( meta.originalMetadata.softDeletes )
+				param meta.originalMetadata.table            = variables._str.plural( variables._str.snake( meta.entityName ) );
+				meta[ "table" ]                              = meta.originalMetadata.table;
+				param meta.originalMetadata.readonly         = false;
+				meta[ "readonly" ]                           = meta.originalMetadata.readonly;
+				param meta.originalMetadata.softDeletes      = false;
+				param meta.originalMetadata.softDeleteColumn = "deletedDate";
+				meta[ "softDeletes" ]                        = isBoolean( meta.originalMetadata.softDeletes )
 				 ? meta.originalMetadata.softDeletes
 				 : lCase( trim( meta.originalMetadata.softDeletes & "" ) ) == "true";
 				meta[ "softDeleteColumn" ]                         = meta.originalMetadata.softDeleteColumn;

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -3539,15 +3539,14 @@ component accessors="true" {
 			);
 		}
 		guardAgainstNotLoaded( "This instance is not loaded so it cannot be restored." );
-		var column = getSoftDeleteColumn();
-		newQuery()
-			.withoutGlobalScope( "softDeletes" )
-			.where( function( q ) {
-				arrayZipEach( [ keyNames(), keyValues() ], function( keyName, keyValue ) {
-					q.where( keyName, keyValue );
-				} );
-			} )
-			.updateAll( { "#column#" : "" } );
+		var column       = getSoftDeleteColumn();
+		var restoreQuery = newQuery().withoutGlobalScope( "softDeletes" );
+		var entityKeys   = keyNames();
+		var entityValues = keyValues();
+		for ( var i = 1; i <= entityKeys.len(); i++ ) {
+			restoreQuery.where( entityKeys[ i ], entityValues[ i ] );
+		}
+		restoreQuery.updateAll( { "#column#" : "" } );
 		clearAttribute( column );
 		assignOriginalAttributes( retrieveAttributesData() );
 		return this;

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -701,6 +701,47 @@ component accessors="true" transientCache="false" {
 			}
 			variables.qb.addNestedWhereQuery( idConstraints );
 		}
+		if ( getEntity().usesSoftDeletes() ) {
+			activateGlobalScopes();
+			return updateAll( { "#getEntity().getSoftDeleteColumn()#" : now() } );
+		}
+		return variables.qb.delete();
+	}
+
+	/**
+	 * Restores all soft-deleted entities matching the configured query.
+	 */
+	public struct function restoreAll() {
+		if ( !getEntity().usesSoftDeletes() ) {
+			throw(
+				type    = "QuickSoftDeletesNotEnabled",
+				message = "[#getEntity().entityName()#] is not configured to use soft deletes."
+			);
+		}
+		withoutGlobalScope( "softDeletes" );
+		return updateAll( { "#getEntity().getSoftDeleteColumn()#" : "" } );
+	}
+
+	/**
+	 * Permanently deletes all entities matching the configured query.
+	 */
+	public struct function forceDeleteAll( array ids = [] ) {
+		getEntity().guardReadOnly();
+		if ( !arrayIsEmpty( arguments.ids ) ) {
+			variables.qb.where( function( q1 ) {
+				ids.each( function( id ) {
+					var values = arrayWrap( id );
+					getEntity().guardAgainstKeyLengthMismatch( values );
+					q1.orWhere( function( q2 ) {
+						getEntity()
+							.keyNames()
+							.each( function( keyName, i ) {
+								q2.where( keyName, values[ i ] );
+							} );
+					} );
+				} );
+			} );
+		}
 		return variables.qb.delete();
 	}
 
@@ -1766,12 +1807,34 @@ component accessors="true" transientCache="false" {
 			variables._applyingGlobalScopes = true;
 
 			if ( !variables._globalScopeExcludeAll ) {
+				if (
+					getEntity().usesSoftDeletes() &&
+					!variables._globalScopeExclusions.contains( "softdeletes" )
+				) {
+					variables.qb.whereNull( getEntity().getSoftDeleteColumn() );
+				}
 				getEntity().applyGlobalScopes( this );
 			}
 
 			variables._applyingGlobalScopes = false;
 			variables._globalScopesApplied  = true;
 		}
+		return this;
+	}
+
+	/**
+	 * Includes soft-deleted entities in this query.
+	 */
+	public any function withTrashed() {
+		return withoutGlobalScope( "softDeletes" );
+	}
+
+	/**
+	 * Restricts this query to only soft-deleted entities.
+	 */
+	public any function onlyTrashed() {
+		withoutGlobalScope( "softDeletes" );
+		variables.qb.whereNotNull( getEntity().getSoftDeleteColumn() );
 		return this;
 	}
 

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -703,7 +703,7 @@ component accessors="true" transientCache="false" {
 		}
 		if ( getEntity().usesSoftDeletes() ) {
 			activateGlobalScopes();
-			return updateAll( { "#getEntity().getSoftDeleteColumn()#" : now() } );
+			return updateAll( { "#getEntity().retrieveSoftDeleteColumn()#" : now() } );
 		}
 		return variables.qb.delete();
 	}
@@ -719,7 +719,7 @@ component accessors="true" transientCache="false" {
 			);
 		}
 		withoutGlobalScope( "softDeletes" );
-		return updateAll( { "#getEntity().getSoftDeleteColumn()#" : "" } );
+		return updateAll( { "#getEntity().retrieveSoftDeleteColumn()#" : "" } );
 	}
 
 	/**
@@ -1811,7 +1811,7 @@ component accessors="true" transientCache="false" {
 					getEntity().usesSoftDeletes() &&
 					!variables._globalScopeExclusions.contains( "softdeletes" )
 				) {
-					variables.qb.whereNull( getEntity().getSoftDeleteColumn() );
+					variables.qb.whereNull( getEntity().retrieveSoftDeleteColumn() );
 				}
 				getEntity().applyGlobalScopes( this );
 			}
@@ -1834,7 +1834,7 @@ component accessors="true" transientCache="false" {
 	 */
 	public any function onlyTrashed() {
 		withoutGlobalScope( "softDeletes" );
-		variables.qb.whereNotNull( getEntity().getSoftDeleteColumn() );
+		variables.qb.whereNotNull( getEntity().retrieveSoftDeleteColumn() );
 		return this;
 	}
 

--- a/tests/resources/app/models/SoftDeleteUser.cfc
+++ b/tests/resources/app/models/SoftDeleteUser.cfc
@@ -3,14 +3,17 @@ component
 	accessors       ="true"
 	table           ="users"
 	softDeletes     ="true"
-	softDeleteColumn="deletedAt"
 {
 
 	property name="id";
 	property name="username";
 	property
-		name  ="deletedAt"
+		name  ="deletedDate"
 		column="email"
 		insert="false";
+
+	function postUpdate() {
+		request.softDeleteUserPostUpdateCalled = true;
+	}
 
 }

--- a/tests/resources/app/models/SoftDeleteUser.cfc
+++ b/tests/resources/app/models/SoftDeleteUser.cfc
@@ -1,0 +1,13 @@
+component
+	extends         ="quick.models.BaseEntity"
+	accessors       ="true"
+	table           ="users"
+	softDeletes     ="true"
+	softDeleteColumn="deletedAt"
+{
+
+	property name="id";
+	property name="username";
+	property name="deletedAt" column="email" insert="false";
+
+}

--- a/tests/resources/app/models/SoftDeleteUser.cfc
+++ b/tests/resources/app/models/SoftDeleteUser.cfc
@@ -8,6 +8,9 @@ component
 
 	property name="id";
 	property name="username";
-	property name="deletedAt" column="email" insert="false";
+	property
+		name  ="deletedAt"
+		column="email"
+		insert="false";
 
 }

--- a/tests/specs/integration/BaseEntity/SoftDeletesSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SoftDeletesSpec.cfc
@@ -1,0 +1,37 @@
+component extends="tests.resources.ModuleIntegrationSpec" {
+
+	function run() {
+		describe( "Soft Deletes", function() {
+			it( "can soft delete, query, restore, and force delete entities", function() {
+				var user = getInstance( "SoftDeleteUser" ).findOrFail( 1 );
+
+				user.delete();
+
+				expect( user.isLoaded() ).toBeTrue();
+				expect( user.trashed() ).toBeTrue();
+				expect( getInstance( "SoftDeleteUser" ).find( 1 ) ).toBeNull();
+				expect( getInstance( "SoftDeleteUser" ).all() ).toHaveLength( 4 );
+				expect( getInstance( "SoftDeleteUser" ).withTrashed().all() ).toHaveLength( 5 );
+				expect( getInstance( "SoftDeleteUser" ).onlyTrashed().count() ).toBe( 1 );
+
+				var trashedUser = getInstance( "SoftDeleteUser" ).withTrashed().findOrFail( 1 );
+				expect( trashedUser.trashed() ).toBeTrue();
+				trashedUser.restore();
+
+				expect( trashedUser.trashed() ).toBeFalse();
+				expect( getInstance( "SoftDeleteUser" ).findOrFail( 1 ).getUsername() ).toBe( "elpete" );
+
+				getInstance( "SoftDeleteUser" ).where( "id", 2 ).deleteAll();
+				expect( getInstance( "SoftDeleteUser" ).find( 2 ) ).toBeNull();
+				getInstance( "SoftDeleteUser" ).onlyTrashed().restoreAll();
+				expect( getInstance( "SoftDeleteUser" ).findOrFail( 2 ).getUsername() ).toBe( "johndoe" );
+				getInstance( "SoftDeleteUser" ).where( "id", 2 ).forceDeleteAll();
+				expect( getInstance( "SoftDeleteUser" ).withTrashed().find( 2 ) ).toBeNull();
+
+				trashedUser.forceDelete();
+				expect( getInstance( "SoftDeleteUser" ).withTrashed().find( 1 ) ).toBeNull();
+			} );
+		} );
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/SoftDeletesSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SoftDeletesSpec.cfc
@@ -4,21 +4,24 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 		describe( "Soft Deletes", function() {
 			it( "can soft delete, query, restore, and force delete entities", function() {
 				var user = getInstance( "SoftDeleteUser" ).findOrFail( 1 );
+				expect( user.retrieveSoftDeleteColumn() ).toBe( "deletedDate" );
 
 				user.delete();
 
 				expect( user.isLoaded() ).toBeTrue();
-				expect( user.trashed() ).toBeTrue();
+				expect( user.isTrashed() ).toBeTrue();
 				expect( getInstance( "SoftDeleteUser" ).find( 1 ) ).toBeNull();
 				expect( getInstance( "SoftDeleteUser" ).all() ).toHaveLength( 4 );
 				expect( getInstance( "SoftDeleteUser" ).withTrashed().all() ).toHaveLength( 5 );
 				expect( getInstance( "SoftDeleteUser" ).onlyTrashed().count() ).toBe( 1 );
 
 				var trashedUser = getInstance( "SoftDeleteUser" ).withTrashed().findOrFail( 1 );
-				expect( trashedUser.trashed() ).toBeTrue();
+				expect( trashedUser.isTrashed() ).toBeTrue();
+				structDelete( request, "softDeleteUserPostUpdateCalled" );
 				trashedUser.restore();
 
-				expect( trashedUser.trashed() ).toBeFalse();
+				expect( trashedUser.isTrashed() ).toBeFalse();
+				expect( request ).toHaveKey( "softDeleteUserPostUpdateCalled" );
 				expect( getInstance( "SoftDeleteUser" ).findOrFail( 1 ).getUsername() ).toBe( "elpete" );
 
 				getInstance( "SoftDeleteUser" ).where( "id", 2 ).deleteAll();


### PR DESCRIPTION
Closes #54

## Issue review

**Recommendation: 9/10 — implement.** Soft deletes are common enough that every application should not have to rebuild the same global scope and lifecycle methods. A metadata-driven implementation fits Quick’s entity model. The tradeoffs are an additional nullable timestamp column, behavior changes for `delete`/`deleteAll` on opted-in entities, and the need to choose permanent deletion explicitly.

## Implementation

Configure an entity with `softDeletes=true`, optionally set `softDeleteColumn` (default `deletedAt`), and define that property. The feature adds:

- default exclusion of soft-deleted rows
- `withTrashed()` and `onlyTrashed()` query controls
- entity `delete()`, `restore()`, `trashed()`, and `forceDelete()` behavior
- bulk `deleteAll()`, `restoreAll()`, and `forceDeleteAll()` behavior
- validation that the configured soft-delete attribute exists
- preserved pre/post delete events for normal and soft deletes

## Test-first evidence

The end-to-end public regression initially failed because `delete()` permanently removed the entity and marked it unloaded. It now covers default visibility, querying trashed rows, restoring, soft bulk deletion/restoration, and permanent entity/bulk deletion.

The first full suite exposed two missing post-delete event assertions after the delete refactor; those were fixed before opening this PR.

## Validation

- focused soft-delete and delete-event specs: 5 passed, 0 failed, 0 errors
- full Lucee 6 suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Uses `qb@14.0.0-beta.3`.