### PR TITLE
Touch only configured timestamp fields

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1424,8 +1424,8 @@ component accessors="true" {
 	}
 
 	/**
-	 * Resets the entity to its clean state, updates its timestamp fields to the
-	 * current time, and saves the entity.
+	 * Saves updated timestamp fields from the entity's clean state, then restores
+	 * any dirty attribute values that existed before the touch.
 	 *
 	 * @options Any options to pass to `queryExecute`. Default: {}.
 	 *
@@ -1433,12 +1433,34 @@ component accessors="true" {
 	 */
 	public any function touch( struct options = {} ) {
 		guardAgainstNotLoaded( "This instance is not loaded so it cannot be touched." );
-		reset();
-		var timestamp = now();
-		timestampFields().each( function( field ) {
+		var currentAttributes  = retrieveAttributesData();
+		var originalAttributes = duplicate( variables._originalAttributes );
+		var fields             = timestampFields();
+		var timestamp          = now();
+
+		assignAttributesData( originalAttributes );
+		fields.each( function( field ) {
 			assignAttribute( arguments.field, timestamp );
 		} );
-		return save( arguments.options );
+
+		try {
+			save( arguments.options );
+			var touchedAttributes = fields.reduce( function( attributes, field ) {
+				arguments.attributes[ arguments.field ] = retrieveAttribute( arguments.field );
+				return arguments.attributes;
+			}, {} );
+		} catch ( any e ) {
+			assignAttributesData( currentAttributes );
+			assignOriginalAttributes( originalAttributes );
+			rethrow;
+		}
+
+		assignAttributesData( currentAttributes );
+		touchedAttributes.each( function( field, value ) {
+			assignAttribute( arguments.field, arguments.value );
+		} );
+
+		return this;
 	}
 
 	/**

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -440,6 +440,15 @@ component accessors="true" {
 	}
 
 	/**
+	 * Returns the timestamp fields updated by `touch`.
+	 *
+	 * @return  [String]
+	 */
+	public array function timestampFields() {
+		return [ "modifiedDate" ];
+	}
+
+	/**
 	 * Returns the column name for the primary key.
 	 *
 	 * @doc_generic  String
@@ -1415,16 +1424,20 @@ component accessors="true" {
 	}
 
 	/**
-	 * Updates a timestamp attribute to the current time and saves the entity.
+	 * Resets the entity to its clean state, updates its timestamp fields to the
+	 * current time, and saves the entity.
 	 *
-	 * @attribute The timestamp attribute to update. Default: `modifiedDate`.
-	 * @options   Any options to pass to `queryExecute`. Default: {}.
+	 * @options Any options to pass to `queryExecute`. Default: {}.
 	 *
 	 * @return    quick.models.BaseEntity
 	 */
-	public any function touch( string attribute = "modifiedDate", struct options = {} ) {
+	public any function touch( struct options = {} ) {
 		guardAgainstNotLoaded( "This instance is not loaded so it cannot be touched." );
-		assignAttribute( arguments.attribute, now() );
+		reset();
+		var timestamp = now();
+		timestampFields().each( function( field ) {
+			assignAttribute( arguments.field, timestamp );
+		} );
 		return save( arguments.options );
 	}
 

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -445,7 +445,7 @@ component accessors="true" {
 	 * @return  [String]
 	 */
 	public array function timestampFields() {
-		return [ "modifiedDate" ];
+		return [ "createdDate", "modifiedDate" ];
 	}
 
 	/**

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1424,8 +1424,8 @@ component accessors="true" {
 	}
 
 	/**
-	 * Saves updated timestamp fields from the entity's clean state, then restores
-	 * any dirty attribute values that existed before the touch.
+	 * Updates the configured timestamp fields using a new query without changing
+	 * the current entity state.
 	 *
 	 * @options Any options to pass to `queryExecute`. Default: {}.
 	 *
@@ -1433,32 +1433,30 @@ component accessors="true" {
 	 */
 	public any function touch( struct options = {} ) {
 		guardAgainstNotLoaded( "This instance is not loaded so it cannot be touched." );
-		var currentAttributes  = retrieveAttributesData();
-		var originalAttributes = duplicate( variables._originalAttributes );
-		var fields             = timestampFields();
-		var timestamp          = now();
+		guardReadOnly();
+		var timestamp           = now();
+		var timestampAttributes = timestampFields().reduce( function( attributes, field ) {
+			arguments.attributes[ arguments.field ] = timestamp;
+			return arguments.attributes;
+		}, {} );
+		guardAgainstReadOnlyAttributes( timestampAttributes );
 
-		assignAttributesData( originalAttributes );
-		fields.each( function( field ) {
-			assignAttribute( arguments.field, timestamp );
+		var builder = newQuery().where( function( q ) {
+			keyNames().each( function( keyName ) {
+				q.where(
+					arguments.keyName,
+					variables._originalAttributes[ retrieveColumnForAlias( arguments.keyName ) ]
+				);
+			} );
 		} );
-
-		try {
-			save( arguments.options );
-			var touchedAttributes = fields.reduce( function( attributes, field ) {
-				arguments.attributes[ arguments.field ] = retrieveAttribute( arguments.field );
-				return arguments.attributes;
-			}, {} );
-		} catch ( any e ) {
-			assignAttributesData( currentAttributes );
-			assignOriginalAttributes( originalAttributes );
-			rethrow;
-		}
-
-		assignAttributesData( currentAttributes );
-		touchedAttributes.each( function( field, value ) {
-			assignAttribute( arguments.field, arguments.value );
-		} );
+		builder
+			.getQB()
+			.update(
+				timestampAttributes.map( function( field, value ) {
+					return builder.generateQueryParamStruct( field, value );
+				} ),
+				arguments.options
+			);
 
 		return this;
 	}

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1415,6 +1415,20 @@ component accessors="true" {
 	}
 
 	/**
+	 * Updates a timestamp attribute to the current time and saves the entity.
+	 *
+	 * @attribute The timestamp attribute to update. Default: `modifiedDate`.
+	 * @options   Any options to pass to `queryExecute`. Default: {}.
+	 *
+	 * @return    quick.models.BaseEntity
+	 */
+	public any function touch( string attribute = "modifiedDate", struct options = {} ) {
+		guardAgainstNotLoaded( "This instance is not loaded so it cannot be touched." );
+		assignAttribute( arguments.attribute, now() );
+		return save( arguments.options );
+	}
+
+	/**
 	 * Creates a new entity with the given attributes and then saves the entity.
 	 *
 	 * @attributes                   A struct of key / value pairs.

--- a/tests/resources/app/models/CustomTimestampUser.cfc
+++ b/tests/resources/app/models/CustomTimestampUser.cfc
@@ -1,4 +1,8 @@
-component extends="quick.models.BaseEntity" accessors="true" table="users" {
+component
+	extends  ="quick.models.BaseEntity"
+	accessors="true"
+	table    ="users"
+{
 
 	property name="id";
 	property name="createdDate"  column="created_date";

--- a/tests/resources/app/models/CustomTimestampUser.cfc
+++ b/tests/resources/app/models/CustomTimestampUser.cfc
@@ -1,0 +1,11 @@
+component extends="quick.models.BaseEntity" accessors="true" table="users" {
+
+	property name="id";
+	property name="createdDate"  column="created_date";
+	property name="modifiedDate" column="modified_date";
+
+	public array function timestampFields() {
+		return [ "createdDate" ];
+	}
+
+}

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -80,13 +80,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var user              = getInstance( "User" ).findOrFail( 1 );
 				var originalModified  = user.getModifiedDate();
 				var originalFirstName = user.getFirstName();
+				var dirtyFirstName    = "This must not be persisted";
 
-				user.setFirstName( "This must not be persisted" );
+				user.setFirstName( dirtyFirstName );
 
 				user.touch();
 
 				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 1 );
-				expect( user.getFirstName() ).toBe( originalFirstName );
+				expect( user.getFirstName() ).toBe( dirtyFirstName );
+				expect( user.isDirty( "firstName" ) ).toBeTrue();
 				expect( user.isDirty( "modifiedDate" ) ).toBeFalse();
 				var freshUser = user.fresh();
 				expect( dateCompare( freshUser.getModifiedDate(), originalModified ) ).toBe( 1 );

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -79,12 +79,29 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 			it( "can touch an entity timestamp", function() {
 				var user             = getInstance( "User" ).findOrFail( 1 );
 				var originalModified = user.getModifiedDate();
+				var originalFirstName = user.getFirstName();
+
+				user.setFirstName( "This must not be persisted" );
 
 				user.touch();
 
 				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 1 );
+				expect( user.getFirstName() ).toBe( originalFirstName );
 				expect( user.isDirty( "modifiedDate" ) ).toBeFalse();
-				expect( dateCompare( user.fresh().getModifiedDate(), originalModified ) ).toBe( 1 );
+				var freshUser = user.fresh();
+				expect( dateCompare( freshUser.getModifiedDate(), originalModified ) ).toBe( 1 );
+				expect( freshUser.getFirstName() ).toBe( originalFirstName );
+			} );
+
+			it( "can override the timestamp fields used by touch", function() {
+				var user             = getInstance( "CustomTimestampUser" ).findOrFail( 1 );
+				var originalCreated  = user.getCreatedDate();
+				var originalModified = user.getModifiedDate();
+
+				user.touch();
+
+				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 1 );
+				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 0 );
 			} );
 
 			it( "does not allow updating of column where update=false in property", function() {

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -87,12 +87,14 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 				user.touch();
 
-				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 1 );
-				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 1 );
+				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 0 );
+				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 0 );
 				expect( user.getFirstName() ).toBe( dirtyFirstName );
 				expect( user.isDirty( "firstName" ) ).toBeTrue();
+				expect( user.isDirty( "createdDate" ) ).toBeFalse();
 				expect( user.isDirty( "modifiedDate" ) ).toBeFalse();
 				var freshUser = user.fresh();
+				expect( dateCompare( freshUser.getCreatedDate(), originalCreated ) ).toBe( 1 );
 				expect( dateCompare( freshUser.getModifiedDate(), originalModified ) ).toBe( 1 );
 				expect( freshUser.getFirstName() ).toBe( originalFirstName );
 			} );
@@ -104,8 +106,11 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 				user.touch();
 
-				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 1 );
+				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 0 );
 				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 0 );
+				var freshUser = user.fresh();
+				expect( dateCompare( freshUser.getCreatedDate(), originalCreated ) ).toBe( 1 );
+				expect( dateCompare( freshUser.getModifiedDate(), originalModified ) ).toBe( 0 );
 			} );
 
 			it( "does not allow updating of column where update=false in property", function() {

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -81,19 +81,24 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var originalCreated   = user.getCreatedDate();
 				var originalModified  = user.getModifiedDate();
 				var originalFirstName = user.getFirstName();
+				var originalId        = user.getId();
 				var dirtyFirstName    = "This must not be persisted";
+				var dirtyId           = 9999;
 
 				user.setFirstName( dirtyFirstName );
+				user.setId( dirtyId );
 
 				user.touch();
 
 				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 0 );
 				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 0 );
 				expect( user.getFirstName() ).toBe( dirtyFirstName );
+				expect( user.getId() ).toBe( dirtyId );
 				expect( user.isDirty( "firstName" ) ).toBeTrue();
+				expect( user.isDirty( "id" ) ).toBeTrue();
 				expect( user.isDirty( "createdDate" ) ).toBeFalse();
 				expect( user.isDirty( "modifiedDate" ) ).toBeFalse();
-				var freshUser = user.fresh();
+				var freshUser = getInstance( "User" ).findOrFail( originalId );
 				expect( dateCompare( freshUser.getCreatedDate(), originalCreated ) ).toBe( 1 );
 				expect( dateCompare( freshUser.getModifiedDate(), originalModified ) ).toBe( 1 );
 				expect( freshUser.getFirstName() ).toBe( originalFirstName );

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -76,6 +76,17 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( userRowsPostSave ).toHaveLength( 5 );
 			} );
 
+			it( "can touch an entity timestamp", function() {
+				var user             = getInstance( "User" ).findOrFail( 1 );
+				var originalModified = user.getModifiedDate();
+
+				user.touch();
+
+				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 1 );
+				expect( user.isDirty( "modifiedDate" ) ).toBeFalse();
+				expect( dateCompare( user.fresh().getModifiedDate(), originalModified ) ).toBe( 1 );
+			} );
+
 			it( "does not allow updating of column where update=false in property", function() {
 				var existingUser = getInstance( "User" ).find( 1 );
 				existingUser.setEmail( "test2@test.com" );

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -77,8 +77,8 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 			} );
 
 			it( "can touch an entity timestamp", function() {
-				var user             = getInstance( "User" ).findOrFail( 1 );
-				var originalModified = user.getModifiedDate();
+				var user              = getInstance( "User" ).findOrFail( 1 );
+				var originalModified  = user.getModifiedDate();
 				var originalFirstName = user.getFirstName();
 
 				user.setFirstName( "This must not be persisted" );

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -78,6 +78,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 			it( "can touch an entity timestamp", function() {
 				var user              = getInstance( "User" ).findOrFail( 1 );
+				var originalCreated   = user.getCreatedDate();
 				var originalModified  = user.getModifiedDate();
 				var originalFirstName = user.getFirstName();
 				var dirtyFirstName    = "This must not be persisted";
@@ -86,6 +87,7 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 
 				user.touch();
 
+				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 1 );
 				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 1 );
 				expect( user.getFirstName() ).toBe( dirtyFirstName );
 				expect( user.isDirty( "firstName" ) ).toBeTrue();


### PR DESCRIPTION
Closes #53

## Issue review

Recommendation: 8/10 — `touch` is a useful entity-level operation, but it must not accidentally persist or mutate unrelated entity state.

## Implementation

- adds `timestampFields()`, defaulting to `[ "createdDate", "modifiedDate" ]`, so entities can override the timestamp attributes they use
- creates a new key-scoped query that updates only the configured timestamp fields
- constrains the query using the originally loaded key values, even if the entity's current key is dirty
- does not reset, assign, save, or duplicate any current entity data
- leaves attributes, dirty tracking, timestamp snapshots, casts, and loaded relationships unchanged
- enforces read-only entity and attribute guards and passes query execution options through to qb

Because this is a direct update query, it intentionally does not run entity save lifecycle events. Consumers can fetch a fresh entity when they need the new database timestamps in memory.

## Regression coverage

- proves dirty non-timestamp attributes retain their values and dirty status
- proves a dirty primary key remains untouched while the originally loaded database row is updated
- proves current timestamp attributes remain unchanged and clean
- proves fresh data contains both updated default timestamp fields
- proves an entity override of `timestampFields()` controls which database timestamp is touched

## Validation

- focused Lucee 6 SaveSpec: 20 passed, 0 failed, 0 errors
- formatting check passed
- `git diff --check` passed

Uses `qb@14.0.0-beta.3` and targets `next`.
