### PR TITLE
Add entity-aware chunk queries

### DIFF
--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1305,6 +1305,34 @@ component accessors="true" transientCache="false" {
 	}
 
 	/**
+	 * Retrieves the configured query in chunks and passes hydrated entities to
+	 * the callback. Returning false from the callback stops further retrieval.
+	 *
+	 * @max      The maximum number of entities in each chunk.
+	 * @callback The callback invoked for each entity collection.
+	 * @options  Any options to pass to `queryExecute`. Default: {}.
+	 *
+	 * @return   quick.models.QuickBuilder
+	 */
+	public any function chunk(
+		required numeric max,
+		required callback,
+		struct options = {}
+	) {
+		activateGlobalScopes();
+		variables.qb.chunk(
+			arguments.max,
+			function( rows ) {
+				var entities   = variables._asQuery ? arguments.rows : arguments.rows.map( variables.loadEntity );
+				var collection = getEntity().newCollection( handleTransformations( eagerLoadRelations( entities ) ) );
+				return callback( collection );
+			},
+			arguments.options
+		);
+		return this;
+	}
+
+	/**
 	 * Returns a Pagination Collection of entities.
 	 *
 	 * @page     The page of results to return.

--- a/tests/specs/integration/BaseEntity/GetSpec.cfc
+++ b/tests/specs/integration/BaseEntity/GetSpec.cfc
@@ -180,6 +180,33 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( p.results[ p.results.len() ].getId() ).toBe( 45 );
 			} );
 
+			it( "can retrieve entities in chunks", function() {
+				var chunks = [];
+				var query  = getInstance( "User" )
+					.orderBy( "id" )
+					.chunk( 2, function( users ) {
+						chunks.append( {
+							"size"        : users.len(),
+							"firstId"     : users[ 1 ].getId(),
+							"quickEntity" : users[ 1 ].isQuickEntity
+						} );
+						return chunks.len() < 2;
+					} );
+
+				expect( query.isQuickBuilder ).toBeTrue();
+				expect( chunks ).toHaveLength( 2 );
+				expect( chunks[ 1 ] ).toBe( {
+					"size"        : 2,
+					"firstId"     : 1,
+					"quickEntity" : true
+				} );
+				expect( chunks[ 2 ] ).toBe( {
+					"size"        : 2,
+					"firstId"     : 3,
+					"quickEntity" : true
+				} );
+			} );
+
 			it( "can eager load and paginate a Quick query", function() {
 				queryExecute( "TRUNCATE TABLE `a`" );
 				queryExecute( "TRUNCATE TABLE `b`" );


### PR DESCRIPTION
Closes #52

## Issue review

**Recommendation: 9/10 — implement.** Chunking lets applications process large result sets with bounded memory while retaining Quick’s entity behavior. qb already provides reliable pagination mechanics, so Quick only needs to supply its hydration and transformation layer. The tradeoff is offset-based pagination: rows changing during processing can shift between chunks, so callers doing concurrent mutation may prefer a future key-based chunk API.

## Implementation

- adds `QuickBuilder.chunk(max, callback, options)`
- hydrates qb rows into Quick entities before invoking the callback
- returns the entity’s configured collection type for every chunk
- applies eager loading and `asQuery`/`asMemento` transformations consistently
- stops when the callback returns `false`
- returns the Quick builder for chaining
- inherits qb’s validation that chunk size must be greater than zero

## Test-first evidence

The public regression initially errored because the callback received raw structs and `getId()` was unavailable. It now receives loaded entities in two-item chunks, verifies ordering, stops after two callbacks, and confirms the returned object is a Quick builder.

## Validation

- focused GetSpec: 35 passed, 0 failed, 0 errors
- full Lucee 6 suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Uses `qb@14.0.0-beta.3`.