### PR TITLE
Allow isDirty checks for one attribute

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -848,11 +848,28 @@ component accessors="true" {
 	}
 
 	/**
-	 * Returns if the entity has been edited since being loaded from the database.
+	 * Returns if the entity, or one specific attribute, has been edited since
+	 * being loaded from the database.
+	 *
+	 * @attribute An optional attribute alias or column name to inspect.
 	 *
 	 * @return  Boolean
 	 */
-	public boolean function isDirty() {
+	public boolean function isDirty( string attribute ) {
+		if ( !isNull( arguments.attribute ) ) {
+			guardAgainstNonExistentAttribute( arguments.attribute );
+			var column            = retrieveColumnForAlias( arguments.attribute );
+			var currentAttributes = retrieveAttributesData( withNulls = true );
+			var originalAttribute = {};
+			var currentAttribute  = {};
+			if ( variables._originalAttributes.keyExists( column ) ) {
+				originalAttribute[ column ] = variables._originalAttributes[ column ];
+			}
+			if ( currentAttributes.keyExists( column ) ) {
+				currentAttribute[ column ] = currentAttributes[ column ];
+			}
+			return compare( computeAttributesHash( originalAttribute ), computeAttributesHash( currentAttribute ) ) != 0;
+		}
 		param variables._originalAttributesHash = computeAttributesHash( variables._originalAttributes );
 		return compare( variables._originalAttributesHash, computeAttributesHash( retrieveAttributesData() ) ) != 0;
 	}

--- a/tests/specs/integration/BaseEntity/IsDirtySpec.cfc
+++ b/tests/specs/integration/BaseEntity/IsDirtySpec.cfc
@@ -17,6 +17,26 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				user.fill( { "last_name" : "Peterson" } );
 				expect( user.isDirty() ).toBeFalse();
 			} );
+
+			it( "can check whether a specific attribute alias or column is dirty", function() {
+				var user = getInstance( "User" ).findOrFail( 1 );
+
+				expect( user.isDirty( "username" ) ).toBeFalse();
+				expect( user.isDirty( "firstName" ) ).toBeFalse();
+				expect( user.isDirty( "first_name" ) ).toBeFalse();
+
+				user.setUsername( "updated-username" );
+				expect( user.isDirty( "username" ) ).toBeTrue();
+				expect( user.isDirty( "firstName" ) ).toBeFalse();
+
+				user.setFirstName( "Updated" );
+				expect( user.isDirty( "firstName" ) ).toBeTrue();
+				expect( user.isDirty( "first_name" ) ).toBeTrue();
+
+				user.setUsername( "elpete" );
+				expect( user.isDirty( "username" ) ).toBeFalse();
+				expect( user.isDirty() ).toBeTrue();
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #51

## Issue review

**Recommendation: 10/10 — implement.** Callers frequently need to decide whether one field changed for auditing, conditional side effects, or targeted validation. Requiring a whole-entity dirty result forces manual comparison against internal state. This is a small, backward-compatible API improvement with little downside.

## Implementation

- adds an optional attribute argument to `isDirty`
- accepts either Quick aliases (`firstName`) or physical columns (`first_name`)
- uses the same case-sensitive hashing semantics as whole-entity dirtiness
- retains the cached whole-entity hash path when no attribute is supplied
- rejects unknown attributes through Quick’s normal attribute validation

## Test-first evidence

The first regression showed that CFML accepted the extra argument but the old implementation ignored it: after changing `username`, `isDirty("firstName")` incorrectly returned true. The test now covers clean attributes, dirty aliases, dirty physical columns, reverting one field, and whole-entity state.

## Validation

- focused IsDirtySpec: 2 passed, 0 failed, 0 errors
- full Lucee 6 suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Uses `qb@14.0.0-beta.3`.