### PR TITLE
Add isClean entity state checks

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -911,6 +911,31 @@ component accessors="true" {
 	}
 
 	/**
+	 * Returns whether the entity, or one specific attribute, is unchanged from
+	 * its originally loaded state.
+	 *
+	 * @attribute An optional attribute alias or column name to inspect.
+	 */
+	public boolean function isClean( string attribute ) {
+		if ( isNull( arguments.attribute ) ) {
+			return !isDirty();
+		}
+
+		guardAgainstNonExistentAttribute( arguments.attribute );
+		var column            = retrieveColumnForAlias( arguments.attribute );
+		var currentAttributes = retrieveAttributesData( withNulls = true );
+		var originalAttribute = {};
+		var currentAttribute  = {};
+		if ( variables._originalAttributes.keyExists( column ) ) {
+			originalAttribute[ column ] = variables._originalAttributes[ column ];
+		}
+		if ( currentAttributes.keyExists( column ) ) {
+			currentAttribute[ column ] = currentAttributes[ column ];
+		}
+		return compare( computeAttributesHash( originalAttribute ), computeAttributesHash( currentAttribute ) ) == 0;
+	}
+
+	/**
 	 * Retrieves a value for an attribute.
 	 *
 	 * @name           The name of the attribute to retrieve.

--- a/tests/specs/integration/BaseEntity/IsDirtySpec.cfc
+++ b/tests/specs/integration/BaseEntity/IsDirtySpec.cfc
@@ -37,6 +37,19 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( user.isDirty( "username" ) ).toBeFalse();
 				expect( user.isDirty() ).toBeTrue();
 			} );
+
+			it( "can test whether the entity or a specific attribute is clean", function() {
+				var user = getInstance( "User" ).findOrFail( 1 );
+
+				expect( user.isClean() ).toBeTrue();
+				expect( user.isClean( "username" ) ).toBeTrue();
+				expect( user.isClean( "first_name" ) ).toBeTrue();
+
+				user.setUsername( "updated-username" );
+				expect( user.isClean() ).toBeFalse();
+				expect( user.isClean( "username" ) ).toBeFalse();
+				expect( user.isClean( "firstName" ) ).toBeTrue();
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Closes #50

## Issue review

**Recommendation: 10/10 — implement.** `isClean` makes the inverse state check readable and avoids repeated negation throughout consuming applications. Supporting one alias or column is especially useful for conditional work tied to a specific field. This is additive and low risk.

## Implementation

- adds `isClean()` for whole-entity state
- adds `isClean(attribute)` for a Quick alias or physical column
- uses the same case-sensitive attribute hashing semantics as `isDirty`
- validates unknown attributes through the normal Quick error path

## Test-first evidence

The public regression initially errored with `QuickMissingMethod`. It now covers a fully clean entity, clean alias and physical-column checks, whole-entity dirtiness after a change, the changed field becoming unclean, and an unrelated field remaining clean.

## Review note

This PR is independently mergeable against `next`. PR #343 adds the complementary optional-attribute support to `isDirty`; if both are merged, a small follow-up refactor could share their per-attribute comparison helper, but neither PR depends on the other.

## Validation

- focused IsDirtySpec: 2 passed, 0 failed, 0 errors
- full Lucee 6 suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`

Uses `qb@14.0.0-beta.3`.