### PR TITLE
Add selective and explicit eager-load clearing

### DIFF
--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -592,6 +592,31 @@ component accessors="true" transientCache="false" {
 	}
 
 	/**
+	 * Removes one or more relationships from the eager-load list. Omitting the
+	 * argument removes every configured eager load.
+	 *
+	 * @relationName A relationship name or array of relationship names to remove.
+	 *
+	 * @return       QuickBuilder
+	 */
+	public any function without( any relationName ) {
+		if ( isNull( arguments.relationName ) ) {
+			variables._eagerLoad = [];
+			return this;
+		}
+
+		var exclusions       = arrayWrap( arguments.relationName );
+		variables._eagerLoad = variables._eagerLoad.filter( function( eagerLoad ) {
+			var path = isStruct( arguments.eagerLoad ) ? arguments.eagerLoad.keyArray()[ 1 ] : arguments.eagerLoad;
+			return !exclusions.some( function( exclusion ) {
+				return compareNoCase( path, exclusion ) == 0 ||
+				compareNoCase( left( path, len( exclusion ) + 1 ), exclusion & "." ) == 0;
+			} );
+		} );
+		return this;
+	}
+
+	/**
 	 * Eager loads the configured relations for the retrieved entities.
 	 * Returns the retrieved entities eager loaded with the configured
 	 * relationships.

--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -593,7 +593,7 @@ component accessors="true" transientCache="false" {
 
 	/**
 	 * Removes one or more relationships from the eager-load list. Omitting the
-	 * argument removes every configured eager load.
+	 * argument leaves the eager-load list unchanged.
 	 *
 	 * @relationName A relationship name or array of relationship names to remove.
 	 *
@@ -601,7 +601,6 @@ component accessors="true" transientCache="false" {
 	 */
 	public any function without( any relationName ) {
 		if ( isNull( arguments.relationName ) ) {
-			variables._eagerLoad = [];
 			return this;
 		}
 
@@ -613,6 +612,16 @@ component accessors="true" transientCache="false" {
 				compareNoCase( left( path, len( exclusion ) + 1 ), exclusion & "." ) == 0;
 			} );
 		} );
+		return this;
+	}
+
+	/**
+	 * Removes every configured eager load.
+	 *
+	 * @return QuickBuilder
+	 */
+	public any function clearEagerLoads() {
+		variables._eagerLoad = [];
 		return this;
 	}
 

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -699,7 +699,10 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} );
 
 				it( "does not clear eager loads when without is called without arguments", () => {
-					var posts = getInstance( "EagerLoadedPost" ).without().preventLazyLoading().get();
+					var posts = getInstance( "EagerLoadedPost" )
+						.without()
+						.preventLazyLoading()
+						.get();
 
 					expect( posts ).toHaveLength( 4 );
 					expect( posts[ 1 ].isRelationshipLoaded( "comments" ) ).toBeTrue();
@@ -707,7 +710,10 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				} );
 
 				it( "can explicitly clear all eager loads", () => {
-					var posts = getInstance( "EagerLoadedPost" ).clearEagerLoads().preventLazyLoading().get();
+					var posts = getInstance( "EagerLoadedPost" )
+						.clearEagerLoads()
+						.preventLazyLoading()
+						.get();
 
 					expect( posts ).toHaveLength( 4 );
 					expect( posts[ 1 ].isRelationshipLoaded( "comments" ) ).toBeFalse();

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -685,6 +685,18 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 						);
 					}
 				} );
+
+				it( "can disable an automatically eager loaded relationship", () => {
+					var posts = getInstance( "EagerLoadedPost" )
+						.without( "comments" )
+						.preventLazyLoading()
+						.get();
+
+					expect( posts ).toHaveLength( 4 );
+					expect( posts[ 1 ].isRelationshipLoaded( "comments" ) ).toBeFalse();
+					expect( () => posts[ 1 ].getComments() ).toThrow( type = "QuickLazyLoadingException" );
+					expect( variables.queries ).toHaveLength( 1, "Only the posts query should execute." );
+				} );
 			} );
 
 			describe( "multiple nested eager loads", () => {

--- a/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/EagerLoadingSpec.cfc
@@ -697,6 +697,23 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					expect( () => posts[ 1 ].getComments() ).toThrow( type = "QuickLazyLoadingException" );
 					expect( variables.queries ).toHaveLength( 1, "Only the posts query should execute." );
 				} );
+
+				it( "does not clear eager loads when without is called without arguments", () => {
+					var posts = getInstance( "EagerLoadedPost" ).without().preventLazyLoading().get();
+
+					expect( posts ).toHaveLength( 4 );
+					expect( posts[ 1 ].isRelationshipLoaded( "comments" ) ).toBeTrue();
+					expect( variables.queries ).toHaveLength( 2 );
+				} );
+
+				it( "can explicitly clear all eager loads", () => {
+					var posts = getInstance( "EagerLoadedPost" ).clearEagerLoads().preventLazyLoading().get();
+
+					expect( posts ).toHaveLength( 4 );
+					expect( posts[ 1 ].isRelationshipLoaded( "comments" ) ).toBeFalse();
+					expect( () => posts[ 1 ].getComments() ).toThrow( type = "QuickLazyLoadingException" );
+					expect( variables.queries ).toHaveLength( 1, "Only the posts query should execute." );
+				} );
 			} );
 
 			describe( "multiple nested eager loads", () => {


### PR DESCRIPTION
Closes #48

## Issue review

Recommendation: 9/10 — selectively removing default eager loads is a useful query-level control, provided the API distinguishes omission from an explicit request to clear everything.

## Implementation

- `without( relationshipName )` removes the named eager load and its nested paths
- `without()` with no arguments is a no-op and clears nothing
- `clearEagerLoads()` explicitly removes every configured eager load
- both methods remain chainable on the public Quick builder

## Regression coverage

- proves a named automatic eager load can be removed
- proves `without()` preserves automatic eager loads
- proves `clearEagerLoads()` removes all eager loads and lazy-loading protection still catches access
- verifies query counts for each behavior

## Validation

- focused Lucee 6 EagerLoadingSpec: 36 passed, 0 failed, 0 errors
- formatting check passed
- `git diff --check` passed

Uses `qb@14.0.0-beta.3` and targets `next`.
