### PR TITLE
Document preconfigured eager loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,34 @@ component extends="quick.models.BaseEntity" {
     variables._queryOptions = {
         cachedWithin : createTimeSpan( 0, 0, 5, 0 )
     };
-
 }
 ```
 
 Query caching stores database results, not live Quick entities or loaded relationships. Cache lifetime and invalidation are managed by the CFML engine, so use short lifetimes for data that Quick or another process may update. For application-specific invalidation or distributed caching, cache entity mementos in CacheBox at the service layer and rehydrate them through Quick's public APIs.
+
+### Preconfigured eager loading
+
+Entities can declare relationships that should be eager loaded on every query by assigning an array of relationship paths to `variables._with`:
+
+```javascript
+component extends="quick.models.BaseEntity" accessors="true" {
+
+    variables._with = [ "author", "comments.author" ];
+
+    function author() {
+        return belongsTo( "User" );
+    }
+
+    function comments() {
+        return hasMany( "Comment" );
+    }
+
+}
+```
+
+The paths use the same dot notation as the query builder's `with()` method, so nested relationships can be preconfigured. Quick adds these relationships whenever it creates a new query for the entity, including calls such as `all()`, `get()`, `first()`, and `find()`.
+
+Preconfigured eager loading is most useful for relationships that nearly every consumer needs. Use it selectively: every configured relationship adds work to each entity query and can retrieve substantially more data than the caller needs. For relationships used only by specific operations, prefer an explicit query-level call such as `getInstance( "Post" ).with( "comments" ).get()`.
 
 ### Tests and Contributing
 


### PR DESCRIPTION
Closes #47

## Issue review

**Recommendation: 9/10 — document.** Preconfigured eager loading is powerful but currently discoverable only by reading implementation or tests. Documenting its syntax, nested paths, query coverage, and over-fetching tradeoff makes the feature safer to adopt.

## Documentation

- shows how to configure `variables._with` on an entity
- includes normal and nested relationship paths
- explains that preconfiguration is applied to new entity queries, including `all`, `get`, `first`, and `find`
- recommends explicit query-level eager loading for relationships not needed by most callers
- warns that automatic eager loading adds queries and can over-fetch data

## Repository note

The standalone `cbQuickDocs` repository currently exposes only a `master` branch. Per the requirement that every PR in this issue pass target `next`, this documentation is added to Quick’s repository README and the PR targets `next`.

## Validation

- `git diff --check`
- no runtime tests run; documentation-only change

The documented behavior is covered by the existing automatic eager-loading integration spec. Uses `qb@14.0.0-beta.3`.