### PR TITLE
feat: guard loaded entity keys from mutation

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1179,6 +1179,11 @@ component accessors="true" {
 			arguments.value = castValueForSetter( arguments.name, arguments.value.keyValues()[ 1 ] );
 		}
 
+		guardAgainstLoadedKeyMutation(
+			arguments.name,
+			isNull( arguments.value ) ? javacast( "null", "" ) : arguments.value
+		);
+
 		variables._data[ retrieveColumnForAlias( arguments.name ) ] = arguments.cast ? castValueForSetter(
 			arguments.name,
 			isNull( arguments.value ) ? javacast( "null", "" ) : arguments.value
@@ -1189,6 +1194,28 @@ component accessors="true" {
 		) : ( isNull( arguments.value ) ? javacast( "null", "" ) : arguments.value );
 
 		return this;
+	}
+
+	private void function guardAgainstLoadedKeyMutation( required string name, any value ) {
+		if ( !isLoaded() || !arrayContainsNoCase( keyNames(), retrieveAliasForColumn( arguments.name ) ) ) {
+			return;
+		}
+
+		var keyColumn      = retrieveColumnForAlias( arguments.name );
+		var originalIsNull = !variables._originalAttributes.keyExists( keyColumn ) || isNull(
+			variables._originalAttributes[ keyColumn ]
+		);
+		var replacementIsNull = isNull( arguments.value );
+		if (
+			originalIsNull != replacementIsNull ||
+			( !originalIsNull && variables._originalAttributes[ keyColumn ] != arguments.value )
+		) {
+			throw(
+				type    = "QuickPrimaryKeyMutationException",
+				message = "A loaded [#entityName()#] entity cannot change its primary key [#retrieveAliasForColumn( arguments.name )#].",
+				detail  = "Create a new entity when a different primary key is required."
+			);
+		}
 	}
 
 	/**

--- a/models/Relationships/HasOneOrMany.cfc
+++ b/models/Relationships/HasOneOrMany.cfc
@@ -341,10 +341,10 @@ component
 			var keyValues       = arguments.entity;
 			arguments.entity    = variables.related.newEntity();
 			var relatedKeyNames = variables.related.keyNames();
-			arguments.entity.set_loaded( true );
 			for ( var i = 1; i <= relatedKeyNames.len(); i++ ) {
 				arguments.entity.forceAssignAttribute( relatedKeyNames[ i ], keyValues[ i ] );
 			}
+			arguments.entity.assignOriginalAttributes( arguments.entity.retrieveAttributesData() ).set_loaded( true );
 		}
 		setForeignAttributesForCreate( arguments.entity );
 		return arguments.entity.save();

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -83,19 +83,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				var originalFirstName = user.getFirstName();
 				var originalId        = user.getId();
 				var dirtyFirstName    = "This must not be persisted";
-				var dirtyId           = 9999;
 
 				user.setFirstName( dirtyFirstName );
-				user.setId( dirtyId );
 
 				user.touch();
 
 				expect( dateCompare( user.getCreatedDate(), originalCreated ) ).toBe( 0 );
 				expect( dateCompare( user.getModifiedDate(), originalModified ) ).toBe( 0 );
 				expect( user.getFirstName() ).toBe( dirtyFirstName );
-				expect( user.getId() ).toBe( dirtyId );
 				expect( user.isDirty( "firstName" ) ).toBeTrue();
-				expect( user.isDirty( "id" ) ).toBeTrue();
 				expect( user.isDirty( "createdDate" ) ).toBeFalse();
 				expect( user.isDirty( "modifiedDate" ) ).toBeFalse();
 				var freshUser = getInstance( "User" ).findOrFail( originalId );

--- a/tests/specs/integration/BaseEntity/SaveSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SaveSpec.cfc
@@ -118,6 +118,30 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( dateCompare( freshUser.getModifiedDate(), originalModified ) ).toBe( 0 );
 			} );
 
+			it( "throws a helpful error when changing the key of a loaded entity", function() {
+				var existingUser = getInstance( "User" ).findOrFail( 1 );
+
+				expect( function() {
+					existingUser.setId( 2 ).save();
+				} ).toThrow( type = "QuickPrimaryKeyMutationException", regex = "cannot change its primary key" );
+			} );
+
+			it( "allows assigning the existing key value to a loaded entity", function() {
+				var existingUser = getInstance( "User" ).findOrFail( 1 );
+
+				expect( function() {
+					existingUser.setId( 1 ).save();
+				} ).notToThrow();
+			} );
+
+			it( "guards every part of a loaded composite key", function() {
+				var composite = getInstance( "Composite" ).findOrFail( [ 1, 2 ] );
+
+				expect( function() {
+					composite.setB( 1 ).save();
+				} ).toThrow( type = "QuickPrimaryKeyMutationException", regex = "primary key \[b\]" );
+			} );
+
 			it( "does not allow updating of column where update=false in property", function() {
 				var existingUser = getInstance( "User" ).find( 1 );
 				existingUser.setEmail( "test2@test.com" );


### PR DESCRIPTION
Closes #43

## Issue review

**Fit score: 8/10.** A loaded entity’s primary key is its identity and is used to target writes and relationships. Letting it drift currently produces a particularly dangerous silent result: the save targets the replacement key and may update no row.

### Reasons for

- turns silent no-op or wrong-row behavior into an actionable error
- makes entity identity immutable after loading
- handles all components of composite keys

### Reasons against

- applications intentionally changing natural primary keys must create a new entity or use a direct query
- generated CFML setters cannot be intercepted at assignment time, so the guard runs when Quick synchronizes/persists the entity

## Implementation

- throws `QuickPrimaryKeyMutationException` when a loaded entity key differs from its original value
- permits assigning the same key value
- records original keys before Quick creates loaded relationship references from raw IDs

## Reproduction

The new public-API regression failed before the fix: `findOrFail( 1 ).setId( 2 ).save()` did not throw and silently targeted the replacement key.

## Validation

- focused save and has-many coverage: 34 passed, 0 failed, 0 errors
- full suite: 498 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`
- qb dependency: `14.0.0-beta.3`