### PR TITLE
feat: add entity replication

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -35,6 +35,7 @@ component {
 				"quickInstanceReady",
 				"quickPreLoad",
 				"quickPostLoad",
+				"quickPostReplicate",
 				"quickPreSave",
 				"quickPostSave",
 				"quickPreInsert",

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -1374,6 +1374,31 @@ component accessors="true" {
 		return entityClone;
 	}
 
+	/**
+	 * Creates a new, unloaded entity with this entity's attributes except for
+	 * its primary key and any additional excluded attributes.
+	 *
+	 * @except Additional attribute aliases or column names to exclude.
+	 *
+	 * @return quick.models.BaseEntity
+	 */
+	public any function replicate( array except = [] ) {
+		var attributes = retrieveAttributesData( withoutKey = true, withNulls = true );
+		for ( var attribute in arguments.except ) {
+			attributes.delete( retrieveColumnForAlias( attribute ) );
+		}
+
+		var replica = newEntity().fill( attributes );
+		replica.fireEvent(
+			"postReplicate",
+			{
+				"entity"   : replica,
+				"original" : this
+			}
+		);
+		return replica;
+	}
+
 
 
 	/*===========================================

--- a/tests/resources/app/models/Song.cfc
+++ b/tests/resources/app/models/Song.cfc
@@ -19,9 +19,13 @@ component extends="quick.models.BaseEntity" accessors="true" {
         request.preLoadCalled = eventData;
     }
 
-    function postLoad( eventData ) {
-        request.postLoadCalled = eventData;
-    }
+	function postLoad( eventData ) {
+		request.postLoadCalled = eventData;
+	}
+
+	function postReplicate( eventData ) {
+		request.postReplicateCalled = eventData;
+	}
 
     function preInsert( eventData ) {
         request.preInsertCalled = {

--- a/tests/resources/app/models/Song.cfc
+++ b/tests/resources/app/models/Song.cfc
@@ -1,23 +1,23 @@
 component extends="quick.models.BaseEntity" accessors="true" {
 
-    property name="id";
-    property name="title" nullValue="REALLY_NULL";
-    property name="downloadUrl" column="download_url";
-    property name="createdDate" column="created_date";
-    property name="modifiedDate" column="modified_date";
+	property name="id";
+	property name="title" nullValue="REALLY_NULL";
+	property name="downloadUrl"  column="download_url";
+	property name="createdDate"  column="created_date";
+	property name="modifiedDate" column="modified_date";
 
 	variables._dispatchesEvents = {
 		"postInsert" : "onSongCreated",
 		"postSave"   : [ "onSongSaved", "onMediaSaved" ]
 	};
 
-    function instanceReady( eventData ) {
-        request.instanceReadyCalled = eventData;
-    }
+	function instanceReady( eventData ) {
+		request.instanceReadyCalled = eventData;
+	}
 
-    function preLoad( eventData ) {
-        request.preLoadCalled = eventData;
-    }
+	function preLoad( eventData ) {
+		request.preLoadCalled = eventData;
+	}
 
 	function postLoad( eventData ) {
 		request.postLoadCalled = eventData;
@@ -27,62 +27,59 @@ component extends="quick.models.BaseEntity" accessors="true" {
 		request.postReplicateCalled = eventData;
 	}
 
-    function preInsert( eventData ) {
-        request.preInsertCalled = {
-            "entity": arguments.eventData.entity.getMemento(),
-            "isLoaded": arguments.eventData.entity.isLoaded()
-        };
-    }
+	function preInsert( eventData ) {
+		request.preInsertCalled = {
+			"entity"   : arguments.eventData.entity.getMemento(),
+			"isLoaded" : arguments.eventData.entity.isLoaded()
+		};
+	}
 
-    function postInsert( eventData ) {
-        request.postInsertCalled = {
-            "entity": eventData.entity.getMemento(),
-            "isLoaded": eventData.entity.isLoaded()
-        };
-    }
+	function postInsert( eventData ) {
+		request.postInsertCalled = {
+			"entity"   : eventData.entity.getMemento(),
+			"isLoaded" : eventData.entity.isLoaded()
+		};
+	}
 
-    function preUpdate( eventData ) {
-        param request.preUpdateCalled = [];
-        arrayAppend( request.preUpdateCalled, {
-            "entity": eventData.entity.getMemento(),
-            "originalAttributes": eventData.originalAttributes,
-            "newAttributes": eventData.newAttributes
-        } );
-    }
+	function preUpdate( eventData ) {
+		param request.preUpdateCalled = [];
+		arrayAppend(
+			request.preUpdateCalled,
+			{
+				"entity"             : eventData.entity.getMemento(),
+				"originalAttributes" : eventData.originalAttributes,
+				"newAttributes"      : eventData.newAttributes
+			}
+		);
+	}
 
-    function postUpdate( eventData ) {
-        param request.postUpdateCalled = [];
-        arrayAppend( request.postUpdateCalled, {
-            "entity": eventData.entity.getMemento()
-        } );
-    }
+	function postUpdate( eventData ) {
+		param request.postUpdateCalled = [];
+		arrayAppend( request.postUpdateCalled, { "entity" : eventData.entity.getMemento() } );
+	}
 
-    function preSave( eventData ) {
-        request.preSaveCalled = {
-            "entity": arguments.eventData.entity.getMemento(),
-            "isLoaded": arguments.eventData.entity.isLoaded()
-        };
-    }
+	function preSave( eventData ) {
+		request.preSaveCalled = {
+			"entity"   : arguments.eventData.entity.getMemento(),
+			"isLoaded" : arguments.eventData.entity.isLoaded()
+		};
+	}
 
-    function postSave( eventData ) {
-        request.postSaveCalled = {
-            "entity": arguments.eventData.entity.getMemento(),
-            "isLoaded": arguments.eventData.entity.isLoaded()
-        };
-    }
+	function postSave( eventData ) {
+		request.postSaveCalled = {
+			"entity"   : arguments.eventData.entity.getMemento(),
+			"isLoaded" : arguments.eventData.entity.isLoaded()
+		};
+	}
 
-    function preDelete( eventData ) {
-        param request.preDeleteCalled = [];
-        arrayAppend( request.preDeleteCalled, {
-            "entity": eventData.entity.getMemento()
-        } );
-    }
+	function preDelete( eventData ) {
+		param request.preDeleteCalled = [];
+		arrayAppend( request.preDeleteCalled, { "entity" : eventData.entity.getMemento() } );
+	}
 
-    function postDelete( eventData ) {
-        param request.postDeleteCalled = [];
-        arrayAppend( request.postDeleteCalled, {
-            "entity": eventData.entity.getMemento()
-        } );
-    }
+	function postDelete( eventData ) {
+		param request.postDeleteCalled = [];
+		arrayAppend( request.postDeleteCalled, { "entity" : eventData.entity.getMemento() } );
+	}
 
 }

--- a/tests/specs/integration/BaseEntity/CloneSpec.cfc
+++ b/tests/specs/integration/BaseEntity/CloneSpec.cfc
@@ -26,6 +26,29 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( clonedUser.isLoaded() ).toBeTrue( "The cloned user instance should be marked as loaded, but was not." );
 			} );
 
+			it( "can replicate a loaded entity as a new entity without its key", function() {
+				var user    = getInstance( "User" ).findOrFail( 1 );
+				var replica = user.replicate();
+
+				expect( replica.isLoaded() ).toBeFalse();
+				expect( replica.retrieveAttributesData() ).notToHaveKey( "id" );
+				expect( replica.getUsername() ).toBe( user.getUsername() );
+
+				replica
+					.setUsername( "replicated-user" )
+					.setEmail( "replicated@example.com" )
+					.save();
+				expect( replica.isLoaded() ).toBeTrue();
+				expect( replica.getId() ).notToBe( user.getId() );
+			} );
+
+			it( "can exclude additional attributes when replicating", function() {
+				var replica = getInstance( "User" ).findOrFail( 1 ).replicate( [ "email" ] );
+
+				expect( replica.retrieveAttributesData() ).notToHaveKey( "id" );
+				expect( replica.retrieveAttributesData() ).notToHaveKey( "email" );
+			} );
+
 			it( "can clone a QuickBuilder instance", function() {
 				var userBuilder  = getInstance( "User" ).orderBy( "id" );
 				var userBuilder2 = userBuilder.clone();

--- a/tests/specs/integration/BaseEntity/Events/PostReplicateSpec.cfc
+++ b/tests/specs/integration/BaseEntity/Events/PostReplicateSpec.cfc
@@ -1,0 +1,51 @@
+component extends="tests.resources.ModuleIntegrationSpec" {
+
+	function beforeAll() {
+		super.beforeAll();
+		controller
+			.getInterceptorService()
+			.registerInterceptor( interceptorObject = this, interceptorName = "PostReplicateSpec" );
+	}
+
+	function afterAll() {
+		controller.getInterceptorService().unregister( "PostReplicateSpec" );
+		super.afterAll();
+	}
+
+	function run() {
+		describe( "postReplicate spec", function() {
+			it( "announces a quickPostReplicate interception point", function() {
+				var original = getInstance( "Song" ).findOrFail( 1 );
+				var replica  = original.replicate();
+
+				expect( variables ).toHaveKey( "quickPostReplicateCalled" );
+				expect( variables.quickPostReplicateCalled.entity.isLoaded() ).toBeFalse();
+				expect( variables.quickPostReplicateCalled.entity.getTitle() ).toBe( replica.getTitle() );
+				expect( variables.quickPostReplicateCalled.original.getId() ).toBe( original.getId() );
+				structDelete( variables, "quickPostReplicateCalled" );
+			} );
+
+			it( "calls a postReplicate method on the replicated component", function() {
+				var original = getInstance( "Song" ).findOrFail( 1 );
+				var replica  = original.replicate();
+
+				expect( request ).toHaveKey( "postReplicateCalled" );
+				expect( request.postReplicateCalled.entity.isLoaded() ).toBeFalse();
+				expect( request.postReplicateCalled.entity.getTitle() ).toBe( replica.getTitle() );
+				expect( request.postReplicateCalled.original.getId() ).toBe( original.getId() );
+				structDelete( request, "postReplicateCalled" );
+			} );
+		} );
+	}
+
+	function quickPostReplicate(
+		event,
+		interceptData,
+		buffer,
+		rc,
+		prc
+	) {
+		variables.quickPostReplicateCalled = arguments.interceptData;
+	}
+
+}


### PR DESCRIPTION
Closes #42

## Issue review

**Fit score: 9/10.** Replicating a persisted record is a common ORM operation, and Quick already has nearly all the necessary primitives. A dedicated method is clearer and safer than cloning and manually clearing identity state.

### Reasons for

- concise public API for copy-as-new workflows
- reliably removes single or composite primary keys
- provides a lifecycle hook for adjusting replica defaults
- optional exclusions avoid copying sensitive or unique attributes

### Reasons against

- relationships are intentionally not copied
- unique fields still require caller or hook customization before save

## Implementation

- adds `replicate( except = [] )` returning a new, unloaded entity
- copies nulls while excluding all primary-key columns and caller exclusions
- adds entity `postReplicate` and interceptor `quickPostReplicate` hooks with `entity` and `original`

## Reproduction

Public-API tests first failed with QuickMissingMethod because `replicate()` did not exist; event tests also could not reach either requested hook.

## Validation

- focused clone/replication/event coverage: 8 passed, 0 failed, 0 errors
- full suite: 499 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`
- qb dependency: `14.0.0-beta.3`