### PR TITLE
fix: qualify aliased selected attributes

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -381,6 +381,16 @@ component accessors="true" {
 		string tableName        = this.tableName(),
 		boolean useParentLookup = true
 	) {
+		if ( reFindNoCase( "\s+AS\s+", arguments.column ) ) {
+			var source = trim( reReplaceNoCase( arguments.column, "\s+AS\s+.*$", "" ) );
+			var alias  = trim( reReplaceNoCase( arguments.column, "^.*?\s+AS\s+", "" ) );
+			return qualifyColumn(
+				column          = source,
+				tableName       = arguments.tableName,
+				useParentLookup = arguments.useParentLookup
+			) & " AS " & alias;
+		}
+
 		if (
 			findNoCase( ".", arguments.column ) != 0 ||
 			!hasAttribute( arguments.column ) ||

--- a/tests/specs/integration/BaseEntity/AsQuerySpec.cfc
+++ b/tests/specs/integration/BaseEntity/AsQuerySpec.cfc
@@ -77,6 +77,18 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( results[ 2 ][ "latestPostId" ] ).toBe( "" );
 			} );
 
+			it( "can select an aliased entity attribute when returning query data", function() {
+				var result = getInstance( "User" )
+					.select( [ "firstName AS firstName" ] )
+					.where( "id", 1 )
+					.asQuery( withAliases = false )
+					.first();
+
+				expect( result ).toBeStruct();
+				expect( result ).toHaveKey( "firstName" );
+				expect( result.firstName ).toBe( "Eric" );
+			} );
+
 			it( "can do eager loading", function() {
 				var results = getInstance( "Post" )
 					.newQuery()


### PR DESCRIPTION
Closes #40

## Issue review

**Fit score: 9/10.** Attribute-to-column translation is a core Quick promise and should continue to work when a select expression supplies an SQL alias, especially for `asQuery()` consumers.

### Reasons for

- makes aliased projections consistent with ordinary Quick selects
- preserves entity property naming in direct query data
- fixes the shared qualifier rather than adding a one-off query workaround

### Reasons against

- string parsing is limited to explicit `AS`, matching qb’s documented alias syntax
- complex expressions are still better expressed with qb raw expressions

## Implementation

- recognizes case-insensitive `source AS alias` selections
- qualifies/translates only the source attribute
- preserves the caller-provided result alias

## Reproduction

The public regression failed before the fix with MySQL `Unknown column firstName in field list` for `select( "firstName AS firstName" ).asQuery( false )`.

## Validation

- focused AsQuerySpec: 4 passed, 0 failed, 0 errors
- full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`
- qb dependency: `14.0.0-beta.3`