### PR TITLE
test: cover has-many deleteAll bindings

### DIFF
--- a/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
+++ b/tests/specs/integration/BaseEntity/Relationships/HasManySpec.cfc
@@ -173,6 +173,16 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				expect( newPost.fresh().getLifecycleEventVar() ).toBeNull();
 			} );
 
+			it( "deletes related entities using the actual foreign key value", function() {
+				var user = getInstance( "User" ).findOrFail( 1 );
+				expect( user.posts().count() ).toBe( 2 );
+
+				user.posts().deleteAll();
+
+				expect( getInstance( "Post" ).where( "user_id", 1 ).count() ).toBe( 0 );
+				expect( getInstance( "Post" ).where( "user_id", 4 ).count() ).toBeGT( 0 );
+			} );
+
 			it( "can first off of the relationship", function() {
 				var user = getInstance( "User" ).find( 1 );
 				var post = user.posts().first();


### PR DESCRIPTION
Refs #124

## Issue review

**Fit score: 9/10.** Relationship `deleteAll()` must bind the parent foreign-key value correctly. Substituting a boolean can delete the wrong rows or fail at the database boundary, so this behavior warrants a permanent integration regression.

### Reasons for

- protects a destructive operation from incorrect bindings
- exercises the normal Quick relationship API and real database effects
- verifies unrelated parents are not affected

### Reasons against

- the original report depended on older Quick/qb versions and specific entity metadata that is no longer available
- application-level cascades remain preferable when no per-child business logic is needed

## Attempted reproduction

I reproduced the reported shape with a loaded `User`, its `hasMany( Post )` relationship, and `user.posts().deleteAll()` on current `next` with qb `14.0.0-beta.3`. The bug did not reproduce: only rows bound to user ID 1 were deleted, and another user’s posts remained. No production change was needed, so this PR adds the public-API regression that proves the current behavior.

## Validation

- focused HasManySpec: 14 passed, 0 failed, 0 errors
- full suite: 496 passed, 0 failed, 0 errors, 3 skipped
- `box run-script format`
- `git diff --check`
- qb dependency: `14.0.0-beta.3`