### PR TITLE
Fix cross-engine CI compatibility

### DIFF
--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -1634,8 +1634,8 @@ component accessors="true" transientCache="false" {
 		}
 
 		var mementos = [];
-		for ( var entity in arguments.entity ) {
-			mementos.append( entity.getMemento( argumentCollection = variables._asMementoSettings ) );
+		for ( var resultEntity in arguments.entity ) {
+			mementos.append( resultEntity.getMemento( argumentCollection = variables._asMementoSettings ) );
 		}
 		return mementos;
 	}

--- a/models/QuickQB.cfc
+++ b/models/QuickQB.cfc
@@ -721,7 +721,7 @@ component
 		}
 
 		var q = arguments.relationQuery;
-		if ( structKeyExists( arguments, "directConstraint" ) ) {
+		if ( structKeyExists( arguments, "directConstraint" ) && !isNull( arguments.directConstraint ) ) {
 			invoke(
 				q,
 				arguments.directConstraint.method,
@@ -839,7 +839,7 @@ component
 
 		if ( listLen( arguments.relationshipName, "." ) == 1 ) {
 			var q = relation.addCompareConstraints( nested = arguments.relationQuery ).clearOrders();
-			if ( structKeyExists( arguments, "directConstraint" ) ) {
+			if ( structKeyExists( arguments, "directConstraint" ) && !isNull( arguments.directConstraint ) ) {
 				invoke(
 					q,
 					arguments.directConstraint.method,


### PR DESCRIPTION
Fixes the two regressions introduced by the internal closure refactor:

- avoid shadowing the `entity` argument in `QuickBuilder`, which Adobe CF rejects
- do not dereference a null optional `directConstraint` on Lucee 5 or BoxLang

Local verification:
- Adobe 2021 QuickCollectionSpec: 3 passed
- Lucee 5 full-null QueryingRelationshipsSpec: 48 passed
- BoxLang 1 full-null QueryingRelationshipsSpec: 48 passed
- CFFormat and git diff --check passed