### PR TITLE
Remove soft delete query closures

### DIFF
--- a/models/QuickBuilder.cfc
+++ b/models/QuickBuilder.cfc
@@ -675,6 +675,28 @@ component accessors="true" transientCache="false" {
 	}
 
 	/**
+	 * Adds grouped primary-key constraints for bulk delete operations.
+	 */
+	private void function addIdConstraints( required array ids ) {
+		if ( arrayIsEmpty( arguments.ids ) ) {
+			return;
+		}
+
+		var idConstraints = variables.qb.forNestedWhere();
+		var keyNames      = getEntity().keyNames();
+		for ( var id in arguments.ids ) {
+			var values = arrayWrap( id );
+			getEntity().guardAgainstKeyLengthMismatch( values );
+			var keyConstraints = idConstraints.forNestedWhere();
+			for ( var i = 1; i <= keyNames.len(); i++ ) {
+				keyConstraints.where( keyNames[ i ], values[ i ] );
+			}
+			idConstraints.addNestedWhereQuery( keyConstraints, "or" );
+		}
+		variables.qb.addNestedWhereQuery( idConstraints );
+	}
+
+	/**
 	 * Deletes matching entities according to the configured query.
 	 *
 	 * @ids     An optional array of ids to add to the previously configured
@@ -687,20 +709,7 @@ component accessors="true" transientCache="false" {
 	 */
 	public struct function deleteAll( array ids = [] ) {
 		getEntity().guardReadOnly();
-		if ( !arrayIsEmpty( arguments.ids ) ) {
-			var idConstraints = variables.qb.forNestedWhere();
-			for ( var id in arguments.ids ) {
-				var values = arrayWrap( id );
-				getEntity().guardAgainstKeyLengthMismatch( values );
-				var keyConstraints = idConstraints.forNestedWhere();
-				var keyNames       = getEntity().keyNames();
-				for ( var i = 1; i <= keyNames.len(); i++ ) {
-					keyConstraints.where( keyNames[ i ], values[ i ] );
-				}
-				idConstraints.addNestedWhereQuery( keyConstraints, "or" );
-			}
-			variables.qb.addNestedWhereQuery( idConstraints );
-		}
+		addIdConstraints( arguments.ids );
 		if ( getEntity().usesSoftDeletes() ) {
 			activateGlobalScopes();
 			return updateAll( { "#getEntity().retrieveSoftDeleteColumn()#" : now() } );
@@ -727,21 +736,7 @@ component accessors="true" transientCache="false" {
 	 */
 	public struct function forceDeleteAll( array ids = [] ) {
 		getEntity().guardReadOnly();
-		if ( !arrayIsEmpty( arguments.ids ) ) {
-			variables.qb.where( function( q1 ) {
-				ids.each( function( id ) {
-					var values = arrayWrap( id );
-					getEntity().guardAgainstKeyLengthMismatch( values );
-					q1.orWhere( function( q2 ) {
-						getEntity()
-							.keyNames()
-							.each( function( keyName, i ) {
-								q2.where( keyName, values[ i ] );
-							} );
-					} );
-				} );
-			} );
-		}
+		addIdConstraints( arguments.ids );
 		return variables.qb.delete();
 	}
 

--- a/tests/specs/integration/BaseEntity/SoftDeletesSpec.cfc
+++ b/tests/specs/integration/BaseEntity/SoftDeletesSpec.cfc
@@ -34,6 +34,14 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 				trashedUser.forceDelete();
 				expect( getInstance( "SoftDeleteUser" ).withTrashed().find( 1 ) ).toBeNull();
 			} );
+
+			it( "can force delete multiple entities by id", function() {
+				getInstance( "SoftDeleteUser" ).forceDeleteAll( [ 1, 2 ] );
+
+				expect( getInstance( "SoftDeleteUser" ).withTrashed().find( 1 ) ).toBeNull();
+				expect( getInstance( "SoftDeleteUser" ).withTrashed().find( 2 ) ).toBeNull();
+				expect( getInstance( "SoftDeleteUser" ).findOrFail( 3 ).getUsername() ).toBe( "janedoe" );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Removes the four internal closures introduced by #340 without changing the public API.

`deleteAll()` and `forceDeleteAll()` now share a private loop-based primary-key constraint builder using prebuilt nested query objects.

Adds public API coverage for force-deleting multiple IDs.

Verification:
- SoftDeletesSpec and DeleteSpec: 7 passed
- changed files pass CFFormat
- git diff --check passes
- production closure literals return to the post-refactor baseline of 6