### PR TITLE
fix: preserve uninitialized BoxLang attributes

### DIFF
--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -558,7 +558,12 @@ component accessors="true" {
 	 */
 	private void function syncVariablesScopeWithData() {
 		for ( var key in retrieveAttributeNames( withVirtualColumns = false ) ) {
-			if ( variables.keyExists( key ) && !isReadOnlyAttribute( key ) ) {
+			var column = retrieveColumnForAlias( key );
+			if (
+				variables.keyExists( key ) &&
+				!isReadOnlyAttribute( key ) &&
+				( variables._data.keyExists( column ) || !isNullValue( key, variables[ key ] ) )
+			) {
 				assignAttribute( key, variables[ key ] );
 			}
 		}

--- a/models/BaseEntity.cfc
+++ b/models/BaseEntity.cfc
@@ -562,7 +562,7 @@ component accessors="true" {
 			if (
 				variables.keyExists( key ) &&
 				!isReadOnlyAttribute( key ) &&
-				( variables._data.keyExists( column ) || !isNullValue( key, variables[ key ] ) )
+				( variables._data.keyExists( column ) || !isNull( variables[ key ] ) )
 			) {
 				assignAttribute( key, variables[ key ] );
 			}

--- a/tests/specs/integration/BaseEntity/MetadataSpec.cfc
+++ b/tests/specs/integration/BaseEntity/MetadataSpec.cfc
@@ -114,6 +114,15 @@ component extends="tests.resources.ModuleIntegrationSpec" {
 					},
 					skip = !server.keyExists( "boxlang" )
 				);
+
+				it(
+					title = "does not persist uninitialized BoxLang accessor values",
+					body  = function() {
+						var user = getInstance( "User" );
+						expect( user.retrieveAttributesData() ).notToHaveKey( "created_date" );
+					},
+					skip = !server.keyExists( "boxlang" )
+				);
 			} );
 		} );
 	}


### PR DESCRIPTION
## Summary

- avoid copying uninitialized BoxLang accessor values into an entity's tracked attribute data
- continue syncing explicitly tracked nulls and initialized accessor values
- add a BoxLang regression covering untouched accessor-backed columns

The broader native BoxLang metadata compatibility work from the original local commit is already represented on `next`; this ports the remaining attribute synchronization guard without duplicating that work.

## Verification

- `box testbox run runner=http://127.0.0.1:60309/tests/runner.cfm bundles=tests.specs.integration.BaseEntity.MetadataSpec` (BoxLang 1.16, full null: 15 passed)
- `box run-script format:check`
- `git diff --check`

The exhaustive local BoxLang run was stopped at the requester's direction; the PR matrix will provide the full cross-engine coverage.